### PR TITLE
Subnet Import - PHP Strict Standards Fix

### DIFF
--- a/app/admin/import-export/import-verify.php
+++ b/app/admin/import-export/import-verify.php
@@ -17,7 +17,8 @@ $User->check_user_session();
 /* get extension */
 $filename = $_FILES['file']['name'];
 $expfields = explode("|",$_POST['expfields']);
-$filetype = strtolower(end(explode(".", $filename)));
+$file_exp = explode(".", $filename);
+$filetype = strtolower(end($file_exp));
 
 /* list of permitted file extensions */
 $allowed = array('xls','csv');
@@ -87,3 +88,4 @@ if(isset($_FILES['file']) && $_FILES['file']['error'] == 0) {
 echo '{"status":"error","error":"Empty file"}';
 exit;
 ?>
+


### PR DESCRIPTION
When trying to import subnets, after selecting the file for upload, the verify fails with the following error:

`[10-Oct-2016 14:07:11] PHP Strict Standards:  Only variables should be passed by reference in phpipam/app/admin/import-export/import-verify.php on line 20`

This PR corrects the explode for the filename to properly meet the PHP Strict Standards.
