### PR TITLE
Fix authentication glitch for LDAP users where user_dn and/or uid_att…

### DIFF
--- a/functions/classes/class.User.php
+++ b/functions/classes/class.User.php
@@ -924,10 +924,10 @@ class User extends Common_functions {
 		$this->ldap = true;							//set ldap flag
 
 		// set uid
-		if (isset($authparams['uid_attr'])) { $udn = $authparams['uid_attr'] . '=' . $username; }
+		if (!empty($authparams['uid_attr'])) { $udn = $authparams['uid_attr'] . '=' . $username; }
 		else 								{ $udn = 'uid=' . $username; }
 		// set DN
-		if (isset($authparams['users_base_dn'])) { $udn = $udn . "," . $authparams['users_base_dn']; }
+		if (!empty($authparams['users_base_dn'])) { $udn = $udn . "," . $authparams['users_base_dn']; }
 		else 									 { $udn = $udn . "," . $authparams['base_dn']; }
 		// authenticate
 		$this->directory_authenticate($authparams, $udn, $password);


### PR DESCRIPTION
…r were not expressly set

auth_LDAP was using isset to check authparams values, which was causing some logic issues if those values had been unset (ie. were "" instead of NULL).  Changed them over to use PHP's empty function (and inverted the corresponding if statements) and this seems to have solved the issue and allows the code to fall to its already defined defaults if those fields are empty.
