### PR TITLE
api: use the correct key for crypt security

### DIFF
--- a/api/index.php
+++ b/api/index.php
@@ -67,7 +67,7 @@ try {
 	    													{ $Response->throw_exception(500, 'php extension '.$extension.' missing'); }
 		}
 		// decrypt request - to JSON
-		$params = json_decode(trim(mcrypt_decrypt(MCRYPT_RIJNDAEL_256, $app->$_GET['app_id'], base64_decode($_GET['enc_request']), MCRYPT_MODE_ECB)));
+		$params = json_decode(trim(mcrypt_decrypt(MCRYPT_RIJNDAEL_256, $app->app_code, base64_decode($_GET['enc_request']), MCRYPT_MODE_ECB)));
 	}
 	// SSL checks
 	elseif($app->app_security=="ssl") {


### PR DESCRIPTION
the client encrypts the request parameters with
the app_code value, not the app_id value as seen
in the old client example code:

base64_encode(mcrypt_encrypt(MCRYPT_RIJNDAEL_256, $this->_app_key, json_encode($request_params), MCRYPT_MODE_ECB));
