### PR TITLE
Seems like a bug in the print-address-table.php

### DIFF
--- a/app/subnets/addresses/print-address-table.php
+++ b/app/subnets/addresses/print-address-table.php
@@ -236,7 +236,7 @@ else {
 				    if($addresses[$n]->excludePing=="1" ) { $hStatus = "padded"; $hTooltip = ""; }
 				    elseif($tDiff < $statuses[0])	{ $hStatus = "success";	$hTooltip = "rel='tooltip' data-container='body' data-html='true' data-placement='left' title='"._("Device is alive")."<hr>"._("Last seen").": ".$addresses[$n]->lastSeen."'"; }
 				    elseif($tDiff < $statuses[1])	{ $hStatus = "warning"; $hTooltip = "rel='tooltip' data-container='body' data-html='true' data-placement='left' title='"._("Device warning")."<hr>"._("Last seen").": ".$addresses[$n]->lastSeen."'"; }
-				    elseif($tDiff < 2592000)		{ $hStatus = "error"; 	$hTooltip = "rel='tooltip' data-container='body' data-html='true' data-placement='left' title='"._("Device is offline")."<hr>"._("Last seen").": ".$addresses[$n]->lastSeen."'";}
+				    elseif($tDiff > $statuses[1])	{ $hStatus = "error"; 	$hTooltip = "rel='tooltip' data-container='body' data-html='true' data-placement='left' title='"._("Device is offline")."<hr>"._("Last seen").": ".$addresses[$n]->lastSeen."'";}
 				    elseif($addresses[$n]->lastSeen == "0000-00-00 00:00:00") { $hStatus = "neutral"; 	$hTooltip = "rel='tooltip' data-container='body' data-html='true' data-placement='left' title='"._("Device is offline")."<hr>"._("Last seen").": "._("Never")."'";}
 				    else							{ $hStatus = "neutral"; $hTooltip = "rel='tooltip' data-container='body' data-html='true' data-placement='left' title='"._("Device status unknown")."'";}
 			    }


### PR DESCRIPTION
Seems like a bug in a new version. Hosts, which is offline more than one month, have "unknown" status, instead of "offline".

By the way, address-details.php is ok at this part.

**print-address-table.php:**
![print-address-table php](https://cloud.githubusercontent.com/assets/5318028/15466116/ae0726ea-20e0-11e6-8f8d-6d651f942f3a.png)

**address-details.php:**
![address-details php](https://cloud.githubusercontent.com/assets/5318028/15466118/ae20de64-20e0-11e6-96cd-b9617242cbf1.png)
