### PR TITLE
fix draw_rack when adding new device and deviceId is empty

### DIFF
--- a/app/tools/racks/draw_rack.php
+++ b/app/tools/racks/draw_rack.php
@@ -18,8 +18,8 @@ $User->check_user_session();
 # init racks object
 $Racks = new phpipam_rack ($Database);
 
-# deviceId not set - set to 0
-if (!isset($_GET['deviceId']))      { $_GET['deviceId'] = 0; }
+# deviceId not set or empty - set to 0
+if (!isset($_GET['deviceId']) || empty($_GET['deviceId']))     { $_GET['deviceId'] = 0; }
 
 # validate rackId
 if (!is_numeric($_GET['rackId']))     { die(); }


### PR DESCRIPTION
this causes a broken image in the new device dialog when selecting a rack and display it without the check for empty value:
app/tools/racks/draw_rack.php?rackId=2&deviceId=
