### PR TITLE
remove warning missing json (upgrade case)

### DIFF
--- a/functions/classes/class.User.php
+++ b/functions/classes/class.User.php
@@ -1571,7 +1571,7 @@ class User extends Common_functions {
      */
     public function get_user_permissions_from_json ($json) {
         $groups = array();
-        foreach(json_decode($json, true) as $group_id => $perm) {
+        foreach((array) json_decode($json, true) as $group_id => $perm) {
             $group_details = $this->groups_parse (array($group_id));
 
             $tmp = array();


### PR DESCRIPTION
Hi,

When I try to upgrade from an older version (like 1.21) it's seems user permission can be null, this impact a null value after json_decode on class.User.php.

The foreach is done without type checking so this impact warning (display or in log) with one foreach error.

My PR propose a simple fix for cast json_decode to array, another more elegant method will be to understand why this is null and fix it before send it to this function.

Best