### PR TITLE
Net_IPv4::parseAddress will cause error on PHP5.4+

### DIFF
--- a/api/v1/functions/functions-tools.php
+++ b/api/v1/functions/functions-tools.php
@@ -44,7 +44,7 @@ function calculateIpCalcResult ($cidr)
     /* IPv4 */
     if ($type == "IPv4")
     {
-        $net = Net_IPv4::parseAddress( $cidr );
+        $net = (new Net_IPv4)->parseAddress( $cidr );
 
         //set ip address type
         $out['Type']            = 'IPv4';


### PR DESCRIPTION
"Strict Standards: Non-static method Net_IPv4::parseAddress() should not be called statically"
