### PR TITLE
Same font-family for class hero-unit

### DIFF
--- a/css/1.2/bootstrap/bootstrap-custom.css
+++ b/css/1.2/bootstrap/bootstrap-custom.css
@@ -531,7 +531,7 @@ td.info2 {
 }
 .hero-unit,
 .hero-unit a {
-	font-family: Georgia,Times,'Times New Roman',serif;
+	font-family: "Source Sans Pro", "Source Sans Pro", Arial, sans-serif;
 	font-size: 36px;
 
 	color: white;


### PR DESCRIPTION
In my opinion it would be better to have the font-family "Source Sans Pro" for the class hero-unit too. It looks nicer and the look and feel is the same for the whole site.
![2016-09-30 08_32_09-ip address management dashboard](https://cloud.githubusercontent.com/assets/1539498/18982703/6de04c54-86e8-11e6-88a5-b4c514c7bee5.png)
