### PR TITLE
Add Alpine Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,7 @@ RUN ln -s /phpipam/apache.conf /etc/apache2/conf.d/apache.conf \
 # Hack so apache can run /bin/ping this seems
 # to be an issue with alpine linux will file
 # bug upstream for fix.
+# https://github.com/gliderlabs/docker-alpine/issues/253
 RUN chmod u+s /bin/ping
 
 EXPOSE 80 443

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,5 +25,10 @@ RUN ln -s /phpipam/apache.conf /etc/apache2/conf.d/apache.conf \
   && mkdir -p /run/apache2 \
   && sed -i 's/#LoadModule rewrite_module modules\/mod_rewrite.so/LoadModule rewrite_module modules\/mod_rewrite.so/' /etc/apache2/httpd.conf
 
+# Hack so apache can run /bin/ping this seems
+# to be an issue with alpine linux will file
+# bug upstream for fix.
+RUN chmod u+s /bin/ping
+
 EXPOSE 80 443
 CMD /usr/sbin/httpd -DFOREGROUND

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN apk add --no-cache php \
   php-openssl php-gmp php-ldap \
   php-gettext php-pcntl php-cli \
   php-pdo_mysql php-mcrypt php-pear \
-  php-xml apache2 php-apache2
+  php-ctype php-xml apache2 php-apache2
 
 ADD . .
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,29 @@
+FROM alpine:3.3
+
+WORKDIR /phpipam
+
+RUN apk add --no-cache php \
+  php-pdo php-json php-sockets \
+  php-openssl php-gmp php-ldap \
+  php-gettext php-pcntl php-cli \
+  php-pdo_mysql php-mcrypt php-pear \
+  php-xml apache2 php-apache2
+
+ADD . .
+
+ENV IPAM_HOST "localhost"
+ENV IPAM_USER "phpipam"
+ENV IPAM_PASS "phpipamadmin"
+ENV IPAM_NAME "phpipam"
+ENV IPAM_PORT 3306
+
+# Setup apache and logging for it
+RUN ln -s /phpipam/apache.conf /etc/apache2/conf.d/apache.conf \
+  && ln -s /phpipam/config.dist.php /phpipam/config.php \
+  && ln -sf /dev/stdout /var/log/apache2/access.log \
+  && ln -sf /dev/stderr /var/log/apache2/error.log \
+  && mkdir -p /run/apache2 \
+  && sed -i 's/#LoadModule rewrite_module modules\/mod_rewrite.so/LoadModule rewrite_module modules\/mod_rewrite.so/' /etc/apache2/httpd.conf
+
+EXPOSE 80 443
+CMD /usr/sbin/httpd -DFOREGROUND

--- a/INSTALL.txt
+++ b/INSTALL.txt
@@ -4,3 +4,14 @@
 please follow this instructions:
 
 http://phpipam.net/documents/installation/
+
+## Docker
+
+If you would like to run PHPIPAM inside of docker you must fist setup a mysql database. After you
+have finished setting one up you can run the following two commands to build your docker image and
+then pass it the following variabled according to your setup.
+
+```
+$ docker build -t phpipam .
+$ docker run -p 8888:80 -e IPAM_HOST='192.168.1.5' -e IPAM_PASS='password' -e IPAM_USER='root' phpipam
+```

--- a/INSTALL.txt
+++ b/INSTALL.txt
@@ -15,3 +15,17 @@ then pass it the following variabled according to your setup.
 $ docker build -t phpipam .
 $ docker run -p 8888:80 -e IPAM_HOST='192.168.1.5' -e IPAM_PASS='password' -e IPAM_USER='root' phpipam
 ```
+
+If you are running your DB inside of docker you will need to log in and run the following command since
+access is only setup for localhost via the install script.
+
+```
+GRANT ALL on `database`.* to user@'%' identified by 'password';
+```
+
+For whatever reason the password also is never set properly so running the following script should fix
+everything up for you.
+
+```
+php functions/scripts/reset-admin-password.php
+```

--- a/apache.conf
+++ b/apache.conf
@@ -1,0 +1,7 @@
+<VirtualHost *:80>
+  DocumentRoot /phpipam
+  <Directory "/phpipam">
+    AllowOverride All
+    Require all granted
+  </Directory>
+</VirtualHost>

--- a/config.dist.php
+++ b/config.dist.php
@@ -2,11 +2,11 @@
 
 /* database connection details
  ******************************/
-$db['host'] = "localhost";
-$db['user'] = "phpipam";
-$db['pass'] = "phpipamadmin";
-$db['name'] = "phpipam";
-$db['port'] = 3306;
+$db['host'] = getenv('IPAM_HOST') ? getenv('IPAM_HOST') : "localhost";
+$db['user'] = getenv('IPAM_USER') ? getenv('IPAM_USER') : "phpipam";
+$db['pass'] = getenv('IPAM_PASS') ? getenv('IPAM_PASS') : "phpipamadmin";
+$db['name'] = getenv('IPAM_NAME') ? getenv('IPAM_NAME') : "phpipam";
+$db['port'] = getenv('IPAM_PORT') ? getenv('IPAM_PORT') : 3306;
 
 /* SSL options for MySQL
  ******************************


### PR DESCRIPTION
This adds a docker file that can be used to make deploying the application
easier. It does not focus on trying to be an all in one solution as you
still need to setup mysql. The full image is only 55.5MB and makes a small
change to the config file that lets you use environment variables to set
config values all name spaced with IPAM_* for safety.

- [x] add documentation for image
- [x] test out functionality more to ensure everything is in working order