### PR TITLE
Optimize app/admin/import-export/import-recompute-logic.php

### DIFF
--- a/app/admin/import-export/import-recompute-logic.php
+++ b/app/admin/import-export/import-recompute-logic.php
@@ -47,6 +47,16 @@ function my_ip2Bin($pi6,$ip)
 	return $binstr;
 }
 
+# Sort each edata subnet bucket by subnet lo->hi then by Id lo->hi.
+function fn_sort_cmp_subnets($a, $b)
+{
+	if ($a['subnet'] == $b['subnet']) {
+		if ($a['id'] == $b['id'] ) { return 0; }
+		return $a['id'] > $b['id'] ? 1 : -1;
+	}
+	return $a['subnet'] > $b['subnet'] ? 1 : -1;
+}
+
 # Read selected fields and pass them to the save form
 foreach($_GET as $key => $value) {
 	if (preg_match("/recomputeSection_(\d+)$/",$key,$matches) && ($value == "on")) {
@@ -80,14 +90,45 @@ $masks = array();
 for ($i = 0; $i <= 32; $i++) { $masks["IPv4"][$i] = 0xffffffff >> (32 - $i) << (32 - $i); }				# IPv4 masks, long
 for ($i = 0; $i <= 128; $i++) { $masks["IPv6"][$i] = str_repeat('1', $i).str_repeat('0', 128 - $i); }	# IPv6 masks, bin str
 
+$rows = ""; $counters = array(); $subnetbyid = array();
+
+/**
+ * Fetch the section subnets and save references into multi-dimentional array edata (subnet buckets)
+ * edata[subnet_section][subnet_type][subnet_mask] = &subnet
+ *
+ * Each bucket contains subnets with identical section, type and mask values.
+ * Each bucket is sorted by subnet address lo->hi, then by id lo->hi.
+ * [section 1 IPv4 /24's], [section 1 IPv4 /16's], [section 1 IPv4 /8's], [section 2 IPv6 /64's] ....
+ *
+ * When selecting a master subnet for a child we can minimise the search tree:
+ *  - Only search buckets belonging to the same section as the child.
+ *  - Only search buckets of the same type as the child (IPv4/IPv6).
+ *  - Only search buckets with a smaller mask than the child (Master > Child)
+ *
+ * We can further optimise the search:
+ *  - Find the most specific master candidates by decrementing search_mask to search the buckets with
+ *    the largest masks first (23,22,21...0). If we find one or more master candidates stop searching
+ *    as the remaining buckets contain less specific subnets.
+ *  - Each bucket is sorted by subnet lo->hi. If we encounter an subnet > than the child the remaining
+ *    items are guaranteed to also not match. Decrement the search_mask and skip to the next bucket.
+ *
+ * If cross-vrf searching is enabled or strict mode is disabled; multiple master candidates may exist.
+ * Select the master from the available candidates based on the selection rules below.
+ * First matching rule wins.
+ *  - Prefer master subnets in the same VRF as the child.
+ *  - Prefer the currently set master subnet.
+ *  - Prefer the master subnet with the lowest id value.
+ *
+ **/
+
+$rows = ""; $counters = array();
+
 # Read IPs for the sections we need to order
 foreach ($rlist as $sect_id => $sect_check) {
 	$section_subnets = $Subnets->fetch_section_subnets($sect_id);
 	# skip empty sections
 	if (sizeof($section_subnets)==0) { continue; }
 
-	$isFolder[$sect_id] = array();
-	
 	foreach ($section_subnets as &$subnet) {
 		$subnet = (array) $subnet;
 		$subnet['ip'] = $Subnets->transform_to_dotted($subnet['subnet']);
@@ -95,35 +136,70 @@ foreach ($rlist as $sect_id => $sect_check) {
 		# Precompute subnet in AND format (long for IPv4 and bin str for IPv6)
 		$subnet['andip'] = ($subnet['type'] == "IPv4") ? $subnet['subnet'] : my_ip2Bin($pi6,$subnet['ip']);
 		# Add to array
-		$edata[$sect_id][] = $subnet;
-		$isFolder[$sect_id][$subnet['id']] = $subnet['isFolder'];
+		$type = $subnet['type'];
+		$mask = $subnet['mask'];
+		$edata[$sect_id][$type][$mask][] = &$subnet;
+		$subnetbyid[$subnet['id']] = &$subnet;
 	}
-}
+	unset($subnet);
 
-$rows = ""; $counters = array();
+	# Sort edata subnet buckets
+	foreach($edata[$sect_id] as $e_type => $a) {
+		foreach($edata[$sect_id][$e_type] as $e_mask => $b) {
+			usort($edata[$sect_id][$e_type][$e_mask], "fn_sort_cmp_subnets");
+		}
+	}
 
-# Recompute master/nested relations for the selected sections and address families
-foreach ($rlist as $sect_id => $sect_check) {
-	# Skip empty sections
-	if (!$edata[$sect_id]) { continue; }
-
+	# Recompute master/nested relations for the selected sections and address families
 	# Grab a subnet and find its closest master
-	foreach ($edata[$sect_id] as &$c_subnet) {
+	foreach ($section_subnets as &$c_subnet) {
 		if (!$sect_check[$c_subnet['type']]) { continue; }	# Skip the IP version we don't want to reorder
 		if ($c_subnet['isFolder']) { continue; } # Skip folders
-		if ($isFolder[$sect_id][$c_subnet['masterSubnetId']]) { continue; } # Skip changing subne with folder masters
+		if ($subnetbyid[$c_subnet['masterSubnetId']]['isFolder']) { continue; } # Skip changing subnet with folder masters
 
-		$c_master_id = "0"; $c_master_ip = ""; $c_master_mask = "";
+		# Search subnets in the same section, of the same type and with smaller masks.
+		$m_candidate = array();
+		$search_mask = $c_subnet['mask'];
+		$search_type  = $c_subnet['type'];
 
-		# Check against all other subnets in section
-		foreach ($edata[$sect_id] as $m_subnet) {
-			if ($c_subnet['type'] != $m_subnet['type']) { continue; }	# Skip if current IP version doesn't match master IP version
-			if ((!$sect_check["CVRF"]) && ($c_subnet['vrfId'] != $m_subnet['vrfId'])) { continue; }	# Skip IPs from other VRFs if cross VRF reordering is not wanted (default is on)
-			# Main logic here - check if subnet within subnet
-			if ((($c_subnet['andip'] & $masks[$c_subnet['type']][$m_subnet['mask']]) == $m_subnet['andip']) && ($c_subnet['mask'] > $m_subnet['mask'])) {	# We have a match
-				if ($m_subnet['mask'] > $c_master_mask) {	# If new master is more specific than old master, record the data
-					$c_master_id = $m_subnet['id']; $c_master_mask = $m_subnet['mask']; $c_master_ip = $m_subnet['ip'];
-				}
+		while (--$search_mask >= 0) {
+			if (sizeof($edata[$sect_id][$search_type][$search_mask]) == 0) { continue; }
+			# We found candidates in the previous round.
+			if (sizeof($m_candidate) > 0) { break; }
+
+			foreach ($edata[$sect_id][$search_type][$search_mask] as $m_subnet) {
+				# buckets are sorted lo->hi. If current m_subnet is > c_subnet then remaining enries will be too.
+				if ($m_subnet['subnet'] > $c_subnet['subnet']) { break; }
+
+				# Skip subnets from other VRFs if cross VRF reordering is not wanted (default is on)
+				if ((!$sect_check["CVRF"]) && ($c_subnet['vrfId'] != $m_subnet['vrfId'])) { continue; }
+
+				# Main logic here - check if subnet within subnet
+				if (($c_subnet['andip'] & $masks[$c_subnet['type']][$m_subnet['mask']]) == $m_subnet['andip']) { $m_candidate[] = $m_subnet; }
+			}
+		}
+
+		$c_master_id = "0"; $c_master_ip = ""; $c_master_mask = ""; $search_child_vrf_only = 0;
+
+		# Choose from the availale master candidates
+		foreach($m_candidate as $m_subnet) {
+			# Candidate is in same VRF as child, select it and only consider candidates from this VRF from now on.
+			if ($m_subnet['vrfId'] == $c_subnet['vrfId']) {
+				$c_master_id = $m_subnet['id']; $c_master_mask = $m_subnet['mask']; $c_master_ip = $m_subnet['ip'];
+				$search_child_vrf_only = 1;
+			}
+
+			# Previous candidate found in child VRF. Ignore candidates from other VRFs
+			if ($search_child_vrf_only == 1 && $m_subnet['vrfId'] != $c_subnet['vrfId']) { continue; }
+
+			# Candidate is our existing master subnet, keep it
+			if ($m_subnet['id'] == $c_subnet['masterSubnetId']) {
+				$c_master_id = $m_subnet['id']; $c_master_mask = $m_subnet['mask']; $c_master_ip = $m_subnet['ip'];
+			}
+
+			# Candidate is more specific than current selection.
+			if ($m_subnet['mask'] > $c_master_mask) {
+				$c_master_id = $m_subnet['id']; $c_master_mask = $m_subnet['mask']; $c_master_ip = $m_subnet['ip'];
 			}
 		}
 
@@ -133,15 +209,16 @@ foreach ($rlist as $sect_id => $sect_check) {
 		$c_subnet['action'] = ($c_subnet['masterSubnetId'] == $c_subnet['new_masterSubnetId'] ? "skip" : "edit");
 		$c_subnet['msg'] = ($c_subnet['masterSubnetId'] == $c_subnet['new_masterSubnetId'] ? _("No change, skip") : _("New master, update"));
 
+		$counters[$c_subnet['action']]++;
+
 		if ( $_GET['recomputeHideUnchanged'] == "on" && $c_subnet['masterSubnetId'] == $c_master_id ) { continue; }
 
 		$rows.="<tr class='".$colors[$c_subnet['action']]."'><td><i class='fa ".$icons[$c_subnet['action']]."' rel='tooltip' data-placement='bottom' title='"._($c_subnet['msg'])."'></i></td>";
 		$rows.="<td>".$sect_names[$sect_id]."</td><td>".$c_subnet['ip']."/".$c_subnet['mask']."</td>";
 		$rows.="<td>".$c_subnet['description']."</td><td>".$vrf_name[$c_subnet['vrfId']]."</td><td>";
 		$rows.=$c_subnet['new_master']."</td><td>".$c_subnet['msg']."</td></tr>\n";
-
-		$counters[$c_subnet['action']]++;
 	}
+	unset($c_subnet);
 }
 
 ?>

--- a/app/admin/import-export/import-recompute.php
+++ b/app/admin/import-export/import-recompute.php
@@ -30,34 +30,34 @@ include 'import-recompute-logic.php';
 $msg = "";
 $rows = "";
 
-# Update Subnet master
-foreach ($rlist as $sect_id => $sect_check) {
-	# Skip empty sections
-	if (!$edata[$sect_id]) { continue; }
+# Update Subnet masters
+foreach($edata as $sect_id => $a) {
+	foreach($edata[$sect_id] as $e_type => $b) {
+		foreach($edata[$sect_id][$e_type] as $e_mask => $c) {
+			foreach($edata[$sect_id][$e_type][$e_mask] as &$c_subnet) {
 
-	# Grab a subnet and find its closest master
-	foreach ($edata[$sect_id] as &$c_subnet) {
-		if ($c_subnet['action'] == "edit") {
+				if ($c_subnet['action'] != "edit") { continue; }
 
-			# We only need id and new master
-			$values = array("id"=>$c_subnet['id'], "masterSubnetId"=>$c_subnet['new_masterSubnetId']);
+				# We only need id and new master
+				$values = array("id"=>$c_subnet['id'], "masterSubnetId"=>$c_subnet['new_masterSubnetId']);
 
-			# update
-			$c_subnet['result'] = $Admin->object_modify("subnets", $c_subnet['action'], "id", $values);
+				# update
+				$c_subnet['result'] = $Admin->object_modify("subnets", $c_subnet['action'], "id", $values);
 
-			if ($c_subnet['result']) {
-				$trc = $colors[$c_subnet['action']];
-				$msg = "Master ".$c_subnet['action']." successful.";
-			} else {
-				$trc = "danger";
-				$msg = "Master ".$c_subnet['action']." failed.";
+				if ($c_subnet['result']) {
+					$trc = $colors[$c_subnet['action']];
+					$msg = "Master ".$c_subnet['action']." successful.";
+				} else {
+					$trc = "danger";
+					$msg = "Master ".$c_subnet['action']." failed.";
+				}
+
+				$rows.="<tr class='".$trc."'><td><i class='fa ".$icons[$c_subnet['action']]."' rel='tooltip' data-placement='bottom' title='"._($msg)."'></i></td>";
+				$rows.="<td>".$sect_names[$sect_id]."</td><td>".$c_subnet['ip']."/".$c_subnet['mask']."</td>";
+				$rows.="<td>".$c_subnet['description']."</td><td>".$vrf_name[$c_subnet['vrfId']]."</td><td>";
+				$rows.=$c_subnet['new_master']."</td><td>"._($msg)."</td></tr>\n";
 			}
-
-			$rows.="<tr class='".$trc."'><td><i class='fa ".$icons[$c_subnet['action']]."' rel='tooltip' data-placement='bottom' title='"._($msg)."'></i></td>";
-			$rows.="<td>".$sect_names[$sect_id]."</td><td>".$c_subnet['ip']."/".$c_subnet['mask']."</td>";
-			$rows.="<td>".$c_subnet['description']."</td><td>".$vrf_name[$c_subnet['vrfId']]."</td><td>";
-			$rows.=$c_subnet['new_master']."</td><td>"._($msg)."</td></tr>\n";
-
+			unset($c_subnet);
 		}
 	}
 }


### PR DESCRIPTION
Optimization of  import-recompute-logic.php. 

We've adopted phpIPAM for a fairly large internal network (~7500 subnets added so far and growing). The biggest wins so far in addressing the slow performance feedback from users has been enabling MySQL query caching and migrating to php7 from php5.5.  It may be worth advocating php7 on the homepage for large installations as the improvements are significant.

Subnets::fetch_subnet_slaves_recursive is the worst performing function remaining taking 45 seconds to render the 10.0.0.0/8 subnets details page (94.9% of total time).  I'm leaning towards a MySQL stored procedure to generate a temporary table containing a list of child subnet ids for a given subnet. We can then avoid the slow recursion in php code ( Subnets::fetch_subnet_slaves called 21,143 times. )

    # Subnet 10.0.0.0/8 has id 1000
    CALL SubnetFamilyTreeById(1000);
    # The temporary table subnet_family_tree1000 now contains a list of 10.0.0.0/8 children ids.
    SELECT * FROM subnets WHERE id IN (SELECT id FROM subnet_family_tree1000);

Is this something that you or others are already working on and would you be happy with such an approach?

The nested set model has the potential to be even faster but is much harder to implement, has issues with insertion and deletion performance and would break if the database was modified outside phpIPAM.

p.s. I'm planning on revisiting import-recompute-logic.php later to extend the form so the users can pick from the available candidates master subnets from a drop-down box.

Thanks

-----------------------------------------------
Improve the performance of import-recompute-logic.php. The majority of the speed
up is from avoiding searching subnets of equal or larger mask size when looking
for a new master subnet e.g. When looking for the master of 10.100.0.0/16 there
is no point looking at /24 subnets, we only need to search /15, /14, /13, /12...

When selecting a new master subnet from available candidates give preference to
subnets in the same VRF, followed by the currently set master subnet.

The largest observed speed increase was from the migration from php55 to php70.
This also has the added benefit of reducing memory_get_peak_usage() by ~%50.

Benchmarks below are from a live production database (~7500 subnets). Synthetic
datasets show greater improvements.

RedHat 6.7. Xeon @2.60GHz, MySQL 5.1.73

PHP 5.5.21, execute import-recompute-logic.php
Original:   112 seconds, 95.7Mb Peak memory usage
Patched :    62 seconds, 77.5Mb Peak memory usage

PHP 7.0.10, execute import-recompute-logic.php
Original:    46 seconds, 36.6Mb Peak memory usage
Patched:      8 seconds, 37.4Mb Peak memory usage