### PR TITLE
Detect HTTPS on non-standard ports

### DIFF
--- a/functions/classes/class.Common.php
+++ b/functions/classes/class.Common.php
@@ -763,7 +763,9 @@ class Common_functions  {
 	 */
 	public function createURL () {
 		# reset url for base
-		if($_SERVER['SERVER_PORT'] == "443") 		{ $url = "https://$_SERVER[HTTP_HOST]"; }
+		 if (($_SERVER['HTTPS'] == 'on') || ($_SERVER['SERVER_PORT'] == 443)) {
+			 $url = "https://$_SERVER[HTTP_HOST]";
+		 }
 		// reverse proxy doing SSL offloading
         elseif(isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] == 'https')  { $url = "https://$_SERVER[HTTP_X_FORWARDED_HOST]"; }
 		elseif(isset($_SERVER['HTTP_X_SECURE_REQUEST'])  && $_SERVER['HTTP_X_SECURE_REQUEST'] == 'true') 	{ $url = "https://$_SERVER[SERVER_NAME]"; }


### PR DESCRIPTION
Currently, when running PHPIPAM over SSL on a port other than 443, SSL is not detected properly and the base URL is set to use HTTP. This causes all CSS and javascript to fail loading.

This patch resolves the issue by checking the $_SERVER variable for the SSL status, as well as the port number.