### PR TITLE
Correct typo

### DIFF
--- a/app/tools/pstn-prefixes/edit-result.php
+++ b/app/tools/pstn-prefixes/edit-result.php
@@ -72,7 +72,7 @@ if($_POST['action']=="add" && $_POST['master']==0) {
     if($all_prefixes!==false) {
         foreach ($all_prefixes as $master_prefix) {
 
-            $overlap_text = _("Prefix overlapps with prefix ".$master_prefix->name." (".$master_prefix->prefix.")");
+            $overlap_text = _("Prefix overlaps with prefix ".$master_prefix->name." (".$master_prefix->prefix.")");
 
             // ranges
             $master_prefix->prefix_raw = $Tools->prefix_normalize ($master_prefix->prefix);

--- a/functions/classes/class.Subnets.php
+++ b/functions/classes/class.Subnets.php
@@ -1424,7 +1424,7 @@ class Subnets extends Common_functions {
 	}
 
 	/**
-	 * Verifies if new subnet overlapps with any of existing subnets in that section and same or null VRF
+	 * Verifies if new subnet overlaps with any of existing subnets in that section and same or null VRF
 	 *
 	 * @access public
 	 * @param int $sectionId
@@ -1446,7 +1446,7 @@ class Subnets extends Common_functions {
 		            if($existing_subnet->isFolder!=1) {
 			            # check overlapping
 						if($this->verify_overlapping ($new_subnet,  $this->transform_to_dotted($existing_subnet->subnet).'/'.$existing_subnet->mask)!==false) {
-							 return _("Subnet $new_subnet overlapps with").' '. $this->transform_to_dotted($existing_subnet->subnet).'/'.$existing_subnet->mask." (".$existing_subnet->description.")";
+							 return _("Subnet $new_subnet overlaps with").' '. $this->transform_to_dotted($existing_subnet->subnet).'/'.$existing_subnet->mask." (".$existing_subnet->description.")";
 						}
 
 					}
@@ -1458,7 +1458,7 @@ class Subnets extends Common_functions {
 	}
 
 	/**
-	 * Verifies if resized subnet overlapps with any of existing subnets in that section and same or null VRF
+	 * Verifies if resized subnet overlaps with any of existing subnets in that section and same or null VRF
 	 *
 	 * @access public
 	 * @param int $sectionId
@@ -1483,7 +1483,7 @@ class Subnets extends Common_functions {
 			            if($existing_subnet->isFolder!=1) {
 				            # check overlapping
 				            if($this->verify_overlapping ($new_subnet,  $this->transform_to_dotted($existing_subnet->subnet).'/'.$existing_subnet->mask)!==false) {
-								 return _("Subnet $new_subnet overlapps with").' '. $this->transform_to_dotted($existing_subnet->subnet).'/'.$existing_subnet->mask." (".$existing_subnet->description.")";
+								 return _("Subnet $new_subnet overlaps with").' '. $this->transform_to_dotted($existing_subnet->subnet).'/'.$existing_subnet->mask." (".$existing_subnet->description.")";
 				            }
 						}
 		            }
@@ -1523,7 +1523,7 @@ class Subnets extends Common_functions {
     			if($ss->isFolder!=1) {
         			if($ss->vrfId==$vrfId || $ss->vrfId==null) {
         				if($this->verify_overlapping ( $new_subnet, $this->transform_to_dotted($ss->subnet)."/".$ss->mask)) {
-        					return _("Subnet overlapps with")." ".$this->transform_to_dotted($ss->subnet).'/'.$ss->mask;
+        					return _("Subnet overlaps with")." ".$this->transform_to_dotted($ss->subnet).'/'.$ss->mask;
         				}
         			}
 
@@ -1690,7 +1690,7 @@ class Subnets extends Common_functions {
 								// not self
 								if ($ss->id != $subnetId) {
 									if($this->verify_overlapping ( $this->transform_to_dotted($subnet)."/".$mask, $this->transform_to_dotted($ss->subnet)."/".$ss->mask)) {
-										$this->Result->show("danger", _("Subnet overlapps with")." ".$this->transform_to_dotted($ss->subnet)."/".$ss->mask, true);
+										$this->Result->show("danger", _("Subnet overlaps with")." ".$this->transform_to_dotted($ss->subnet)."/".$ss->mask, true);
 									}
 								}
 							}
@@ -1707,7 +1707,7 @@ class Subnets extends Common_functions {
 								if($fs->id!=$subnetId) {
 									//verify that all nested are inside its parent
 									if($this->verify_overlapping ( $this->transform_to_dotted($subnet)."/".$mask, $this->transform_to_dotted($fs->subnet)."/".$fs->mask)) {
-										$this->Result->show("danger", _("Subnet overlapps with")." ".$this->transform_to_dotted($fs->subnet)."/".$fs->mask, true);
+										$this->Result->show("danger", _("Subnet overlaps with")." ".$this->transform_to_dotted($fs->subnet)."/".$fs->mask, true);
 									}
 								}
 							}
@@ -1862,7 +1862,7 @@ class Subnets extends Common_functions {
 				foreach($newsubnets as $new_subnet) {
 					$new_subnet = (object) $new_subnet;
 					if($this->verify_overlapping ($this->transform_to_dotted($new_subnet->subnet)."/".$new_subnet->mask, $this->transform_to_dotted($nested_subnet->subnet)."/".$nested_subnet->mask)===true) {
-						$this->Result->show("danger", _("Subnet overlapping - ").$this->transform_to_dotted($new_subnet->subnet)."/".$new_subnet->mask." overlapps with ".$this->transform_to_dotted($nested_subnet->subnet)."/".$nested_subnet->mask, true);
+						$this->Result->show("danger", _("Subnet overlapping - ").$this->transform_to_dotted($new_subnet->subnet)."/".$new_subnet->mask." overlaps with ".$this->transform_to_dotted($nested_subnet->subnet)."/".$nested_subnet->mask, true);
 					}
 				}
 			}

--- a/functions/locale/changes.txt
+++ b/functions/locale/changes.txt
@@ -2569,7 +2569,7 @@ msgstr ""
 msgid "Invalid Network!"
 msgstr ""
 
-msgid "Subnet $new_subnet overlapps with"
+msgid "Subnet $new_subnet overlaps with"
 msgstr ""
 
 msgid "Mask must be an integer"

--- a/functions/locale/cs_CZ.UTF8/LC_MESSAGES/phpipam.po
+++ b/functions/locale/cs_CZ.UTF8/LC_MESSAGES/phpipam.po
@@ -276,7 +276,7 @@ msgstr "Číslo vlan musí být max 4094"
 
 #: functions/functions-network.php:825 functions/functions-network.php:842
 #: functions/functions-network.php:904 functions/functions-network.php:930
-msgid "Subnet overlapps with"
+msgid "Subnet overlaps with"
 msgstr "Podsíť se překrývá s"
 
 #: functions/functions-network.php:1199

--- a/functions/locale/de_DE.UTF8/LC_MESSAGES/phpipam.po
+++ b/functions/locale/de_DE.UTF8/LC_MESSAGES/phpipam.po
@@ -287,7 +287,7 @@ msgstr "Die h&ouml;chste VLAN Nummer ist 4094"
 
 #: functions/functions-network.php:825 functions/functions-network.php:842
 #: functions/functions-network.php:904 functions/functions-network.php:930
-msgid "Subnet overlapps with"
+msgid "Subnet overlaps with"
 msgstr "Subnetz &uuml;berschneidet sich mit"
 
 #: functions/functions-network.php:1199
@@ -6300,7 +6300,7 @@ msgstr "IP Adresse verschieben fehlgeschlagen"
 msgid "Invalid Network!"
 msgstr "Ung&uuml;ltiges Netzwerk!"
 
-msgid "Subnet $new_subnet overlapps with"
+msgid "Subnet $new_subnet overlaps with"
 msgstr "Subnetz $new_subnet &uuml;berschneidet sich mit"
 
 msgid "Mask must be an integer"

--- a/functions/locale/en_GB.UTF-8/LC_MESSAGES/phpipam.po
+++ b/functions/locale/en_GB.UTF-8/LC_MESSAGES/phpipam.po
@@ -276,7 +276,7 @@ msgstr ""
 
 #: functions/functions-network.php:825 functions/functions-network.php:842
 #: functions/functions-network.php:904 functions/functions-network.php:930
-msgid "Subnet overlapps with"
+msgid "Subnet overlaps with"
 msgstr ""
 
 #: functions/functions-network.php:1199
@@ -6009,7 +6009,7 @@ msgstr ""
 msgid "Invalid Network!"
 msgstr ""
 
-msgid "Subnet $new_subnet overlapps with"
+msgid "Subnet $new_subnet overlaps with"
 msgstr ""
 
 msgid "Mask must be an integer"

--- a/functions/locale/en_US.UTF8/LC_MESSAGES/phpipam.po
+++ b/functions/locale/en_US.UTF8/LC_MESSAGES/phpipam.po
@@ -276,7 +276,7 @@ msgstr ""
 
 #: functions/functions-network.php:825 functions/functions-network.php:842
 #: functions/functions-network.php:904 functions/functions-network.php:930
-msgid "Subnet overlapps with"
+msgid "Subnet overlaps with"
 msgstr ""
 
 #: functions/functions-network.php:1199
@@ -6009,7 +6009,7 @@ msgstr ""
 msgid "Invalid Network!"
 msgstr ""
 
-msgid "Subnet $new_subnet overlapps with"
+msgid "Subnet $new_subnet overlaps with"
 msgstr ""
 
 msgid "Mask must be an integer"

--- a/functions/locale/es_ES.UTF8/LC_MESSAGES/phpipam.po
+++ b/functions/locale/es_ES.UTF8/LC_MESSAGES/phpipam.po
@@ -276,7 +276,7 @@ msgstr "El número de VLAN máximo es 4094"
 
 #: functions/functions-network.php:825 functions/functions-network.php:842
 #: functions/functions-network.php:904 functions/functions-network.php:930
-msgid "Subnet overlapps with"
+msgid "Subnet overlaps with"
 msgstr "La Subred solapa con"
 
 #: functions/functions-network.php:1199

--- a/functions/locale/fr_FR.UTF8/LC_MESSAGES/phpipam.po
+++ b/functions/locale/fr_FR.UTF8/LC_MESSAGES/phpipam.po
@@ -274,7 +274,7 @@ msgstr "Le numéro de VLAN ne peut excéder 4094"
 
 #: functions/functions-network.php:825 functions/functions-network.php:842
 #: functions/functions-network.php:904 functions/functions-network.php:930
-msgid "Subnet overlapps with"
+msgid "Subnet overlaps with"
 msgstr "Chevauchement de sous-réseau avec"
 
 #: functions/functions-network.php:1199
@@ -6244,7 +6244,7 @@ msgstr "Echec de déplacement d'adresse IP"
 msgid "Invalid Network!"
 msgstr "Réseau invalide !"
 
-msgid "Subnet $new_subnet overlapps with"
+msgid "Subnet $new_subnet overlaps with"
 msgstr "Le sous-réseau $new_subnet chevauche"
 
 msgid "Mask must be an integer"

--- a/functions/locale/nl_NL.UTF8/LC_MESSAGES/phpipam.po
+++ b/functions/locale/nl_NL.UTF8/LC_MESSAGES/phpipam.po
@@ -284,7 +284,7 @@ msgstr "Het VLAN-nummer kan maximaal 4094 zijn"
 
 #: functions/functions-network.php:825 functions/functions-network.php:842
 #: functions/functions-network.php:904 functions/functions-network.php:930
-msgid "Subnet overlapps with"
+msgid "Subnet overlaps with"
 msgstr "Subnet overlapt met"
 
 #: functions/functions-network.php:1199
@@ -6103,7 +6103,7 @@ msgstr "Fout bij het verplaatsen van IP-adres"
 msgid "Invalid Network!"
 msgstr "Ongeldig netwerk!"
 
-msgid "Subnet $new_subnet overlapps with"
+msgid "Subnet $new_subnet overlaps with"
 msgstr "Subnet $new_subnet overlapt met"
 
 msgid "Mask must be an integer"

--- a/functions/locale/pt_BR.UTF8/LC_MESSAGES/phpipam.po
+++ b/functions/locale/pt_BR.UTF8/LC_MESSAGES/phpipam.po
@@ -276,7 +276,7 @@ msgstr "N&uacute;mero de VLANs deve ser de no m&aacute;ximo 4094"
 
 #: functions/functions-network.php:825 functions/functions-network.php:842
 #: functions/functions-network.php:904 functions/functions-network.php:930
-msgid "Subnet overlapps with"
+msgid "Subnet overlaps with"
 msgstr "Sub-rede se sobrep&otilde;e a"
 
 #: functions/functions-network.php:1199

--- a/functions/locale/sl_SI.UTF8/LC_MESSAGES/phpipam.po
+++ b/functions/locale/sl_SI.UTF8/LC_MESSAGES/phpipam.po
@@ -276,7 +276,7 @@ msgstr "Najvišja vrednost VLANa je lahko 4094"
 
 #: functions/functions-network.php:825 functions/functions-network.php:842
 #: functions/functions-network.php:904 functions/functions-network.php:930
-msgid "Subnet overlapps with"
+msgid "Subnet overlaps with"
 msgstr "Omrežje se prekriva z"
 
 #: functions/functions-network.php:1199


### PR DESCRIPTION
"Overlaps" was typo'd as "overlapps."  Changes all instances in the code from one of the other.
