### PR TITLE
Extended support for PDO_MYSQL SSL options

### DIFF
--- a/config.dist.php
+++ b/config.dist.php
@@ -1,6 +1,6 @@
 <?php
 
-/*	database connection details
+/*  database connection details
  ******************************/
 $db['host'] = "localhost";
 $db['user'] = "phpipam";
@@ -8,11 +8,20 @@ $db['pass'] = "phpipamadmin";
 $db['name'] = "phpipam";
 $db['port'] = 3306;
 
-// SSL options
-$db['ssl']  	= false;
-$db['ssl_key']	= "";
-$db['ssl_cert']	= "";
-$db['ssl_ca']	= "";
+/* SSL options
+ ******************************/
+// See http://php.net/manual/en/ref.pdo-mysql.php 
+//     https://dev.mysql.com/doc/refman/5.7/en/ssl-options.html
+
+// Please update these settings before setting 'ssl' to true.
+// All settings can be commented out or set to NULL if not needed
+
+$db['ssl']        = false;                           # true/false, enable or disable SSL as a whole
+$db['ssl_key']    = "/path/to/cert.key";             # path to an SSL key file. Only makes sense combined with ssl_cert
+$db['ssl_cert']   = "/path/to/cert.crt";             # path to an SSL certificate file. Only makes sense combined with ssl_key
+$db['ssl_ca']     = "/path/to/ca.crt";               # path to a file containing SSL CA certs
+$db['ssl_capath'] = "/path/to/ca_certs";             # path to a directory containing CA certs
+$db['ssl_cipher'] = "DHE-RSA-AES256-SHA:AES128-SHA"; # one or more SSL Ciphers
 
 /**
  * php debugging on/off
@@ -23,9 +32,9 @@ $db['ssl_ca']	= "";
 $debugging = false;
 
 /**
- *	manual set session name for auth
- *	increases security
- *	optional
+ *  manual set session name for auth
+ *  increases security
+ *  optional
  */
 $phpsessname = "phpipam";
 


### PR DESCRIPTION
Refactored the SSL config and handling of the settings to allow for
setting (or not setting) any of the options that PDO supports.

This will allow a user to specify client auth (ssl_key + ssl_cert), server auth (ssl_ca or ssl_capath), cipers (ssl_cipher) or any combo of these.  Settings are passed over as specified in the config and validation is left to PDO.

Tested against MariaDB 10 Galera Cluster
