### PR TITLE
Improve changelog widget performance

### DIFF
--- a/functions/classes/class.Log.php
+++ b/functions/classes/class.Log.php
@@ -1506,28 +1506,31 @@ class Logging extends Common_functions {
     	# begin query
 			$query = "
 					select * from (
-					select `cid`, `coid`,`ctype`,`real_name`,`caction`,`cresult`,`cdate`,`cdiff`,`ip_addr`,'mask',`sectionId`,`subnetId`,`ipaddresses`.`id` as `tid`,`users`.`id` as `userid`,`subnets`.`isFolder` as `isFolder`,`subnets`.`description` as `sDescription`
+					(select `cid`, `coid`,`ctype`,`real_name`,`caction`,`cresult`,`cdate`,`cdiff`,`ip_addr`,'mask',`sectionId`,`subnetId`,`ipaddresses`.`id` as `tid`,`users`.`id` as `userid`,`subnets`.`isFolder` as `isFolder`,`subnets`.`description` as `sDescription`
 					FROM `changelog`
 					LEFT JOIN `users` ON `users`.`id`=`changelog`.`cuser`
 					LEFT JOIN `ipaddresses` ON `changelog`.`coid`=`ipaddresses`.`id`
 					LEFT JOIN `subnets` ON `subnets`.`id`=`ipaddresses`.`subnetId`
 					where `changelog`.`ctype` = 'ip_addr'
+					order by `cid` desc limit $limit)
 
 					union all
 
-					select `cid`, `coid`,`ctype`,`real_name`,`caction`,`cresult`,`cdate`,`cdiff`,`subnet`,`mask`,`sectionId`,'subnetId',`subnets`.`id` as `tid`,`users`.`id` as `userid`,`subnets`.`isFolder` as `isFolder`,`subnets`.`description` as `sDescription`
+					(select `cid`, `coid`,`ctype`,`real_name`,`caction`,`cresult`,`cdate`,`cdiff`,`subnet`,`mask`,`sectionId`,'subnetId',`subnets`.`id` as `tid`,`users`.`id` as `userid`,`subnets`.`isFolder` as `isFolder`,`subnets`.`description` as `sDescription`
 					FROM `changelog`
 					LEFT JOIN `users` ON `users`.`id`=`changelog`.`cuser`
 					LEFT JOIN `subnets` ON `subnets`.`id`=`changelog`.`coid`
 					where `changelog`.`ctype` = 'subnet'
+					order by `cid` desc limit $limit)
 
 					union all
 
-					select `cid`, `coid`,`ctype`,`real_name`,`caction`,`cresult`,`cdate`,`cdiff`,`name` ,'empty','empty','empty',`sections`.`id` as `tid`,`users`.`id` as `userid`,'empty',`sections`.`description` as `sDescription`
+					(select `cid`, `coid`,`ctype`,`real_name`,`caction`,`cresult`,`cdate`,`cdiff`,`name` ,'empty','empty','empty',`sections`.`id` as `tid`,`users`.`id` as `userid`,'empty',`sections`.`description` as `sDescription`
 					FROM `changelog`
 					LEFT JOIN `users` ON `users`.`id`=`changelog`.`cuser`
 					LEFT JOIN `sections` ON `sections`.`id`=`changelog`.`coid`
 					where `changelog`.`ctype` = 'section'
+					order by `cid` desc limit $limit)
 
 					) as `ips`";
 


### PR DESCRIPTION
Improve Logging::fetch_all_changelogs SQL and changelog widget load performance (3.5 to 0.20s).

Can you also index changelog.ctype when you next bump the SCHEMA version? This further improves the Logging::fetch_all_changelogs SQL query performance (0.20 to 0.01s).

ALTER TABLE `changelog` ADD INDEX(`ctype`);


[MySQL 5.1, RedHat x64]

-----------------------------------------------------

The changelog widget is taking 3.15s to render and calls
Logging::fetch_all_changelogs to display the last 5 change entries.

Running EXPLAIN on the captured Logging::fetch_all_changelogs SQL shows a full
table scan on the combined UNION ALL results (All 121,315 rows).

Limiting the UNION ALL data sets by applying the ORDER BY and LIMIT clauses to
the sub-queries improves the query performance to 0.20s.

Indexing changelog.ctype further improves query performance to 0.01s.