### PR TITLE
fix SQL error when adding a subnet via API

### DIFF
--- a/functions/classes/class.Log.php
+++ b/functions/classes/class.Log.php
@@ -84,7 +84,23 @@ class Logging extends Common_functions {
 		# cache
 		if ($this->user_id===null) {
 			# null
-			if (!isset($_SESSION['ipamusername'])) { $this->user_id = null; }
+			$user_id = null;
+			if (!isset($_SESSION['ipamusername'])) {
+				// when API calls subnet_create we get:
+				// Error: SQLSTATE[23000]: Integrity constraint violation: 1048 Column 'cuser' cannot be null
+				// so let's get a user_id
+				if (array_key_exists("HTTP_PHPIPAM_TOKEN", $_SERVER)) {
+					$admin = new Admin($this->Database, False);
+					$token = $admin->fetch_object ("users", "token", $_SERVER['HTTP_PHPIPAM_TOKEN']);
+					if ($token === False) {
+						$this->user_id = null; 
+					} else {
+						$user_id = $token;
+					}
+				} else {
+					$this->user_id = null; 
+				}
+			}
 			else {
 				try { $user_id = $this->Database->getObjectQuery("select * from `users` where `username` = ? limit 1", array($_SESSION['ipamusername'])); }
 				catch (Exception $e) { $this->Result->show("danger", _("Database error: ").$e->getMessage()); }


### PR DESCRIPTION
when calling API->subnet_add(), the subnet is correctly created but i got a message back:

<div class='alert alert-danger'>Error: SQLSTATE[23000]: Integrity constraint violation: 1048 Column 'cuser' cannot be null</div>


It came from:
functions/classes/class.Subnets.php:
                $this->Log->write_changelog('subnet', "add", 'success', array(), $values);

 functions/classes/class.Log.php
        private function changelog_write_to_db ($changelog) {
        ...
       "cuser"  => $this->user_id,

=> $this->user_id is null
