### PR TITLE
Fixed #779 wording on widget button

### DIFF
--- a/app/dashboard/widget-popup.php
+++ b/app/dashboard/widget-popup.php
@@ -52,5 +52,5 @@ $widgets = (array) $widgets;
 
 <!-- footer -->
 <div class="pFooter">
-	<button class="btn btn-sm btn-default hidePopups"><?php print _('Cancel'); ?></button>
+	<button class="btn btn-sm btn-default hidePopups"><?php print _('Close'); ?></button>
 </div>


### PR DESCRIPTION
This fixes the wording of the cancel button and changes it to close on the add widget popup.
