### PR TITLE
Always full IP in visualizer-tooltip

### DIFF
--- a/app/subnets/subnet-visual.php
+++ b/app/subnets/subnet-visual.php
@@ -52,7 +52,7 @@ for($m=$start_visual; $m<=$stop_visual; $m=gmp_strval(gmp_add($m,1))) {
 		$class = "unused";
 		$id = $m;
 		$action = 'all-add';
-		$title = "";
+		$title = $Subnets->transform_to_dotted($m);
 
 		# set colors
 		$background = "#ffffff";


### PR DESCRIPTION
We usually have large networks (/22) and with these sizes the visualizer gets confusing when only the last octet is shown, even in the tooltip on unused addresses. This patch enables the full IP in the tooltip-header even when the IP is not in use.
