### PR TITLE
Avoid showing unmonitored IP addresses in inactive hosts list

### DIFF
--- a/functions/classes/class.Subnets.php
+++ b/functions/classes/class.Subnets.php
@@ -2015,7 +2015,7 @@ class Subnets extends Common_functions {
     	// fetch settings
     	$this->settings ();
     	// search
-  		try { $res = $this->Database->getObjectsQuery("select * from `ipaddresses` where `lastSeen` between ? and ? limit $limit;", array(date("Y-m-d H:i:s", strtotime(date("Y-m-d H:i:s"))-$timelimit), date("Y-m-d H:i:s", strtotime(date("Y-m-d H:i:s"))-(int) str_replace(";","",strstr($this->settings->pingStatus, ";")))) ); }
+  		try { $res = $this->Database->getObjectsQuery("select ipaddresses.* from `ipaddresses` join subnets on ipaddresses.subnetId = subnets.id where subnets.pingSubnet = 1 and `lastSeen` between ? and ? limit $limit;", array(date("Y-m-d H:i:s", strtotime(date("Y-m-d H:i:s"))-$timelimit), date("Y-m-d H:i:s", strtotime(date("Y-m-d H:i:s"))-(int) str_replace(";","",strstr($this->settings->pingStatus, ";")))) ); }
 		catch (Exception $e) {
 			$this->Result->show("danger", _("Error: ").$e->getMessage());
 			return false;


### PR DESCRIPTION
After disabling subnet ping checks, it's hosts became visible in "inactive-hosts" widget, because they have old value in "lastSeen" field. To avoid this, I've added condition subnets.pingSubnet = 1 in mysql query in Subnets => find_inactive_hosts()
