### PR TITLE
Fix sorting of IP addresses

### DIFF
--- a/functions/classes/class.Subnets.php
+++ b/functions/classes/class.Subnets.php
@@ -449,12 +449,12 @@ class Subnets extends Common_functions {
 		# fetch
 		// if sectionId is not numeric, assume it is section name rather than id, set query appropriately
 		if (is_numeric($sectionId)) {
-			$query = "SELECT *,CAST(subnet AS DECIMAL(39,0)) as `subnet_int` FROM `subnets` where `sectionId` = ? order by `isFolder` desc, case `isFolder` when 1 then description else $order[0] end $order[1]";
+			$query = "(SELECT *,CAST(subnet AS DECIMAL(39,0)) as `subnet_int` FROM `subnets` where `sectionId` = ? and isFolder=1 order by description $order[1]) UNION (SELECT *,CAST(subnet AS DECIMAL(39,0)) as `subnet_int` FROM `subnets` where `sectionId` = ? and isFolder=0 order by $order[0] $order[1])";
 		}
 		else {
-			$query = "SELECT *,CAST(subnet AS DECIMAL(39,0)) as `subnet_int` FROM `subnets` where `sectionId` in (SELECT id from sections where name = ?) order by `isFolder` desc, case `isFolder` when 1 then description else $order[0] end $order[1]";
+			$query = "(SELECT *,CAST(subnet AS DECIMAL(39,0)) as `subnet_int` FROM `subnets` where `sectionId` in (SELECT id from sections where name = ?) and isFolder=1 order by description $order[1]) UNION (SELECT *,CAST(subnet AS DECIMAL(39,0)) as `subnet_int` FROM `subnets` where `sectionId` in (SELECT id from sections where name = ?) and isFolder=0 order by $order[0] $order[1])";
 		}
-		try { $subnets = $this->Database->getObjectsQuery($query, array($sectionId)); }
+		try { $subnets = $this->Database->getObjectsQuery($query, array($sectionId, $sectionId)); }
 		catch (Exception $e) {
 			$this->Result->show("danger", _("Error: ").$e->getMessage());
 			return false;


### PR DESCRIPTION
MySQL doesn't seem to sort the IP addresses in a numeric way well, even though the fields are being typecasted to integers if the sort has a case statement. This causes alphabetically lower but numeric higher addresses to end up before their counterparts.

This fix splits the queries for the folder and for the addresses, so we can use a simple order by instead of a order-by-case-statement.