### PR TITLE
Migration method for LDAP settings as well as backwards compat tweak

### DIFF
--- a/app/upgrade/upgrade-execute.php
+++ b/app/upgrade/upgrade-execute.php
@@ -25,6 +25,7 @@ if($Install->upgrade_database()===true) {
 
 	# migrate settings
 	$User->migrate_domain_settings ();
+  $User->migrate_ldap_settings ();
 
 	# check for possible errors
 	if(sizeof($errors = $Tools->verify_database())>0) {


### PR DESCRIPTION
Conflicts merged:
    app/upgrade/upgrade-execute.php

This adds a migration method for pre-1.2 -> 1.2 ldap auth settings.  The changes are minor and the code should be fairly self explanatory.  The only necessary migration are the SSL/TLS parameters, whose names changed.

Also, added some backwards compat in auth_LDAP(), just in case a migration doesn't occur, to keep people from getting locked out.
