### PR TITLE
Call exit() to avoid redirection loop

### DIFF
--- a/app/login/index.php
+++ b/app/login/index.php
@@ -9,6 +9,7 @@ if( !empty($_SERVER['PHP_AUTH_USER']) ) {
 	// Redirect user where he came from, if unknown go to dashboard.
 	if( isset($_COOKIE['phpipamredirect']) )    { header("Location: ".$_COOKIE['phpipamredirect']); }
 	else                                        { header("Location: ".create_link("dashboard")); }
+	exit();
 }
 ?>
 


### PR DESCRIPTION
Without this exit() call you will enter an infinite redirection loop (when using HTTP auth) between /dashboard and /login because you will login, but later in the same code your session will be destroyed.

This must have been introduced by either one of those 2 commits: 

https://github.com/phpipam/phpipam/commit/b87311e3ef1a6a788c66495c17cb3ce6c113bd60#diff-c00c1dae75bb383a248354a92a7ee0b5
https://github.com/phpipam/phpipam/commit/7866a30fbaecd59e7d2c3f06cd3716567d76db7b#diff-c00c1dae75bb383a248354a92a7ee0b5
