### PR TITLE
Split zones into forward, reverse v4 and reverse v6

### DIFF
--- a/app/admin/powerDNS/domain-records.php
+++ b/app/admin/powerDNS/domain-records.php
@@ -8,41 +8,43 @@
 $User->check_user_session();
 
 # validate domain
-$domain = $PowerDNS->fetch_domain($_GET['ipaddrid']);
+$domain = $PowerDNS->fetch_domain ($_GET['ipaddrid']);
 
 # validate
-if ($domain === false) {$Result->show("danger", _("Invalid domain"), false);} else {
-    # set order
-    $PowerDNS->set_query_values(1000, "name,type", " asc");
-    # fetch records
-    $records = $PowerDNS->fetch_all_domain_records($domain->id);
+if ($domain===false)	{ $Result->show ("danger", _("Invalid domain"), false); }
+else {
+	# set order
+	$PowerDNS->set_query_values (10000, "name,type", " asc");
+	# fetch records
+	$records = $PowerDNS->fetch_all_domain_records ($domain->id);
 
-    # exclude SOA, NS
-    if (sizeof($records) > 0) {
-        foreach ($records as $k => $r) {
-            // soa, NS
-            if ($r->type == "SOA" || $r->type == "NS") {
-                $records_default[] = $r;
-                unset($records[$k]);
-            }
-            // split to $origins ?
-        }
-    }
-    ?>
+	# exclude SOA, NS
+	if (sizeof($records)>0) {
+		foreach ($records as $k=>$r) {
+			// soa, NS
+			if ($r->type=="SOA" || $r->type=="NS") {
+				$records_default[] = $r;
+				unset ($records[$k]);
+			}
+			// split to $origins ?
+		}
+	}
+?>
 
 <br>
-<h4><?php print _('Records for domain');?> <strong><?php print $_GET['ipaddrid'];?></strong></h4><hr>
+<h4><?php print _('Records for domain'); ?> <strong><?php print $_GET['ipaddrid']; ?></strong></h4><hr>
 
 <!-- Add new -->
 <div class="btn-group" style="margin-bottom:10px;margin-top: 25px;">
-	<a href="<?php print create_link("administration", "powerDNS", "domains");?>" class='btn btn-sm btn-default'><i class='fa fa-angle-left'></i> <?php print _('Domains');?></a>
-	<button class='btn btn-sm btn-default btn-success editRecord' data-action='add' data-id='0' data-domain_id='<?php print $domain->id;?>'><i class='fa fa-plus'></i> <?php print _('New record');?></button>
+	<a href="<?php print create_link ("administration", "powerDNS", "domains"); ?>" class='btn btn-sm btn-default'><i class='fa fa-angle-left'></i> <?php print _('Domains'); ?></a>
+	<button class='btn btn-sm btn-default btn-success editRecord' data-action='add' data-id='0' data-domain_id='<?php print $domain->id; ?>'><i class='fa fa-plus'></i> <?php print _('New record'); ?></button>
 </div>
 
 <?php
 // none
-    if ($records === false) {$Result->show("info", _("Domain has no records"), false);} else {
-        ?>
+if($records===false) { $Result->show("info", _("Domain has no records"), false); }
+else {
+?>
 <!--  -->
 
 <!-- table -->
@@ -51,72 +53,73 @@ if ($domain === false) {$Result->show("danger", _("Invalid domain"), false);} el
 <!-- Headers -->
 <tr>
 	<th></th>
-    <th><?php print _('Name');?></th>
-    <th><?php print _('Type');?></th>
-    <th><?php print _('Content');?></th>
-    <th><?php print _('TTL');?></th>
-    <th><?php print _('Prio');?></th>
-    <th><?php print _('Last update');?></th>
+    <th><?php print _('Name'); ?></th>
+    <th><?php print _('Type'); ?></th>
+    <th><?php print _('Content'); ?></th>
+    <th><?php print _('TTL'); ?></th>
+    <th><?php print _('Prio'); ?></th>
+    <th><?php print _('Last update'); ?></th>
 </tr>
 
 <?php
 
 // function to print record
-        function print_record($r)
-        {
-            // check if disabled
-            $trclass = $r->disabled == "1" ? 'alert alert-danger' : '';
+function print_record ($r) {
+	// check if disabled
+	$trclass = $r->disabled=="1" ? 'alert alert-danger':'';
 
-            print "<tr class='$trclass'>";
-            // actions
-            print "	<td>";
-            print "	<div class='btn-group'>";
-            print "		<button class='btn btn-default btn-xs editRecord' data-action='edit'   data-id='$r->id' data-domain_id='$r->domain_id'><i class='fa fa-pencil'></i></button>";
-            print "		<button class='btn btn-default btn-xs editRecord' data-action='delete' data-id='$r->id' data-domain_id='$r->domain_id'><i class='fa fa-remove'></i></button>";
-            print "	</div>";
-            print "	</td>";
+	print "<tr class='$trclass'>";
+	// actions
+	print "	<td>";
+	print "	<div class='btn-group'>";
+	print "		<button class='btn btn-default btn-xs editRecord' data-action='edit'   data-id='$r->id' data-domain_id='$r->domain_id'><i class='fa fa-pencil'></i></button>";
+	print "		<button class='btn btn-default btn-xs editRecord' data-action='delete' data-id='$r->id' data-domain_id='$r->domain_id'><i class='fa fa-remove'></i></button>";
+	print "	</div>";
+	print "	</td>";
 
-            // content
-            print "	<td>$r->name</td>";
-            print "	<td><span class='badge badge1'>$r->type</span></td>";
-            print "	<td>$r->content</td>";
-            print "	<td>$r->ttl</td>";
-            print "	<td>$r->prio</td>";
-            print "	<td>$r->change_date</td>";
+	// content
+	print "	<td>$r->name</td>";
+	print "	<td><span class='badge badge1'>$r->type</span></td>";
+	print "	<td>$r->content</td>";
+	print "	<td>$r->ttl</td>";
+	print "	<td>$r->prio</td>";
+	print "	<td>$r->change_date</td>";
 
-            print "</tr>";
-        }
+	print "</tr>";
+}
+
 
 // default records
-        if (isset($records_default)) {
+if (isset($records_default)) {
 
-            print "<tr>";
-            print "	<th colspan='7'  style='padding-top:20px;'>" . _("SOA, NS records") . "</th>";
-            print "</tr>";
+print "<tr>";
+print "	<th colspan='7'  style='padding-top:20px;'>"._("SOA, NS records")."</th>";
+print "</tr>";
 
 // defaults
-            foreach ($records_default as $r) {
-                print_record($r);
-            }
-        }
+foreach ($records_default as $r) {
+	print_record ($r);
+}
+}
 
 // host records
-        print "<tr>";
-        print "	<th colspan='7' style='padding-top:20px;'>" . _("Domain records") . "</th>";
-        print "</tr>";
+print "<tr>";
+print "	<th colspan='7' style='padding-top:20px;'>"._("Domain records")."</th>";
+print "</tr>";
 
 // defaults
-        if (sizeof($records) > 0) {
-            foreach ($records as $r) {
-                print_record($r);
-            }
-        } else {
-            print "<tr>";
-            print "	<td colspan='7'><div class='alert alert-info'>" . _("No records") . "</div></td>";
-            print "</tr>";
-        }
+if (sizeof($records)>0) {
+	foreach ($records as $r) {
+		print_record ($r);
+	}
+}
+else {
+print "<tr>";
+print "	<td colspan='7'><div class='alert alert-info'>"._("No records")."</div></td>";
+print "</tr>";
+}
 
-        ?>
+?>
 
 </table>
 <?php

--- a/app/admin/powerDNS/domain-records.php
+++ b/app/admin/powerDNS/domain-records.php
@@ -8,43 +8,41 @@
 $User->check_user_session();
 
 # validate domain
-$domain = $PowerDNS->fetch_domain ($_GET['ipaddrid']);
+$domain = $PowerDNS->fetch_domain($_GET['ipaddrid']);
 
 # validate
-if ($domain===false)	{ $Result->show ("danger", _("Invalid domain"), false); }
-else {
-	# set order
-	$PowerDNS->set_query_values (10000, "name,type", " asc");
-	# fetch records
-	$records = $PowerDNS->fetch_all_domain_records ($domain->id);
+if ($domain === false) {$Result->show("danger", _("Invalid domain"), false);} else {
+    # set order
+    $PowerDNS->set_query_values(1000, "name,type", " asc");
+    # fetch records
+    $records = $PowerDNS->fetch_all_domain_records($domain->id);
 
-	# exclude SOA, NS
-	if (sizeof($records)>0) {
-		foreach ($records as $k=>$r) {
-			// soa, NS
-			if ($r->type=="SOA" || $r->type=="NS") {
-				$records_default[] = $r;
-				unset ($records[$k]);
-			}
-			// split to $origins ?
-		}
-	}
-?>
+    # exclude SOA, NS
+    if (sizeof($records) > 0) {
+        foreach ($records as $k => $r) {
+            // soa, NS
+            if ($r->type == "SOA" || $r->type == "NS") {
+                $records_default[] = $r;
+                unset($records[$k]);
+            }
+            // split to $origins ?
+        }
+    }
+    ?>
 
 <br>
-<h4><?php print _('Records for domain'); ?> <strong><?php print $_GET['ipaddrid']; ?></strong></h4><hr>
+<h4><?php print _('Records for domain');?> <strong><?php print $_GET['ipaddrid'];?></strong></h4><hr>
 
 <!-- Add new -->
 <div class="btn-group" style="margin-bottom:10px;margin-top: 25px;">
-	<a href="<?php print create_link ("administration", "powerDNS", "domains"); ?>" class='btn btn-sm btn-default'><i class='fa fa-angle-left'></i> <?php print _('Domains'); ?></a>
-	<button class='btn btn-sm btn-default btn-success editRecord' data-action='add' data-id='0' data-domain_id='<?php print $domain->id; ?>'><i class='fa fa-plus'></i> <?php print _('New record'); ?></button>
+	<a href="<?php print create_link("administration", "powerDNS", "domains");?>" class='btn btn-sm btn-default'><i class='fa fa-angle-left'></i> <?php print _('Domains');?></a>
+	<button class='btn btn-sm btn-default btn-success editRecord' data-action='add' data-id='0' data-domain_id='<?php print $domain->id;?>'><i class='fa fa-plus'></i> <?php print _('New record');?></button>
 </div>
 
 <?php
 // none
-if($records===false) { $Result->show("info", _("Domain has no records"), false); }
-else {
-?>
+    if ($records === false) {$Result->show("info", _("Domain has no records"), false);} else {
+        ?>
 <!--  -->
 
 <!-- table -->
@@ -53,73 +51,72 @@ else {
 <!-- Headers -->
 <tr>
 	<th></th>
-    <th><?php print _('Name'); ?></th>
-    <th><?php print _('Type'); ?></th>
-    <th><?php print _('Content'); ?></th>
-    <th><?php print _('TTL'); ?></th>
-    <th><?php print _('Prio'); ?></th>
-    <th><?php print _('Last update'); ?></th>
+    <th><?php print _('Name');?></th>
+    <th><?php print _('Type');?></th>
+    <th><?php print _('Content');?></th>
+    <th><?php print _('TTL');?></th>
+    <th><?php print _('Prio');?></th>
+    <th><?php print _('Last update');?></th>
 </tr>
 
 <?php
 
 // function to print record
-function print_record ($r) {
-	// check if disabled
-	$trclass = $r->disabled=="1" ? 'alert alert-danger':'';
+        function print_record($r)
+        {
+            // check if disabled
+            $trclass = $r->disabled == "1" ? 'alert alert-danger' : '';
 
-	print "<tr class='$trclass'>";
-	// actions
-	print "	<td>";
-	print "	<div class='btn-group'>";
-	print "		<button class='btn btn-default btn-xs editRecord' data-action='edit'   data-id='$r->id' data-domain_id='$r->domain_id'><i class='fa fa-pencil'></i></button>";
-	print "		<button class='btn btn-default btn-xs editRecord' data-action='delete' data-id='$r->id' data-domain_id='$r->domain_id'><i class='fa fa-remove'></i></button>";
-	print "	</div>";
-	print "	</td>";
+            print "<tr class='$trclass'>";
+            // actions
+            print "	<td>";
+            print "	<div class='btn-group'>";
+            print "		<button class='btn btn-default btn-xs editRecord' data-action='edit'   data-id='$r->id' data-domain_id='$r->domain_id'><i class='fa fa-pencil'></i></button>";
+            print "		<button class='btn btn-default btn-xs editRecord' data-action='delete' data-id='$r->id' data-domain_id='$r->domain_id'><i class='fa fa-remove'></i></button>";
+            print "	</div>";
+            print "	</td>";
 
-	// content
-	print "	<td>$r->name</td>";
-	print "	<td><span class='badge badge1'>$r->type</span></td>";
-	print "	<td>$r->content</td>";
-	print "	<td>$r->ttl</td>";
-	print "	<td>$r->prio</td>";
-	print "	<td>$r->change_date</td>";
+            // content
+            print "	<td>$r->name</td>";
+            print "	<td><span class='badge badge1'>$r->type</span></td>";
+            print "	<td>$r->content</td>";
+            print "	<td>$r->ttl</td>";
+            print "	<td>$r->prio</td>";
+            print "	<td>$r->change_date</td>";
 
-	print "</tr>";
-}
-
+            print "</tr>";
+        }
 
 // default records
-if (isset($records_default)) {
+        if (isset($records_default)) {
 
-print "<tr>";
-print "	<th colspan='7'  style='padding-top:20px;'>"._("SOA, NS records")."</th>";
-print "</tr>";
+            print "<tr>";
+            print "	<th colspan='7'  style='padding-top:20px;'>" . _("SOA, NS records") . "</th>";
+            print "</tr>";
 
 // defaults
-foreach ($records_default as $r) {
-	print_record ($r);
-}
-}
+            foreach ($records_default as $r) {
+                print_record($r);
+            }
+        }
 
 // host records
-print "<tr>";
-print "	<th colspan='7' style='padding-top:20px;'>"._("Domain records")."</th>";
-print "</tr>";
+        print "<tr>";
+        print "	<th colspan='7' style='padding-top:20px;'>" . _("Domain records") . "</th>";
+        print "</tr>";
 
 // defaults
-if (sizeof($records)>0) {
-	foreach ($records as $r) {
-		print_record ($r);
-	}
-}
-else {
-print "<tr>";
-print "	<td colspan='7'><div class='alert alert-info'>"._("No records")."</div></td>";
-print "</tr>";
-}
+        if (sizeof($records) > 0) {
+            foreach ($records as $r) {
+                print_record($r);
+            }
+        } else {
+            print "<tr>";
+            print "	<td colspan='7'><div class='alert alert-info'>" . _("No records") . "</div></td>";
+            print "</tr>";
+        }
 
-?>
+        ?>
 
 </table>
 <?php

--- a/app/admin/powerDNS/domains-print.php
+++ b/app/admin/powerDNS/domains-print.php
@@ -6,8 +6,27 @@
 
 # verify that user is logged in
 $User->check_user_session();
+
 # fetch domains
-$domains = $PowerDNS->fetch_all_domains ();
+$type = $_GET['subnetId'];
+
+switch ($type) {
+	case 'domains':
+		$domains = $PowerDNS->fetch_all_forward_domains ();
+		break;
+
+	case 'reverse_v4':
+		$domains = $PowerDNS->fetch_reverse_v4_domains ();
+		break;
+
+	case 'reverse_v6':
+		$domains = $PowerDNS->fetch_reverse_v6_domains ();
+		break;
+
+	default:
+		$Result->show("danger", "Invalid request", true);
+		break;
+}
 
 # split to reverse and normal
 if (sizeof($domains)>0) {

--- a/app/admin/powerDNS/domains-print.php
+++ b/app/admin/powerDNS/domains-print.php
@@ -12,14 +12,17 @@ $type = $_GET['subnetId'];
 
 switch ($type) {
 	case 'domains':
+		$title = _("Domains");
 		$domains = $PowerDNS->fetch_all_forward_domains ();
 		break;
 
 	case 'reverse_v4':
+		$title = _("IPv4 reverse domains");
 		$domains = $PowerDNS->fetch_reverse_v4_domains ();
 		break;
 
 	case 'reverse_v6':
+		$title = _("IPv6 reverse domains");
 		$domains = $PowerDNS->fetch_reverse_v6_domains ();
 		break;
 
@@ -28,27 +31,10 @@ switch ($type) {
 		break;
 }
 
-# split to reverse and normal
-if (sizeof($domains)>0) {
-	foreach($domains as $d) {
-		// ipv4 reverse records
-		if (strpos($d->name, ".in-addr.arpa")) {
-			$reverse4[] = $d;
-		}
-		// ipv6 reverse records
-		elseif (strpos($d->name, ".ipv6.arpa")) {
-			$reverse6[] = $d;
-		}
-		// normal
-		else {
-			$records[] = $d;
-		}
-	}
-}
 ?>
 
 <br>
-<h4><?php print _('Domains'); ?></h4><hr>
+<h4><?php print $title; ?></h4><hr>
 
 <!-- Add new -->
 <button class='btn btn-sm btn-default btn-success editDomain' style="margin-bottom:10px;margin-top: 25px;" data-action='add' data-id='0'><i class='fa fa-plus'></i> <?php print _('Create domain'); ?></button>
@@ -112,35 +98,13 @@ function print_records_domains ($d) {
 }
 
 // domain records
-if (isset($records)) {
-	print "<tr>";
-	print "	<th colspan='6'  style='padding-top:20px;'>"._("Domains")."</th>";
-	print "</tr>";
+if (isset($domains)) {
 	// print
-	foreach ($records as $r) {
+	foreach ($domains as $r) {
 		print_records_domains ($r);
 	}
 }
-// ipv4 reverse records records
-if (isset($reverse4)) {
-	print "<tr>";
-	print "	<th colspan='6'  style='padding-top:20px;'>"._("IPv4 reverse domain")."</th>";
-	print "</tr>";
-	// print
-	foreach ($reverse4 as $r) {
-		print_records_domains ($r);
-	}
-}
-// ipv6 reverse records records
-if (isset($reverse6)) {
-	print "<tr>";
-	print "	<th colspan='6'  style='padding-top:20px;'>"._("IPv6 reverse domains")."</th>";
-	print "</tr>";
-	// print
-	foreach ($reverse6 as $r) {
-		print_records_domains ($r);
-	}
-}
+
 ?>
 
 </table>

--- a/app/admin/powerDNS/index.php
+++ b/app/admin/powerDNS/index.php
@@ -29,9 +29,9 @@ $pdns = $PowerDNS->db_settings;
 <ul class="nav nav-tabs">
 	<?php
 	// tabs
-	$tabs = array("domains", "settings", "defaults");
+	$tabs = array("domains", "reverse_v4", "reverse_v6", "settings", "defaults");
 
-	//default tab
+	// default tab
 	if(!isset($_GET['subnetId'])) {
 		if(!$test)	{ $_GET['subnetId'] = "settings"; }
 		else		{ $_GET['subnetId'] = "domains"; }
@@ -42,8 +42,9 @@ $pdns = $PowerDNS->db_settings;
 
 	// print
 	foreach($tabs as $t) {
+		$title = str_replace('_', ' ', $t);
 		$class = $_GET['subnetId']==$t ? "class='active'" : "";
-		print "<li role='presentation' $class><a href=".create_link("administration", "powerDNS", "$t").">". _(ucwords($t))."</a></li>";
+		print "<li role='presentation' $class><a href=".create_link("administration", "powerDNS", "$t").">". _(ucwords($title))."</a></li>";
 	}
 	?>
 </ul>
@@ -51,8 +52,15 @@ $pdns = $PowerDNS->db_settings;
 <div>
 <?php
 // include content
-if(!file_exists(dirname(__FILE__) . '/'.$_GET['subnetId'].".php")) 	{ $Result->show("danger", "Invalid request", true); }
-else																{ include(dirname(__FILE__) . '/'.$_GET['subnetId'].".php"); }
+$section = $_GET['subnetId'];
+if (preg_match("/reverse_/", $section)) {
+	$filename = 'domains.php';
+} else {
+	$filename = "$_GET[subnetId].php";
+}
+
+if(!file_exists(dirname(__FILE__) . '/'.$filename)) 	{ $Result->show("danger", "Invalid request", true); }
+else													{ include(dirname(__FILE__) . '/'.$filename); }
 ?>
 </div>
 

--- a/functions/classes/class.PDO.php
+++ b/functions/classes/class.PDO.php
@@ -520,7 +520,7 @@ abstract class DB {
 
 		$statement = $this->pdo->prepare($query);
 
-		//debuq
+		//debug
 		$this->log_query ($statement);
 		$statement->execute((array)$values);
 
@@ -599,12 +599,14 @@ abstract class DB {
 		}
 	}
 
-	public function findObjects($table, $field, $value, $sortField = 'id', $sortAsc = true) {
+	public function findObjects($table, $field, $value, $sortField = 'id', $sortAsc = true, $like = false, $negate = false) {
 		$table = $this->escape($table);
 		$field = $this->escape($field);
 		$sortField = $this->escape($sortField);
+		$like === true ? $operator = "LIKE" : $operator = "=";
+		$negate === true ? $negate_operator = "NOT " : $negate_operator = "";
 
-		return $this->getObjectsQuery('SELECT * FROM `' . $table . '` WHERE `'. $field .'`=? ORDER BY `'.$sortField.'` ' . ($sortAsc ? '' : 'DESC') . ';', array($value));
+		return $this->getObjectsQuery('SELECT * FROM `' . $table . '` WHERE `'. $field .'`'.$negate_operator. $operator .'? ORDER BY `'.$sortField.'` ' . ($sortAsc ? '' : 'DESC') . ';', array($value));
 	}
 
 	public function findObject($table, $field, $value) {

--- a/functions/classes/class.PowerDNS.php
+++ b/functions/classes/class.PowerDNS.php
@@ -370,6 +370,69 @@ class PowerDNS extends Common_functions {
 		return sizeof($res)>0 ? $res : false;
 	}
 
+    /**
+     * Fetches all forward domains
+     *
+     * @access public
+     * @return void
+     */
+    public function fetch_all_forward_domains () {
+        # fetch
+        try { $res = $this->Database_pdns->findObjects("domains", "name", "%.arpa", "name", true, true, true); }
+        catch (Exception $e) {
+            $this->Result->show("danger", _("Error: ").$e->getMessage());
+            return false;
+        }
+        # cache
+        if (sizeof($res)>0) {
+            foreach ($res as $r) { $this->domains_cache[$r->id] = $r; }
+        }
+        # result
+        return sizeof($res)>0 ? $res : false;
+    }
+
+    /**
+     * Fetches all reverse IPv4 domains
+     *
+     * @access public
+     * @return void
+     */
+    public function fetch_reverse_v4_domains () {
+        # fetch
+        try { $res = $this->Database_pdns->findObjects("domains", "name", "%.in-addr.arpa", "name", true, true); }
+        catch (Exception $e) {
+            $this->Result->show("danger", _("Error: ").$e->getMessage());
+            return false;
+        }
+        # cache
+        if (sizeof($res) > 0) {
+            foreach ($res as $r) { $this->domains_cache[$r->id] = $r; }
+        }
+        # result
+        return sizeof($res) > 0 ? $res : false;
+    }
+
+    /**
+     * Fetches all reverse IPv6 domains
+     *
+     * @access public
+     * @return void
+     */
+    public function fetch_reverse_v6_domains () {
+        # fetch
+        try { $res = $this->Database_pdns->findObjects("domains", "name", "%.ipv6.arpa", "name", true, true); }
+        catch (Exception $e) {
+            $this->Result->show("danger", _("Error: ").$e->getMessage());
+            return false;
+        }
+        # cache
+        if (sizeof($res) > 0) {
+            foreach ($res as $r) { $this->domains_cache[$r->id] = $r; }
+        }
+        # result
+        return sizeof($res) > 0 ? $res : false;
+    }
+
 	/**
 	 * Fetches domain record by id (numberic) of name (varchar)
 	 *


### PR DESCRIPTION
This PR changes introduces two new tabs to the PowerDNS page. 

We have ~20k domains under management with PowerDNS and scrolling to the bottom of a huge list of forward zones to get to the reverse section was a bit annoying :) If this PR is OK I will work on pagination of records, similar to how subnets paginate IP address.
