### PR TITLE
Import script is missing upload directory

### DIFF
--- a/app/subnets/import-subnet/upload/.htaccess
+++ b/app/subnets/import-subnet/upload/.htaccess
@@ -1,0 +1,8 @@
+# Don't list directory contents
+IndexIgnore *
+# Deny access via web to it
+Deny from all
+
+# Disable script execution
+AddHandler cgi-script .php .php2 .php3 .php4 .php5 .php6 .php7 .php8 .pl .py .js .jsp .asp .htm .html .shtml .sh .cgi
+Options -ExecCGI -Indexes


### PR DESCRIPTION
When trying to import IP addresses from the subnet view the script would always fail because the destination directory was missing. 

Used in app/subnets/import-subnet/import-verify.php:22
