### PR TITLE
Fixes #387

### DIFF
--- a/functions/classes/class.Tools.php
+++ b/functions/classes/class.Tools.php
@@ -1009,7 +1009,7 @@ class Tools extends Common_functions {
 
 		# get definition
 		$definition = strstr($schema, "CREATE TABLE `$table` (");
-		$definition = trim(strstr($definition, ";\n", true));
+		$definition = trim(strstr($definition, ";" . PHP_EOL, true));
 
 		# get each line to array
 		$definition = explode(PHP_EOL, $definition);


### PR DESCRIPTION
Prevents strstr() from returning an empty string on Windows, which in turn flags all standard fields as custom.
