### PR TITLE
API subnet PATCH : ignore if id2 contains empty string

### DIFF
--- a/api/v2/controllers/Subnets.php
+++ b/api/v2/controllers/Subnets.php
@@ -228,6 +228,7 @@ class Subnets_controller extends Common_api_functions {
 			if($this->_params->id2=="resize") 			{ return $this->subnet_resize (); }
 			// split
 			elseif($this->_params->id2=="split") 		{ return $this->subnet_split (); }
+			elseif($this->_params->id2=="") { }
 			// error
 			else										{ $this->Response->throw_exception(400, 'Invalid parameters'); }
 		}


### PR DESCRIPTION
I am using Nginx + Php-fpm with the nginx rewrite rules from https://github.com/phpipam/phpipam/issues/41

When i PATCH a subnet, the url is "PATCH /api/manage/subnets/404/ HTTP/1.1
Note the ending /, the following rewrite rules matches:
    rewrite ^/api/(._)/(._)/(.*) /api/index.php?app_id=$1&controller=$2&id=$3 last;

Anyways, anyone could add a trailing "/" and the url is still valid, PhpIpam should allow this.
