### PR TITLE
Add quotes to mysqldump command

### DIFF
--- a/app/admin/export-database/generate-mysql.php
+++ b/app/admin/export-database/generate-mysql.php
@@ -25,7 +25,7 @@ $filename = "phpipam_MySQL_dump_". date("Y-m-d") .".sql";
 
 //set content
 /* $command = "mysqldump --opt -h $db['host'] -u $db['user'] -p $db['pass'] $db['name'] | gzip > $backupFile"; */
-$command = "mysqldump --opt -h ". $db['host'] ." -u ". $db['user'] ." -p". $db['pass'] ." ". $db['name'];
+$command = "mysqldump --opt -h '". $db['host'] ."' -u '". $db['user'] ."' -p'". $db['pass'] ."' '". $db['name'] ."'";
 
 $content  = "# phpipam Database dump \n";
 $content .= "#    command executed: $command \n";


### PR DESCRIPTION
Command fails on special characters (e.g. ampersand in password)
