### PR TITLE
Fix Log class constructor discarding settings

### DIFF
--- a/functions/classes/class.Common.php
+++ b/functions/classes/class.Common.php
@@ -254,7 +254,7 @@ class Common_functions  {
 	 * fetches settings from database
 	 *
 	 * @access private
-	 * @return none
+	 * @return void
 	 */
 	public function get_settings () {
 		# constant defined

--- a/functions/classes/class.Log.php
+++ b/functions/classes/class.Log.php
@@ -232,10 +232,15 @@ class Logging extends Common_functions {
 		# Result
 		$this->Result = new Result ();
 		# User
-  		$this->log_username = @$_SESSION['ipamusername'];
+		$this->log_username = @$_SESSION['ipamusername'];
 
 		# settings
-		$this->settings = $settings===null || $settings===false ? $this->get_settings () : (object) $settings;
+		if ($settings===null || $settings===false) {
+			$this->get_settings(); #assigns $this->settings internally
+		}
+		else {
+			$this->settings = (object) $settings;
+		}
 		# debugging
 		$this->set_debugging();
 		# set log type


### PR DESCRIPTION
Fixes https://github.com/phpipam/phpipam/issues/468.

Essentially, the ternary statement was assigning the return value of `$this->get_settings()`, `null`, to `$this->settings`.

As a result, logging would always go to the database due to that being the default behavior in the `Log->write` function.
