### PR TITLE
Add a EOF to the the "No subnets..." message

### DIFF
--- a/functions/scripts/pingCheck.php
+++ b/functions/scripts/pingCheck.php
@@ -80,7 +80,7 @@ if(!file_exists($Scan->settings->scanFPingPath)){ die("Invalid fping path!"); }
 //first fetch all subnets to be scanned
 $scan_subnets = $Subnets->fetch_all_subnets_for_pingCheck (1);
 if($Scan->debugging)							{ print_r($scan_subnets); }
-if($scan_subnets===false) 						{ die("No subnets are marked for checking status updates"); }
+if($scan_subnets===false) 						{ die("No subnets are marked for checking status updates\n"); }
 //fetch all addresses that need to be checked
 foreach($scan_subnets as $s) {
 


### PR DESCRIPTION
This is useful when you append the standard output to a log file so it doesn't mess up the lines.
The output will be coherent with the discoveryCheck.php script
https://github.com/phpipam/phpipam/blob/master/functions/scripts/discoveryCheck.php#L101