### PR TITLE
api: Fix some custom field nesting bugs

### DIFF
--- a/api/controllers/Addresses.php
+++ b/api/controllers/Addresses.php
@@ -441,7 +441,7 @@ class Addresses_controller extends Common_api_functions  {
 
 		# append old address details and fill details if not provided - calidate_update_parameters fetches $this->old_address
 		foreach ($this->old_address as $ok=>$oa) {
-			if (!isset($values[$ok])) {
+			if (!array_key_exists($ok, $values)) {
 				if(!is_null($oa)) {
 					$values[$ok] = $oa;
 				}

--- a/api/controllers/Common.php
+++ b/api/controllers/Common.php
@@ -962,6 +962,30 @@ class Common_api_functions {
     	}
 	}
 
+	/**
+	* Unmarshal nested custom field data into the root object, and unset
+	* the custom_fields parameter when done. This function does not have
+	* any effect on requests for controllers that don't have custom fields,
+	* or if the app_nest_custom_fields setting is not enabled.
+	*
+	* @access public
+	* @return void
+	*/
+	public function unmarshal_nested_custom_fields() {
+		if (!$this->app->app_nest_custom_fields) {
+			return;
+		}
+		if (is_array($this->_params->custom_fields) && isset($this->custom_fields)) {
+			foreach ($this->_params->custom_fields as $key => $value) {
+				if (array_key_exists($key, $this->custom_fields)) {
+					$this->_params->$key = $value;
+				} else {
+					$this->Response->throw_exception(400, "${key} is not a valid custom field");
+				}
+			}
+			unset($this->_params->custom_fields);
+		}
+	}
 }
 
 ?>

--- a/api/controllers/Responses.php
+++ b/api/controllers/Responses.php
@@ -286,8 +286,10 @@ class Responses {
 	 * @return void
 	 */
 	private function nest_custom_fields ($custom_fields = array()) {
-		// if result is array (multiple items) than loop
-		if(is_array($this->result['data'])) {
+		// Nest all fields in an array result.  Guard against arrays
+		// with string keys to ensure we don't mistakenly assume a
+		// simple associative array is an array of objects.
+		if (is_array($this->result['data']) && sizeof(array_filter(array_keys($this->result['data']), 'is_string')) == 0) {
 			foreach ($this->result['data'] as $dk=>$d) {
 				if(sizeof($custom_fields)>0) {
 					foreach($custom_fields as $k=>$cf) {
@@ -302,8 +304,9 @@ class Responses {
 				}
 			}
 		}
-		// single result
-		else {
+		// This is a single element but we need to guard against
+		// non-objects here too.
+		elseif (is_object($this->result['data'])) {
 			if(sizeof($custom_fields)>0) {
 				foreach($custom_fields as $k=>$cf) {
 					// add to result

--- a/api/controllers/Sections.php
+++ b/api/controllers/Sections.php
@@ -170,7 +170,10 @@ class Sections_controller extends Common_api_functions {
 			}
 			// check result
 			if(sizeof($result)==0) 						{ $this->Response->throw_exception(404, "No subnets found"); }
-			else										{ return array("code"=>200, "data"=>$this->prepare_result ($result, "subnets", true, true)); }
+			else {
+				$this->custom_fields = $this->Tools->fetch_custom_fields('subnets');
+				return array("code"=>200, "data"=>$this->prepare_result ($result, "subnets", true, true));
+			}
 		}
 		// verify ID
 		elseif(isset($this->_params->id)) {

--- a/api/controllers/Subnets.php
+++ b/api/controllers/Subnets.php
@@ -229,7 +229,10 @@ class Subnets_controller extends Common_api_functions {
 				}
 				// check result
 				if($result===false)						{ $this->Response->throw_exception(404, "No addresses found"); }
-				else									{ return array("code"=>200, "data"=>$this->prepare_result ($result, "addresses", true, true)); }
+				else {
+					$this->custom_fields = $this->Tools->fetch_custom_fields('ipaddresses');
+					return array("code"=>200, "data"=>$this->prepare_result ($result, "addresses", true, true));
+				}
 			}
 			// slaves
 			elseif($this->_params->id2=="slaves") {

--- a/api/controllers/Vlans.php
+++ b/api/controllers/Vlans.php
@@ -170,7 +170,10 @@ class Vlans_controller extends Common_api_functions {
 
 			// check result
 			if($result==NULL)						{ $this->Response->throw_exception(404, "No subnets found"); }
-			else									{ return array("code"=>200, "data"=>$this->prepare_result ($result, "subnets", true, true)); }
+			else {
+				$this->custom_fields = $this->Tools->fetch_custom_fields('subnets');
+				return array("code"=>200, "data"=>$this->prepare_result ($result, "subnets", true, true));
+			}
 		}
 		// custom fields
 		elseif (@$this->_params->id=="custom_fields") {

--- a/api/controllers/Vrfs.php
+++ b/api/controllers/Vrfs.php
@@ -166,7 +166,10 @@ class Vrfs_controller extends Common_api_functions {
 
 				// check result
 				if($result===false)					{ $this->Response->throw_exception(404, 'No subnets belonging to this vrf'); }
-				else								{ return array("code"=>200, "data"=>$this->prepare_result ($result, "subnets", true, true)); }
+				else {
+					$this->custom_fields = $this->Tools->fetch_custom_fields('subnets');
+					return array("code"=>200, "data"=>$this->prepare_result ($result, "subnets", true, true));
+				}
 			}
 			// error
 			else {

--- a/api/index.php
+++ b/api/index.php
@@ -185,6 +185,14 @@ try {
 	// pass app params for links result
 	$controller->app = $app;
 
+	// Unmarshal the custom_fields JSON object into the main object for
+	// POST and PATCH. This only works for controllers that support custom
+	// fields and if the app has nested custom fields enabled, otherwise
+	// this is skipped.
+	if (strtoupper($_SERVER['REQUEST_METHOD']) == 'POST' || strtoupper($_SERVER['REQUEST_METHOD']) == 'PATCH') {
+		$controller->unmarshal_nested_custom_fields();
+	}
+
 	// check if the action exists in the controller. if not, throw an exception.
 	if( method_exists($controller, strtolower($_SERVER['REQUEST_METHOD'])) === false ) {
 		$Response->throw_exception(501, $Response->errors[501]);

--- a/api/index.php
+++ b/api/index.php
@@ -251,7 +251,7 @@ if($time_response) {
 }
 
 //output result
-echo $Response->formulate_result ($result, $time, $app->nest_custom_fields, $controller->custom_fields);
+echo $Response->formulate_result ($result, $time, $app->app_nest_custom_fields, $controller->custom_fields);
 
 // exit
 exit();


### PR DESCRIPTION
This PR fixes custom field nesting:

 * Fixes the toggle (the field being referenced in `formulate_result` in `index.php` was off
 * Fixes nesting of custom fields when sub-objects are being requested (ie: addresses in a subnet)
 * Also ensures nesting does not fire on non-objects, suppressing warnings on things like `/api/APP/user/`

Note there still seems to be some issues with aliased controllers (ie: `/vrf/`, which aliases to `/vrfs/`), due to the way that these controllers hand off to their targets. This might be something that needs to be fundamentally refactored before it functions as intended.

Ref: #1073 