### PR TITLE
Add a "Hide unchanged subnets" option to the Subnets Import/Export re…

### DIFF
--- a/app/admin/import-export/import-recompute-logic.php
+++ b/app/admin/import-export/import-recompute-logic.php
@@ -133,6 +133,8 @@ foreach ($rlist as $sect_id => $sect_check) {
 		$c_subnet['action'] = ($c_subnet['masterSubnetId'] == $c_subnet['new_masterSubnetId'] ? "skip" : "edit");
 		$c_subnet['msg'] = ($c_subnet['masterSubnetId'] == $c_subnet['new_masterSubnetId'] ? _("No change, skip") : _("New master, update"));
 
+		if ( $_GET['recomputeHideUnchanged'] == "on" && $c_subnet['masterSubnetId'] == $c_master_id ) { continue; }
+
 		$rows.="<tr class='".$colors[$c_subnet['action']]."'><td><i class='fa ".$icons[$c_subnet['action']]."' rel='tooltip' data-placement='bottom' title='"._($c_subnet['msg'])."'></i></td>";
 		$rows.="<td>".$sect_names[$sect_id]."</td><td>".$c_subnet['ip']."/".$c_subnet['mask']."</td>";
 		$rows.="<td>".$c_subnet['description']."</td><td>".$vrf_name[$c_subnet['vrfId']]."</td><td>";

--- a/app/admin/import-export/import-recompute-select.php
+++ b/app/admin/import-export/import-recompute-select.php
@@ -94,6 +94,7 @@ print "<tr>	<th><input type='checkbox' id='recomputeSectionSelectAll' checked> "
 			<th><input type='checkbox' id='recomputeCVRFSelectAll' checked> Cross VRF</th></tr>";
 print $section_rows;
 print "</tbody></table>";
+print "<input type='checkbox' name='recomputeHideUnchanged' checked>" . _('Hide unchanged subnets');
 print "</form>";
 ?>
 </div>


### PR DESCRIPTION
…compute form.

Previewing the impact of running a recompute is difficult on installations with
5000+ subnets requiring multiple PgDn presses to locate a few changed items
within thousands of unchanged lines. Add an option to preview only changed items.