### PR TITLE
display section description in overlay instead of the section name

### DIFF
--- a/app/sections/index.php
+++ b/app/sections/index.php
@@ -103,7 +103,7 @@ require( dirname(__FILE__) . '/../admin/admin-menu-config.php' );
 							if( ($section->name == $_GET['section']) || ($section->id == $_GET['section']) ) 	{ print "<li class='active'>"; }
 							else 																				{ print "<li>"; }
 
-							print "	<a href='".create_link("subnets",$section->id)."' rel='tooltip' data-placement='bottom' title='"._('Show all subnets in section')." $section->name'>$section->name</a>";
+							print "	<a href='".create_link("subnets",$section->id)."' rel='tooltip' data-placement='bottom' title='$section->description'>$section->name</a>";
 							print "</li>";
 						}
 					}


### PR DESCRIPTION
Hello!

First of all, thanks for you hard work. It is very usefull for us! Our first little pull request is to take advantage of the section description.

Before this PR, the overlay for a section name was "Show all subnets in section XXX". I propose to display the section description in replacement. 
