### PR TITLE
Fix adduser

### DIFF
--- a/app/admin/users/edit-result.php
+++ b/app/admin/users/edit-result.php
@@ -36,7 +36,7 @@ if($_POST['action']=="edit"||$_POST['action']=="delete") {
 }
 
 # if password changes check and hash passwords
-if(strlen(@$_POST['password1'])>0 || (@$_POST['action']=="add" && $auth_method->type=="local")) {
+if((strlen(@$_POST['password1'])>0 || (@$_POST['action']=="add") && $auth_method->type=="local")) {
 	//checks
 	if($_POST['password1']!=$_POST['password2'])						{ $Result->show("danger", _("Passwords do not match"), true); }
 	if(strlen($_POST['password1'])<8)									{ $Result->show("danger", _("Password must be at least 8 characters long!"), true); }

--- a/app/admin/users/edit-result.php
+++ b/app/admin/users/edit-result.php
@@ -36,6 +36,7 @@ if($_POST['action']=="edit"||$_POST['action']=="delete") {
 }
 
 # if password changes check and hash passwords
+if($auth_method->type != "local") { $_POST['password1'] = ""; $_POST['password2'] = ""; }
 if((strlen(@$_POST['password1'])>0 || (@$_POST['action']=="add") && $auth_method->type=="local")) {
 	//checks
 	if($_POST['password1']!=$_POST['password2'])						{ $Result->show("danger", _("Passwords do not match"), true); }


### PR DESCRIPTION
If you add a aduser and password-field is auto-filled, message "Passwords not matched" appears.

set password-fields to empty string if authmethod != local
