### PR TITLE
Fix address_types caching

### DIFF
--- a/functions/classes/class.Addresses.php
+++ b/functions/classes/class.Addresses.php
@@ -151,6 +151,8 @@ class Addresses extends Common_functions {
 		foreach($types as $t) {
 			$types_out[$t->id] = (array) $t;
 		}
+		# save to cache
+		$this->address_types = $types_out;
 		# return
 		return $types_out;
 	}


### PR DESCRIPTION
The usage of this function, like [here](https://github.com/phpipam/phpipam/blob/d459dd5c3e32887fa04f37b7df4cb2cd64bb3aa7/functions/classes/class.Addresses.php#L167), seems to assume it's filling the local array (as it does in class.Subnets) but it isn't, this fixes it!
