### PR TITLE
API fixes.  Changed  to public, changed variable test in class.Common…

### DIFF
--- a/api/controllers/Common.php
+++ b/api/controllers/Common.php
@@ -655,10 +655,12 @@ class Common_api_functions {
 		}
 		# array
 		else {
+			// create a new array for the remapped data
+			$result_remapped = array();
+
 			// loop
 			foreach ($result as $m=>$r) {
 				// start object
-				$result_remapped = array();
 				$result_remapped[$m] = new StdClass ();
 
 				// search and replace

--- a/api/controllers/L2domains.php
+++ b/api/controllers/L2domains.php
@@ -23,7 +23,7 @@ class L2domains_controller extends Common_api_functions {
 	 * @var mixed
 	 * @access protected
 	 */
-	protected $custom_fields;
+	public $custom_fields;
 
 	/**
 	 * Database object

--- a/api/controllers/Sections.php
+++ b/api/controllers/Sections.php
@@ -22,7 +22,7 @@ class Sections_controller extends Common_api_functions {
 	 * @var mixed
 	 * @access protected
 	 */
-	protected $custom_fields;
+	public $custom_fields;
 
 	/**
 	 * Database object

--- a/api/controllers/Subnets.php
+++ b/api/controllers/Subnets.php
@@ -22,7 +22,7 @@ class Subnets_controller extends Common_api_functions {
 	 * @var mixed
 	 * @access protected
 	 */
-	protected $custom_fields;
+	public $custom_fields;
 
 	/**
 	 * settings

--- a/api/controllers/Subnets.php
+++ b/api/controllers/Subnets.php
@@ -518,7 +518,7 @@ class Subnets_controller extends Common_api_functions {
 	 */
 	private function read_subnet ($subnetId = null) {
 		// null
-		$subnetId = !is_null($subnetId) ? $this->_params->id : $subnetId;
+		$subnetId = is_null($subnetId) ? $this->_params->id : $subnetId;
 		// fetch
 		$result = $this->Subnets->fetch_subnet ("id", $subnetId);
         // add nameservers

--- a/api/controllers/Vlans.php
+++ b/api/controllers/Vlans.php
@@ -23,7 +23,7 @@ class Vlans_controller extends Common_api_functions {
 	 * @var mixed
 	 * @access protected
 	 */
-	protected $custom_fields;
+	public $custom_fields;
 
 	/**
 	 * settings

--- a/functions/classes/class.Common.php
+++ b/functions/classes/class.Common.php
@@ -163,7 +163,7 @@ class Common_functions  {
 		if(strlen($table)==0)   return false;
 		if(is_null($method))	return false;
 		if(is_null($value))		return false;
-		if($value==0)		    return false;
+		if($value===0)		    return false;
 
 		# null method
 		$method = is_null($method) ? "id" : $this->Database->escape($method);


### PR DESCRIPTION
….php to use strict comparison, modified remap_result_keys in Common.php so it doesn't eat result arrays

public/protected status of $custom_fields needs to be evaluated but we can confirm that being protected almost universally breaks the API as of HEAD on 12 Apr.

The changes in api/controllers/Common.php and functions/classes/class.Common.php appear to fix  actual bugs.
