### PR TITLE
Recursive nameservers and bugfixes

### DIFF
--- a/app/admin/admin-menu-config.php
+++ b/app/admin/admin-menu-config.php
@@ -27,6 +27,7 @@ $admin_menu['IP related management'][] = array("show"=>true,	"icon"=>"fa-server"
 $admin_menu['IP related management'][] = array("show"=>true,	"icon"=>"fa-sitemap","name"=>"Subnets", 					"href"=>"subnets", 					"description"=>"Subnet management");
 $admin_menu['IP related management'][] = array("show"=>true,	"icon"=>"fa-desktop","name"=>"Devices", 					"href"=>"devices", 					"description"=>"Device management");
 $admin_menu['IP related management'][] = array("show"=>true,	"icon"=>"fa-cloud", 	"name"=>"VLAN", 					"href"=>"vlans", 					"description"=>"VLAN management");
+$admin_menu['IP related management'][] = array("show"=>true,	"icon"=>"fa-cloud", 	"name"=>"Nameservers", 					"href"=>"nameservers", 					"description"=>"Recursive nameserver sets for subnets");
 if($User->settings->enableVRF==1)
 $admin_menu['IP related management'][] = array("show"=>true,	"icon"=>"fa-cloud", 	"name"=>"VRF", 						"href"=>"vrfs", 					"description"=>"VRF management");
 $admin_menu['IP related management'][] = array("show"=>true,	"icon"=>"fa-cloud-download", 	"name"=>"RIPE import", 	"href"=>"ripe-import", 				"description"=>"Import subnets from RIPE");

--- a/app/admin/nameservers/edit-result.php
+++ b/app/admin/nameservers/edit-result.php
@@ -1,0 +1,56 @@
+<?php
+
+/**
+ * Script to edit nameserver sets
+ ***************************/
+
+/* functions */
+require( dirname(__FILE__) . '/../../../functions/functions.php');
+
+# initialize user object
+$Database 	= new Database_PDO;
+$User 		= new User ($Database);
+$Admin	 	= new Admin ($Database);
+$Result 	= new Result ();
+
+# verify that user is logged in
+$User->check_user_session();
+
+
+# Name and primary nameserver must be present!
+if($_POST['name'] == "") { $Result->show("danger", _("Name is mandatory"), true); }
+if($_POST['namesrv1'] == "") { $Result->show("danger", _("Primary nameserver is mandatory"), true); }
+
+// set sections
+if(@$_POST['nameserverId']!=1) {
+	foreach($_POST as $key=>$line) {
+		if (strlen(strstr($key,"section-"))>0) {
+			$key2 = str_replace("section-", "", $key);
+			$temp[] = $key2;
+			unset($_POST[$key]);
+		}
+	}
+	# glue sections together
+	$_POST['permissions'] = sizeof($temp)>0 ? implode(";", $temp) : null;
+}
+else {
+	$_POST['permissions'] = "";
+}
+
+# set update array
+$values = array("id"=>@$_POST['nameserverId'],
+				"name"=>$_POST['name'],
+				"namesrv1"=>$_POST['namesrv1'],
+				"namesrv2"=>$_POST['namesrv2'],
+				"namesrv3"=>$_POST['namesrv3'],
+				"description"=>$_POST['description'],
+				"permissions"=>$_POST['permissions']
+				);
+# update
+if(!$Admin->object_modify("nameservers", $_POST['action'], "nameserverid", $values))	{ $Result->show("danger",  _("Failed to $_POST[action] nameserver set").'!', true); }
+else																	{ $Result->show("success", _("Nameserver set $_POST[action] successfull").'!', false); }
+
+
+# remove all references if delete
+if($_POST['action']=="delete") { $Admin->remove_object_references ("nameservers", "id", $_POST['nameserverId']); }
+?>

--- a/app/admin/nameservers/edit.php
+++ b/app/admin/nameservers/edit.php
@@ -1,0 +1,118 @@
+<?php
+
+/**
+ *	Print all available nameserver sets and configurations
+ ************************************************/
+
+/* functions */
+require( dirname(__FILE__) . '/../../../functions/functions.php');
+
+# initialize user object
+$Database 	= new Database_PDO;
+$User 		= new User ($Database);
+$Admin	 	= new Admin ($Database);
+$Tools	 	= new Tools ($Database);
+$Sections	= new Sections ($Database);
+$Result 	= new Result ();
+
+# verify that user is logged in
+$User->check_user_session();
+
+# get Nameserver sets
+if($_POST['action']!="add") {
+	$nameservers = $Admin->fetch_object ("nameservers", "id", $_POST['nameserverId']);
+	$nameservers!==false ? : $Result->show("danger", _("Invalid ID"), true, true);
+	$nameservers = (array) $nameservers;
+}
+
+# disable edit on delete
+$readonly = $_POST['action']=="delete" ? "readonly" : "";
+?>
+
+
+<!-- header -->
+<div class="pHeader"><?php print ucwords(_("$_POST[action]")); ?> <?php print _('Nameserver set'); ?></div>
+
+<!-- content -->
+<div class="pContent">
+
+	<form id="nameserverManagementEdit">
+	<table id="nameserverManagementEdit2" class="table table-noborder table-condensed">
+
+	<!-- name  -->
+	<tr>
+		<td><?php print _('Name'); ?></td>
+		<td>
+			<input type="text" class="name form-control input-sm" name="name" placeholder="<?php print _('Nameserver set'); ?>" value="<?php print @$nameservers['name']; ?>" <?php print $readonly; ?>>
+		</td>
+	</tr>
+	<!-- Nameservers -->
+	<tr>
+		<td><?php print _('Primary'); ?></td>
+		<td>
+			<input type="text" class="rd form-control input-sm" name="namesrv1" placeholder="<?php print _('Primary nameserver'); ?>" value="<?php print @$nameservers['namesrv1']; ?>" <?php print $readonly; ?>>
+		</td>
+	</tr>
+	<tr>
+		<td><?php print _('Secondary'); ?></td>
+		<td>
+			<input type="text" class="rd form-control input-sm" name="namesrv2" placeholder="<?php print _('Secondary nameserver'); ?>" value="<?php print @$nameservers['namesrv2']; ?>" <?php print $readonly; ?>>
+		</td>
+	</tr>
+	<tr>
+		<td><?php print _('Tertiary'); ?></td>
+		<td>
+			<input type="text" class="rd form-control input-sm" name="namesrv3" placeholder="<?php print _('Tertiary nameserver'); ?>" value="<?php print @$nameservers['namesrv3']; ?>" <?php print $readonly; ?>>
+		</td>
+	</tr>
+
+	<!-- Description -->
+	<tr>
+		<td><?php print _('Description'); ?></td>
+		<td>
+			<?php
+			if( ($_POST['action'] == "edit") || ($_POST['action'] == "delete") ) { print '<input type="hidden" name="nameserverId" value="'. $_POST['nameserverId'] .'">'. "\n";}
+			?>
+			<input type="hidden" name="action" value="<?php print $_POST['action']; ?>">
+			<input type="text" class="description form-control input-sm" name="description" placeholder="<?php print _('Description'); ?>" value="<?php print @$nameservers['description']; ?>" <?php print $readonly; ?>>
+		</td>
+	</tr>
+	
+	<!-- sections -->
+	<tr>
+		<td style="vertical-align: top !important"><?php print _('Sections to display<br>nameserver set in'); ?>:</td>
+		<td>
+		<?php
+		# select sections
+		$Sections->fetch_all_sections();
+		# reformat domains sections to array
+		$nameservers_sections = explode(";", @$nameservers['permissions']);
+		$nameservers_sections = is_array($nameservers_sections) ? $nameservers_sections : array();
+		// loop
+		foreach($Sections->sections as $section) {
+			if(in_array($section->id, @$nameservers_sections) || @$nameservers['id']=="1") 	{ print '<div class="checkbox" style="margin:0px;"><input type="checkbox" name="section-'. $section->id .'" value="on" checked> '. $section->name .'</div>'. "\n"; }
+			else 																		{ print '<div class="checkbox" style="margin:0px;"><input type="checkbox" name="section-'. $section->id .'" value="on">'. $section->name .'</span></div>'. "\n"; }
+		}
+		?>
+		</td>
+	</tr>
+
+	</table>
+	</form>
+
+	<?php
+	//print delete warning
+	if($_POST['action'] == "delete")	{ $Result->show("warning", "<strong>"._('Warning').":</strong> "._("removing nameserver set will also remove all references from belonging subnets!"), false);}
+	?>
+</div>
+
+
+<!-- footer -->
+<div class="pFooter">
+	<div class="btn-group">
+		<button class="btn btn-sm btn-default hidePopups"><?php print _('Cancel'); ?></button>
+		<button class="btn btn-sm btn-default <?php if($_POST['action']=="delete") { print "btn-danger"; } else { print "btn-success"; } ?>" id="editNameservers"><i class="fa <?php if($_POST['action']=="add") { print "fa-plus"; } else if ($_POST['action']=="delete") { print "fa-trash-o"; } else { print "fa-check"; } ?>"></i> <?php print ucwords(_($_POST['action'])); ?></button>
+	</div>
+	<!-- result -->
+	<div class="nameserverManagementEditResult"></div>
+</div>

--- a/app/admin/nameservers/index.php
+++ b/app/admin/nameservers/index.php
@@ -1,0 +1,62 @@
+<?php
+
+/**
+ *	Print all available nameserver sets
+ ************************************************/
+
+# verify that user is logged in
+$User->check_user_session();
+
+# fetch all vrfs
+$all_nameservers = $Admin->fetch_all_objects("nameservers", "id");
+?>
+
+<h4><?php print _('Manage Nameserver sets'); ?></h4>
+<hr><br>
+
+<button class='btn btn-sm btn-default nameserverManagement' data-action='add' data-nameserverid='' style='margin-bottom:10px;'><i class='fa fa-plus'></i> <?php print _('Add nameserver set'); ?></button>
+
+<!-- nameserver sets -->
+<?php
+
+# first check if they exist!
+if($all_nameservers===false) { $Result->show("danger", _("No nameserver sets defined")."!", true);}
+else {
+	print '<table id="nameserverManagement" class="table table-striped table-top table-hover table-auto">'. "\n";
+
+	# headers
+	print '<tr>'. "\n";
+	print '	<th>'._('Nameserver set').'</th>'. "\n";
+	print '	<th>'._('Primary').'</th>'. "\n";
+	print '	<th>'._('Secondary').'</th>'. "\n";
+	print '	<th>'._('Tertiary').'</th>'. "\n";
+	print '	<th>'._('Description').'</th>'. "\n";
+	print '	<th></th>'. "\n";
+	print '</tr>'. "\n";
+
+	# loop
+	foreach ($all_nameservers as $nameservers) {
+		//cast
+		$nameservers = (array) $nameservers;
+
+		//print details
+		print '<tr>'. "\n";
+		print '	<td class="name">'. $nameservers['name'] .'</td>'. "\n";
+		print '	<td class="namesrv1">'. $nameservers['namesrv1'] .'</td>'. "\n";
+		print '	<td class="namesrv2">'. $nameservers['namesrv2'] .'</td>'. "\n";
+		print '	<td class="namesrv3">'. $nameservers['namesrv3'] .'</td>'. "\n";
+		print '	<td class="description">'. $nameservers['description'] .'</td>'. "\n";
+		print "	<td class='actions'>";
+		print "	<div class='btn-group'>";
+		print "		<button class='btn btn-xs btn-default nameserverManagement' data-action='edit'   data-nameserverid='$nameservers[id]'><i class='fa fa-pencil'></i></button>";
+		print "		<button class='btn btn-xs btn-default nameserverManagement' data-action='delete' data-nameserverid='$nameservers[id]'><i class='fa fa-times'></i></button>";
+		print "	</div>";
+		print "	</td>";
+		print '</tr>'. "\n";
+	}
+	print '</table>'. "\n";
+}
+?>
+
+<!-- edit result holder -->
+<div class="nameserverManagementEdit"></div>

--- a/app/admin/requests/edit.php
+++ b/app/admin/requests/edit.php
@@ -65,7 +65,7 @@ $custom_fields = $Tools->fetch_custom_fields('ipaddresses');
 	<tr>
 		<th><?php print _('IP address'); ?></th>
 		<td>
-			<input type="text" name="ip_addr" class="ip_addr form-control input-sm" value="<?php print @request['ip_addr']; ?>" size="30">
+			<input type="text" name="ip_addr" class="ip_addr form-control input-sm" value="<?php print @$request['ip_addr']; ?>" size="30">
 			<input type="hidden" name="requestId" value="<?php print $request['id']; ?>">
 			<input type="hidden" name="requester" value="<?php print $request['requester']; ?>">
     	</td>

--- a/app/admin/requests/edit.php
+++ b/app/admin/requests/edit.php
@@ -65,7 +65,7 @@ $custom_fields = $Tools->fetch_custom_fields('ipaddresses');
 	<tr>
 		<th><?php print _('IP address'); ?></th>
 		<td>
-			<input type="text" name="ip_addr" class="ip_addr form-control input-sm" value="<?php print @request['ip_addr']; ?>" size="30">
+			<input type="text" name="ip_addr" class="ip_addr form-control input-sm" value="<?php print $Addresses->transform_to_dotted($Addresses->get_first_available_address ($request['subnetId'], $Subnets)); ?>" size="30">
 			<input type="hidden" name="requestId" value="<?php print $request['id']; ?>">
 			<input type="hidden" name="requester" value="<?php print $request['requester']; ?>">
     	</td>

--- a/app/admin/requests/edit.php
+++ b/app/admin/requests/edit.php
@@ -65,7 +65,7 @@ $custom_fields = $Tools->fetch_custom_fields('ipaddresses');
 	<tr>
 		<th><?php print _('IP address'); ?></th>
 		<td>
-			<input type="text" name="ip_addr" class="ip_addr form-control input-sm" value="<?php print $Addresses->transform_to_dotted($Addresses->get_first_available_address ($request['subnetId'], $Subnets)); ?>" size="30">
+			<input type="text" name="ip_addr" class="ip_addr form-control input-sm" value="<?php print @request['ip_addr']; ?>" size="30">
 			<input type="hidden" name="requestId" value="<?php print $request['id']; ?>">
 			<input type="hidden" name="requester" value="<?php print $request['requester']; ?>">
     	</td>

--- a/app/admin/requests/edit.php
+++ b/app/admin/requests/edit.php
@@ -65,7 +65,7 @@ $custom_fields = $Tools->fetch_custom_fields('ipaddresses');
 	<tr>
 		<th><?php print _('IP address'); ?></th>
 		<td>
-			<input type="text" name="ip_addr" class="ip_addr form-control input-sm" value="<?php print @$request['ip_addr']; ?>" size="30">
+			<input type="text" name="ip_addr" class="ip_addr form-control input-sm" value="<?php print @request['ip_addr']; ?>" size="30">
 			<input type="hidden" name="requestId" value="<?php print $request['id']; ?>">
 			<input type="hidden" name="requester" value="<?php print $request['requester']; ?>">
     	</td>

--- a/app/admin/subnets/edit-nameserver-dropdown.php
+++ b/app/admin/subnets/edit-nameserver-dropdown.php
@@ -1,0 +1,88 @@
+<?php
+
+/*
+ * Print select vlan in subnets
+ *******************************/
+
+/* required functions */
+if(!is_object($User)) {
+	/* functions */
+	require( dirname(__FILE__) . '/../../../functions/functions.php');
+
+	# initialize user object
+	$Database 	= new Database_PDO;
+	$User 		= new User ($Database);
+	$Tools	 	= new Tools ($Database);
+	$Sections	= new Sections ($Database);
+	$Result 	= new Result ();
+}
+
+# verify that user is logged in
+$User->check_user_session();
+
+# fetch all permitted domains
+$permitted_nameservers = $Sections->fetch_section_nameserver_sets ($_POST['sectionId']);
+
+
+# fetch all belonging nameserver set
+$cnt = 0;
+foreach($permitted_nameservers as $k=>$n) {
+	// fetch nameserver sets and append
+
+	$nameserver_set = $Tools->fetch_multiple_objects("nameservers", "id", $n, "name", "namesrv1", "namesrv2", "namesrv3");
+
+	
+	//save to array
+	$nsout[$n] = $nameserver_set;
+	
+	
+	//count add
+	$cnt++;
+}
+//filter out empty
+$permitted_nameservers = array_filter($nsout);
+
+
+?>
+
+<select name="nameserverId" class="form-control input-sm input-w-auto">
+	<option disabled="disabled"><?php print _('Select nameserver set'); ?>:</option>
+	<option disabled="disabled"></option>
+	<option value="0"><?php print _('No nameservers'); ?></option>
+	<option disabled="disabled"></option>
+
+	<?php
+	
+	# print all available nameserver sets
+	foreach($permitted_nameservers as $n) {
+			
+			if($n[0]!==null) {
+				foreach($n as $ns) {
+					// set print
+					$printNS = "$ns->name";
+				
+					$printNS .= " (" . $ns->namesrv1;
+		
+		// Only print namesrv2+3 if present
+	if ( !empty($ns->namesrv2) ) {
+		$printNS .= ", " . $ns->namesrv2;
+	}
+	if ( !empty($ns->namesrv3) ) {
+		$printNS .= ", " . $ns->namesrv3;
+	}
+	$printNS .= ")";			
+					
+
+					/* selected? */
+					if(@$subnet_old_details['nameserverId']==$ns->id) 	{ print '<option value="'. $ns->id .'" selected>'. $printNS .'</option>'. "\n"; }
+					elseif(@$_POST['nameserverId'] == $ns->id) 	{ print '<option value="'. $ns->id .'" selected>'. $printNS .'</option>'. "\n"; }
+					else 										{ print '<option value="'. $ns->id .'">'. $printNS .'</option>'. "\n"; }
+				}
+			}
+
+	}
+	?>
+
+
+
+</select>

--- a/app/admin/subnets/edit-result.php
+++ b/app/admin/subnets/edit-result.php
@@ -249,7 +249,8 @@ else {
 					"allowRequests"=>$Admin->verify_checkbox(@$_POST['allowRequests']),
 					"showName"=>$Admin->verify_checkbox(@$_POST['showName']),
 					"discoverSubnet"=>$Admin->verify_checkbox(@$_POST['discoverSubnet']),
-					"pingSubnet"=>$Admin->verify_checkbox(@$_POST['pingSubnet'])
+					"pingSubnet"=>$Admin->verify_checkbox(@$_POST['pingSubnet']),
+					"nameserverId"=>$_POST['nameserverId']
 					);
 	# for new subnets we add permissions
 	if($_POST['action']=="add") {

--- a/app/admin/subnets/edit-vlan-dropdown.php
+++ b/app/admin/subnets/edit-vlan-dropdown.php
@@ -22,11 +22,12 @@ $User->check_user_session();
 
 # fetch all permitted domains
 $permitted_domains = $Sections->fetch_section_domains ($_POST['sectionId']);
+
 # fetch all belonging vlans
 $cnt = 0;
 foreach($permitted_domains as $k=>$d) {
 	// fetch vlans and append
-	$vlans = $Tools->fetch_multiple_objects("vlans", "domainId", $d, "number");
+	$vlans = $Tools->fetch_multiple_objects("vlans", "vlanId", $d, "number");
 	//fetch domain
 	$domain = $Tools->fetch_object("vlanDomains","id",$d);
 	//save to array

--- a/app/admin/subnets/edit.php
+++ b/app/admin/subnets/edit.php
@@ -161,6 +161,15 @@ $(".input-switch").bootstrapSwitch(switch_options);
          </td>
         <td class="info2"><?php print _('Select VLAN'); ?></td>
     </tr>
+	
+	<!-- Nameservers -->
+	<tr>
+		<td class="middle"><?php print _('Nameserver(s)'); ?></td>
+		<td id="nameserverDropdown">
+			<?php include('edit-nameserver-dropdown.php'); ?>
+		</td>
+		<td class="info2"><?php print _('Select nameserver set'); ?></td>
+    </tr>
 
     <!-- Master subnet -->
     <tr>

--- a/app/admin/vlans/print-domain-vlans.php
+++ b/app/admin/vlans/print-domain-vlans.php
@@ -91,7 +91,7 @@ else {
 		print '<tr>'. "\n";
 
 		print '	<td class="name">'. $vlan['name'] .'</td>'. "\n";
-		print '	<td class="number"><a href="'.create_link("tools","vlan",$vlan['vlanId']).'">'. $vlan['number'] .'</a></td>'. "\n";
+		print '	<td class="number"><a href="'.create_link("tools","vlan", $vlan['domainId'], $vlan['vlanId']).'">'. $vlan['number'] .'</a></td>'. "\n";
 		print '	<td class="description">'. $vlan['description'] .'</td>'. "\n";
 
 		if(sizeof($custom) > 0) {
@@ -100,7 +100,7 @@ else {
 
 					print "<td class='customField hidden-xs hidden-sm'>";
 
-					// creat links
+					// create links
 					$vlan[$field['name']] = create_links ($vlan[$field['name']]);
 
 					//booleans

--- a/app/subnets/addresses/mail-notify.php
+++ b/app/subnets/addresses/mail-notify.php
@@ -15,6 +15,7 @@ $Subnets	= new Subnets ($Database);
 $Tools	    = new Tools ($Database);
 $Addresses	= new Addresses ($Database);
 
+
 # verify that user is logged in
 $User->check_user_session();
 
@@ -24,10 +25,11 @@ is_numeric($_POST['id']) || strlen($_POST['id'])==0 ?:	$Result->show("danger", _
 # get IP address id
 $id = $_POST['id'];
 
-# fetch address, subnet and vlan
+# fetch address, subnet, vlan and nameservers
 $address = (array) $Addresses->fetch_address (null, $id);
 $subnet  = (array) $Subnets->fetch_subnet (null, $address['subnetId']);
-$vlan    = (array) $Tools->fetch_object("vlans", "vlanId", @$address['vlanId']);
+$vlan    = (array) $Tools->fetch_object ("vlans", "vlanId", $subnet['vlanId']);
+$nameservers    = (array) $Tools->fetch_object("nameservers", "id", $subnet['nameserverId']);
 
 # get all custom fields
 $custom_fields = $Tools->fetch_custom_fields ('ipaddresses');
@@ -43,21 +45,39 @@ $title = _('IP address details').' :: ' . $address['ip'];
 
 
 # address
-										$content[] = "&bull; "._('IP address').": \t $address[ip]/$subnet[mask]";
+										$content[] = "&bull; "._('IP address').": \t\t $address[ip]/$subnet[mask]";
 # description
-empty($address['description']) ? : 		$content[] = "&bull; "._('Description').":\t $address[description]";
+empty($address['description']) ? : 		$content[] = "&bull; "._('Description').":\t\t $address[description]";
 # hostname
-empty($address['dns_name']) ? : 		$content[] = "&bull; "._('Hostname').": \t $address[dns_name]";
-# subnet desc
-$s_descrip = empty($address['description']) ? "" : 	 " (" . $subnet['description']. ")";
+empty($address['dns_name']) ? : 		$content[] = "&bull; "._('Hostname').": \t\t $address[dns_name]";
+# Only show subnet description if defined
+$s_descrip = empty($subnet['description']) ? "" : 	 " (" . $subnet['description']. ")";
 # subnet
-										$content[] = "&bull; "._('Subnet').": \t $subnet[ip]/$subnet[mask] $s_descrip";
+						$content[] = "&bull; "._('Subnet').": \t\t $subnet[ip]/$subnet[mask] $s_descrip";
 # gateway
 $gateway = $Subnets->find_gateway($subnet['id']);
 if($gateway !==false)
- 										$content[] = "&bull; "._('Gateway').": \t". $Subnets->transform_to_dotted($gateway->ip_addr);
+ 						$content[] = "&bull; "._('Gateway').": \t\t". $Subnets->transform_to_dotted($gateway->ip_addr);
+									
+
 # VLAN
-empty($address['vlan']) ? : 			$content[] = "&bull; "._('VLAN').": \t\t $address[vlan]";
+empty($subnet['vlanId']) ? : 			$content[] = "&bull; "._('VLAN ID').": \t\t $vlan[number] ($vlan[name])";
+
+# Nameserver sets
+if ( !empty( $subnet['nameserverId'] ) ) {
+	$nslist = $nameservers['namesrv1'];
+
+	// Only print namesrv2+3 if present
+	if ( !empty($nameservers['namesrv2']) ) {
+		$nslist .= ", " . $nameservers['namesrv2'];
+	}
+	if ( !empty($nameservers['namesrv3']) ) {
+		$nslist .= ", " . $nameservers['namesrv3'];
+	}
+						$content[] = "&bull; "._('Nameservers').": \t $nslist (${nameservers['name']})";
+}
+
+
 # Switch
 if(!empty($address['switch'])) {
 	# get device by id
@@ -65,17 +85,17 @@ if(!empty($address['switch'])) {
 	!sizeof($device)>1 ? : 				$content[] = "&bull; "._('Device').": \t\t $device[hostname]";
 }
 # port
-empty($address['port']) ? : 			$content[] = "&bull; "._('Port').": \t $address[port]";
+empty($address['port']) ? : 			$content[] = "&bull; "._('Port').": \t\t $address[port]";
 # mac
-empty($address['mac']) ? : 				$content[] = "&bull; "._('Mac address').": \t $address[mac]";
+empty($address['mac']) ? : 			$content[] = "&bull; "._('Mac address').": \t\t $address[mac]";
 # owner
-empty($address['owner']) ? : 			$content[] = "&bull; "._('Owners').": \t $address[owner]";
+empty($address['owner']) ? : 			$content[] = "&bull; "._('Owners').": \t\t $address[owner]";
 
 # custom
 if(sizeof($custom_fields) > 0) {
 	foreach($custom_fields as $custom_field) {
 		if(!empty($address[$custom_field['name']])) {
-										$content[] =  "&bull; ". _($custom_field['name']).":\t".$address[$custom_field['name']];
+						$content[] =  "&bull; ". _($custom_field['name']).":\t".$address[$custom_field['name']];
 		}
 	}
 }
@@ -114,7 +134,7 @@ if(sizeof($custom_fields) > 0) {
 	<tr>
 		<th><?php print _('Content'); ?></th>
 		<td style="padding-right:20px;">
-			<textarea name="content" class='form-control input-sm' rows="7" style="width:100%;"><?php print implode("\n", $content); ?></textarea>
+			<textarea name="content" class='form-control input-sm' rows="10" style="width:100%;"><?php print implode("\n", $content); ?></textarea>
 		</td>
 	</tr>
 

--- a/app/subnets/index.php
+++ b/app/subnets/index.php
@@ -8,7 +8,7 @@ $User->check_user_session();
 # subnet id must be numeric
 if(!is_numeric($_GET['subnetId'])) 	{ $Result->show("danger", _('Invalid ID'), true); }
 
-# fetch subnet reated stuff
+# fetch subnet related stuff
 $custom_fields = $Tools->fetch_custom_fields ('subnets');											//custom fields
 $subnet  = (array) $Subnets->fetch_subnet(null, $_GET['subnetId']);									//subnet details
 if(sizeof($subnet)==0) 				{ $Result->show("danger", _('Subnet does not exist'), true); }	//die if empty
@@ -22,6 +22,9 @@ if($subnet_permission == 0)			{ $Result->show("danger", _('You do not have permi
 
 # fetch VLAN details
 $vlan = (array) $Tools->fetch_object("vlans", "vlanId", $subnet['vlanId']);
+
+# fetch recursive nameserver details
+$nameservers = (array) $Tools->fetch_object("nameservers", "id", $subnet['nameserverId']);
 
 # fetch all addresses and calculate usage
 if($slaves) {

--- a/app/subnets/subnet-details.php
+++ b/app/subnets/subnet-details.php
@@ -66,6 +66,38 @@ $rowSpan = 10 + sizeof($custom_fields);
 		?>
 		</td>
 	</tr>
+	
+	<!-- nameservers -->
+		<tr>
+		<th><?php print _('Nameservers'); ?></th>
+		<td>
+		<?php
+		
+		// Only show nameservers if defined for subnet
+		if(!empty($subnet['nameserverId'])) {
+			# fetch recursive nameserver details
+			$nameservers = (array) $Tools->fetch_object("nameservers", "id", $subnet['nameserverId']);
+			
+			print $nameservers['namesrv1'];
+		
+			// Print secondary and tertiery nameserver if defined)
+			if(!empty($nameservers['namesrv2'])) {print ' , '.$nameservers['namesrv2']; }
+			if(!empty($nameservers['namesrv3'])) {print ' , '.$nameservers['namesrv3']; }
+			
+			//Print name of nameserver group
+			print ' ('.$nameservers['name'].')';				
+		
+			}
+			
+		else {
+			print "<span class='text-muted'>-</span>";
+			}
+		
+		?>
+		</td>
+	</tr>
+	
+	
 
 	<?php
 	# VRF

--- a/db/SCHEMA.sql
+++ b/db/SCHEMA.sql
@@ -103,6 +103,7 @@ CREATE TABLE `sections` (
   `editDate` TIMESTAMP  NULL  ON UPDATE CURRENT_TIMESTAMP,
   `showVLAN` BOOL  NOT NULL  DEFAULT '0',
   `showVRF` BOOL  NOT NULL  DEFAULT '0',
+  `showNameservers` BOOL NOT NULL DEFAULT '0',
   `DNS` VARCHAR(128)  NULL  DEFAULT NULL,
   PRIMARY KEY (`name`),
   UNIQUE KEY `id_2` (`id`),
@@ -231,6 +232,7 @@ CREATE TABLE `subnets` (
   `pingSubnet` BOOL NULL  DEFAULT '0',
   `discoverSubnet` BINARY(1)  NULL  DEFAULT '0',
   `DNSrecursive` TINYINT(1)  NULL  DEFAULT '0',
+  `nameserverId` INT(11) NULL DEFAULT '0',
   `scanAgent` INT(11)  DEFAULT NULL,
   `isFolder` BOOL NULL  DEFAULT '0',
   `isFull` TINYINT(1)  NULL  DEFAULT '0',
@@ -400,6 +402,28 @@ CREATE TABLE `vrf` (
   PRIMARY KEY (`vrfId`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
+# Dump of table nameservers
+# ------------------------------------------------------------
+DROP TABLE IF EXISTS `nameservers`;
+
+CREATE TABLE `nameservers` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `name` varchar(255) NOT NULL,
+  `namesrv1` varchar(255) DEFAULT NULL,
+  `namesrv2` varchar(255) DEFAULT NULL,
+  `namesrv3` varchar(255) DEFAULT NULL,
+  `description` text,
+  `permissions` varchar(128) DEFAULT NULL,
+  `editDate` TIMESTAMP  NULL  ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`nameserverId`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+/* insert default values */
+INSERT INTO `nameservers` (`name`, `namesrv1`, `namesrv2`, `description`)
+VALUES
+	('Global', '10.10.10.10', '10.10.11.12', ''),
+	('DMZ1', '192.168.100.10', '192.168.11.12', 'Nameservers used by DMZ servers');
+
+
 
 # Dump of table api
 # ------------------------------------------------------------
@@ -552,4 +576,4 @@ VALUES
 
 # update version
 # ------------------------------------------------------------
-UPDATE `settings` set `version` = '1.17';
+UPDATE `settings` set `version` = '1.18';

--- a/db/UPDATE-v1.18.sql
+++ b/db/UPDATE-v1.18.sql
@@ -1,0 +1,26 @@
+/* Update version */
+UPDATE `settings` set `version` = '1.18';
+/* reset db check field */
+UPDATE `settings` set `dbverified` = 0;
+
+
+/* add table for recursive nameservers to subnets */
+DROP TABLE IF EXISTS `nameservers`;
+
+CREATE TABLE `nameservers` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `name` varchar(255) NOT NULL,
+  `namesrv1` varchar(255) DEFAULT NULL,
+  `namesrv2` varchar(255) DEFAULT NULL,
+  `namesrv3` varchar(255) DEFAULT NULL,
+  `description` text,`
+  `permissions` varchar(128) DEFAULT NULL,
+  `editDate` TIMESTAMP  NULL  ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`nameserverId`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+/* add reference to nameservers in subnets table */
+ALTER TABLE `subnets` ADD `nameserverId` int(11) NULL DEFAULT '0' AFTER `DNSrecursive`;
+
+/* add bool to show/hide nameservers per section */
+ALTER TABLE `sections` ADD `ShowNameservers` BOOL NOT NULL DEFAULT '0' AFTER `ShowVRF`;

--- a/functions/classes/class.Sections.php
+++ b/functions/classes/class.Sections.php
@@ -429,11 +429,27 @@ class Sections  {
 		# return permitted
 		return $permitted;
 	}
-
-
-
-
-
+	
+	public function fetch_section_nameserver_sets ($sectionId) {
+		# first fetch all nameserver sets
+		$Admin = new Admin ($this->Database, false);
+		$nameservers = $Admin->fetch_all_objects ("nameservers");
+		# loop and check
+		foreach($nameservers as $n) {
+			//default
+			if($n->id==1) {
+					$permitted[] = $n->id;
+			}
+			else {
+				//array
+				if(in_array($sectionId, explode(";", $n->permissions))) {
+					$permitted[] = $n->id;
+				}
+			}
+		}
+		# return permitted
+		return $permitted;
+	}
 
 
 

--- a/functions/classes/class.Subnets.php
+++ b/functions/classes/class.Subnets.php
@@ -2651,6 +2651,31 @@ class Subnets {
 		# join and print
 		print implode( "\n", $html );
 	}
+	
+        /**
+         * Fetches all nameservers defined
+         *
+         * @access public
+         * @param mixed $sectionId
+         * @return void
+         */
+		 
+	/*	 
+    public function fetch_nameservers() {
+                
+			# set query
+            $query = "select distinct(`v`.`id`),`v`.`name`,`v`.`namesrv1`, `v`.`namesrv2` , `v`.`namesrv3` from `nameservers` order by `v`.`name` asc;";
+            
+			# fetch
+            try { $nameservers = $this->Database->getObjectsQuery($query, array(); }
+            catch (Exception $e) {
+                    $this->Result->show("danger", _("Error: ").$e->getMessage());
+                    return false;
+            }
+            # result
+            return sizeof($nameservers)>0 ? $nameservers : false;
 
+	}	
+	*/
 
 }

--- a/js/magic-1.15.js
+++ b/js/magic-1.15.js
@@ -1715,6 +1715,16 @@ $(document).on("click", "#editVRF", function() {
     submit_popup_data (".vrfManagementEditResult", "app/admin/vrfs/edit-result.php", $('form#vrfManagementEdit').serialize());
 });
 
+/* ---- Nameservers ----- */
+//load edit form
+$('.nameserverManagement').click(function() {
+	open_popup("400", "app/admin/nameservers/edit.php", {nameserverId:$(this).attr('data-nameserverid'), action:$(this).attr('data-action')} );
+});
+//submit form
+$(document).on("click", "#editNameservers", function() {
+    submit_popup_data (".nameserverManagementEditResult", "app/admin/nameservers/edit-result.php", $('form#nameserverManagementEdit').serialize());
+});
+
 
 /* ---- IP requests ----- */
 //load edit form


### PR DESCRIPTION
Hi Miha,

I've added support for recursive nameservers per subnet including limiting them per section. Each 'nameserver set' has the possibility for three nameservers and a description. This has been integrated into print/edit/mail notify for each subnet. Add/edit/delete nameservers from the admin-menu etc. The code is primarily copied from the vlan-code so expect to see reused code :-)

Version bumped to 1.18 including UPDATE-1.18.sql and updated SCHEMA.sql.

Bugfixes:
- Add missing reference for domainId in print-domain-vlans.php.
- Show the correct values for subnets and vlans when sending mail notifications

Please review throughly and change whatever you like - but I hope it will be of good use.

/Jonas
