### PR TITLE
Improve changelog widget performance

### DIFF
--- a/functions/classes/class.Log.php
+++ b/functions/classes/class.Log.php
@@ -1545,15 +1545,7 @@ class Logging extends Common_functions {
 					$subquery_filter2
 					order by `cid` desc limit $limit)
 
-					) as `ips`";
-
-	    # append filtered query query
-		if($filter) {
-			$query .= " where `coid`=:expr or `ctype`=:expr or `real_name` like :expr or `cdate` like :expr or `cdiff` like :expr or INET_NTOA(`ip_addr`) like :expr ";
-		}
-
-		# append limit
-		$query .= " order by `cid` desc limit $limit;";
+					) as `ips` order by `cid` desc limit $limit;";
 
 	    # fetch
 	    try { $logs = $this->Database->getObjectsQuery($query, array("expr"=>$expr)); }


### PR DESCRIPTION
Improve the Logging::fetch_all_changelogs SQL query. 
v2 with fixed results with filtering.

Can you also add an index to changelog.ctype when you next bump the schema revision?

ALTER TABLE `changelog` ADD INDEX(`ctype`);

Thanks
-------------------------------------------------------------------------------------
The changelog widget is taking 3.15s to render and calls
Logging::fetch_all_changelogs to display the last 5 change entries.

Logging::fetch_all_changelogs performs the SQL query:

	SELECT FROM changelog <LEFT LOIN STUFF> WHERE where ctype = 'ip_addr'
	UNION ALL
	SELECT FROM changelog <LEFT LOIN STUFF> WHERE where ctype = 'subnet'
	UNION ALL
	SELECT FROM changelog <LEFT LOIN STUFF> WHERE where ctype = 'section'

As ctype=set('ip_addr','subnet','section') the UNION ALL result is the entire
table (All 121,315 rows and growing...). We then order by `cid` desc limit $limit
on the entire table array to get the required most recent $limit rows.

Limiting the UNION ALL data sets by also applying the search filters, ORDER BY
and LIMIT clauses to the sub-queries improves the query performance to 0.20s.

Indexing changelog.ctype further improves query performance to 0.01s.