### PR TITLE
validate search term is IP address rather than MAC address

### DIFF
--- a/app/tools/search/search-results.php
+++ b/app/tools/search/search-results.php
@@ -23,7 +23,7 @@ $search_term = str_replace("*", "%", $search_term);
 
 
 // IP address low/high reformat
-if ($Tools->validate_mac ($search_term)===false) {
+if ($Tools->validate_ip($search_term)) {
     // identify
     $type = $Addresses->identify_address( $search_term ); //identify address type
 


### PR DESCRIPTION
This patch fixes a bug where searching for a 12 digit IP address (ie: 192.168.222.111) would not be found successfully. 

Shorter IP addresses (ie: 10.20.30.40) would not return true from validate_mac which wouldn't trigger the bug.
