### PR TITLE
Fixed bug #451: The field Software-Version is not stored in the database

### DIFF
--- a/app/admin/devices/edit-result.php
+++ b/app/admin/devices/edit-result.php
@@ -83,7 +83,8 @@ $values = array("id"=>@$device['switchId'],
 				"ip_addr"=>@$device['ip_addr'],
 				"type"=>@$device['type'],
 				"description"=>@$device['description'],
-				"sections"=>@$device['sections']
+				"sections"=>@$device['sections'],
+				"sw_version"=>@$device['sw_version']
 				);
 # custom fields
 if(isset($update)) {

--- a/app/admin/devices/edit.php
+++ b/app/admin/devices/edit.php
@@ -148,7 +148,7 @@ $('#switchManagementEdit').change(function() {
 	<tr>
 		<td><?php print _('SW version'); ?></td>
 		<td>
-			<input type="text" name="version" class="form-control input-sm" placeholder="<?php print _('Software version'); ?>" value="<?php if(isset($device['version'])) print $device['version']; ?>" <?php print $readonly; ?>>
+			<input type="text" name="sw_version" class="form-control input-sm" placeholder="<?php print _('Software version'); ?>" value="<?php if(isset($device['sw_version'])) print $device['sw_version']; ?>" <?php print $readonly; ?>>
 		</td>
 	</tr>
 

--- a/db/SCHEMA.sql
+++ b/db/SCHEMA.sql
@@ -292,6 +292,7 @@ CREATE TABLE `devices` (
   `rack_start` int(11) unsigned DEFAULT null,
   `rack_size` int(11) unsigned DEFAULT null,
   `editDate` timestamp NULL DEFAULT NULL ON UPDATE CURRENT_TIMESTAMP,
+  `sw_version` VARCHAR(32) DEFAULT NULL
   PRIMARY KEY (`id`),
   KEY `hostname` (`hostname`)
 ) ENGINE=InnoDB AUTO_INCREMENT=3 DEFAULT CHARSET=utf8;


### PR DESCRIPTION
In the _Edit device_ screen is a field _SW Version_ which should hold the software-version of the device. Unfortunately, this field is never stored in the backend. This commit extend the database scheme and take care of the field when the backend is storing the device information. 

![edit_device_sw_version](https://cloud.githubusercontent.com/assets/16800907/16075892/08c81658-32f1-11e6-98d3-96c799fed81f.PNG)
