### PR TITLE
Fix multiple issues when there are no sections

### DIFF
--- a/functions/classes/class.Sections.php
+++ b/functions/classes/class.Sections.php
@@ -223,7 +223,7 @@ class Sections extends Common_functions {
 	 * @access public
 	 * @param string $order_by (default: "order")
 	 * @param bool $sort_asc (default: true)
-	 * @return void
+	 * @return array
 	 */
 	public function fetch_all_sections ($order_by="order", $sort_asc=true) {
 		# fetch all
@@ -239,7 +239,7 @@ class Sections extends Common_functions {
 			}
 		}
 		# response
-		return sizeof($sections)>0 ? $sections : false;
+		return sizeof($sections)>0 ? $sections : array();
 	}
 
 	/**


### PR DESCRIPTION
Make Sections->fetch_all_sections() return an empty array if no sections

Issues are mostly errors about looping over a non-array.

Changing the return type of this function is OK as empty array == false. I don't see any explicit === false checks.
