### PR TITLE
fix LDAP user lookups for non-NetIQ types

### DIFF
--- a/functions/adLDAP/src/classes/adLDAPUsers.php
+++ b/functions/adLDAP/src/classes/adLDAPUsers.php
@@ -213,7 +213,7 @@ class adLDAPUsers {
     * @param bool $isGUID Is the username passed a GUID or a samAccountName
     * @return array
     */
-    public function info($username, $fields = NULL, $isGUID = false)
+    public function info($username, $fields = NULL, $isGUID = false, $type = NULL)
     {
         if ($username === NULL) { return false; }
         if (!$this->adldap->getLdapBind()) { return false; }
@@ -226,9 +226,15 @@ class adLDAPUsers {
              $filter = "userPrincipalName=" . $username;
         }
         else {
-             $filter = ($type == "NetIQ")? "cn=" . $username:"samaccountname=" . $username;
+             if ($type == "NetIQ") {
+                $filter = "cn=" . $username;
+             } elseif ($type == "LDAP") {
+                $filter = "uid=" . $username;
+             } else {
+                $filter = "samaccountname=" . $username;
+             }
         }
-        $filter = ($type == "NetIQ")? "(&(objectClass=person)({$filter}))":"(&(objectCategory=person)({$filter}))";
+        $filter = ($type == "NetIQ" or $type == "LDAP") ? "(&(objectClass=person)({$filter}))":"(&(objectCategory=person)({$filter}))";
         if ($fields === NULL) { 
             $fields = array("samaccountname","mail","memberof","department","displayname","telephonenumber","primarygroupid","objectsid"); 
         }


### PR DESCRIPTION
two issues to address:
- the $type variable was not valid for the info() function
- the fallbacks were AD specific

so an authentication method of type "LDAP" would result in a
filter of something like:
(&(objectCategory=person)(samaccountname=parsonsa*))

when it should be like this for OpenLDAP or FreeIPA (389):
(&(objectClass=person)(uid=parsonsa*))

I've tested against FreeIPA, which is my use case.  this should
not alter the behavior for AD, which is likely the most common
use case.
