### PR TITLE
Fix deletion of sections - $s is a stdclass object, not a string

### DIFF
--- a/functions/classes/class.Addresses.php
+++ b/functions/classes/class.Addresses.php
@@ -970,7 +970,7 @@ class Addresses extends Common_functions {
 
 		# create query
 		foreach($subnets as $k=>$s) {
-			$tmp[] = " `subnetId`=$s ";
+			$tmp[] = " `subnetId`={$s->id} ";
 		}
 		$query  = "select count(*) as `cnt` from `ipaddresses` where ".implode("or", $tmp).";";
 


### PR DESCRIPTION
Presently gives this error if you try to delete a section with multiple subnets:

Object of class stdClass could not be converted to string in /var/www/vhosts/ipam.bambambi.net/functions/classes/class.Addresses.php on line 973
