### PR TITLE
Cocoon ip search patch

### DIFF
--- a/app/tools/search/search-results-export.php
+++ b/app/tools/search/search-results-export.php
@@ -24,13 +24,19 @@ $User->check_user_session();
 $search_term = $_REQUEST['search_term'];
 
 # check if mac address or ip address
-if(strlen($search_term)==17) {
-	if(substr_count($search_term, ":") == 5) 												{ $type = "mac"; }	//count : -> must be 5
+if(strlen($search_term)==17 && substr_count($search_term, ":") == 5)
+{
+        $type = "mac"; //count : -> must be 5
 }
-else if(strlen($search_term) == 12) {
-	if( (substr_count($search_term, ":") == 0) && (substr_count($search_term, ".") == 0) ) 	{ $type = "mac"; }	//no dots or : -> mac without :
+else if(strlen($search_term) == 12 && (substr_count($search_term, ":") == 0) && (substr_count($search_term, ".") == 0))
+{
+        $type = "mac"; //no dots or : -> mac without :
 }
-else 																						{ $type = $Addresses->identify_address( $search_term ); }		# identify address type
+else
+{
+        $type = $Addresses->identify_address( $search_term ); //identify address type
+}
+
 
 # reformat if IP address for search
 if ($type == "IPv4") 		{ $search_term_edited = $Tools->reformat_IPv4_for_search ($search_term); }	//reformat the IPv4 address!

--- a/app/tools/search/search-results.php
+++ b/app/tools/search/search-results.php
@@ -36,13 +36,18 @@ $User->check_user_session();
 $search_term = str_replace("*", "%", $search_term);
 
 # check if mac address or ip address
-if(strlen($search_term)==17) {
-	if(substr_count($search_term, ":") == 5) 												{ $type = "mac"; }	//count : -> must be 5
+if(strlen($search_term)==17 && substr_count($search_term, ":") == 5)
+{
+        $type = "mac"; //count : -> must be 5
 }
-else if(strlen($search_term) == 12) {
-	if( (substr_count($search_term, ":") == 0) && (substr_count($search_term, ".") == 0) ) 	{ $type = "mac"; }	//no dots or : -> mac without :
+else if(strlen($search_term) == 12 && (substr_count($search_term, ":") == 0) && (substr_count($search_term, ".") == 0))
+{
+        $type = "mac"; //no dots or : -> mac without :
 }
-else 																						{ $type = $Addresses->identify_address( $search_term ); }		# identify address type
+else
+{
+        $type = $Addresses->identify_address( $search_term ); //identify address type
+}
 
 # reformat if IP address for search
 if ($type == "IPv4") 		{ $search_term_edited = $Tools->reformat_IPv4_for_search ($search_term); }	//reformat the IPv4 address!


### PR DESCRIPTION
If the search term is exactly 12 in length it only checks if it does not contains "." or ":", then it handles it as mac.
But it misses to handle the case when it is 12 in length and does contain "." or ":".
(my patch 29 on SF)
