### PR TITLE
Api token write reduction

### DIFF
--- a/api/controllers/User.php
+++ b/api/controllers/User.php
@@ -513,6 +513,17 @@ class User_controller extends Common_api_functions {
 	private function refresh_token_expiration () {
 		# reset values
 		$this->token = $this->User->user->token;
+        
+		// convert existing expiry date string to a timestamp
+		$expire_time = strtotime($this->token_expires);
+
+		// Write Throttling from token updates
+		// In order to keep the DB writes from token updates to a minimum, only update the expire time
+		// if the expire time was set more than 60 seconds ago.
+		if ( ((time()+$this->token_valid_time) - $expire_time) < 60) {
+				return;
+		}
+
 		$this->token_expires = date("Y-m-d H:i:s", time()+$this->token_valid_time);
 		# set token values
 		$values = array(


### PR DESCRIPTION
This is a performance improvement that reduces the frequency of database writes when updating currently valid API tokens.  In refresh_token_expiration(), previously, it would update the token expiration timestamp every time the token was used. In our testing, this would result in as many as 5 writes per second during heavy API usage that was otherwise read-only.  In a WAN-distributed Galera cluster, this produced serious slowdowns compared to minimal writes.

This change add some simple math that checks if the new expire time is less than 60 seconds later than the currently-set expire time, and if so, it skips updating the token.

This reduces token updates to once per minute rather than 5 per second, and should have minimal impact on token usage.

Before the change:  890 API calls averaging 0.5913530813174301 sec per call
After the change:  890 API calls averaging 0.37313375017616185 sec per call

A 37% increase in speed for our test (YMMV)

<img width="1219" alt="screen shot 2016-04-19 at 4 52 54 pm" src="https://cloud.githubusercontent.com/assets/80896/14659568/f7f49d2c-0651-11e6-962c-d67559f0c9b6.png">
