### PR TITLE
Minor optimisation for the subnet details index.php page

### DIFF
--- a/app/subnets/index.php
+++ b/app/subnets/index.php
@@ -30,17 +30,6 @@ $vlan = (array) $Tools->fetch_object("vlans", "vlanId", $subnet['vlanId']);
 # fetch recursive nameserver details
 $nameservers = (array) $Tools->fetch_object("nameservers", "id", $subnet['nameserverId']);
 
-# fetch all addresses and calculate usage
-if($slaves) {
-	$addresses = $Addresses->fetch_subnet_addresses_recursive ($subnet['id'], false);
-	$slave_subnets = (array) $Subnets->fetch_subnet_slaves ($subnet['id']);
-} else {
-	$addresses = $Addresses->fetch_subnet_addresses ($subnet['id']);
-}
-
-// get usage
-$subnet_usage  = $Subnets->calculate_subnet_usage ($subnet, true);
-
 # verify that is it displayed in proper section, otherwise warn!
 if($subnet['sectionId']!=$_GET['section'])	{
 	$sd = (array) $Sections->fetch_section(null,$subnet['sectionId']);
@@ -130,13 +119,19 @@ if ($User->settings->enableNAT==1) {
 
 	<!-- subnet slaves list -->
 	<div class="col-xs-12 subnetSlaves">
-		<?php if($slaves) include('subnet-slaves.php'); ?>
+		<?php
+		if($slaves) {
+			$slave_subnets = (array) $Subnets->fetch_subnet_slaves ($subnet['id']);
+			include('subnet-slaves.php');
+		}
+		?>
 	</div>
 
 	<!-- addresses -->
 	<div class="col-xs-12 ipaddresses_overlay">
 		<?php
 		if(!$slaves) {
+			$addresses = $Addresses->fetch_subnet_addresses ($subnet['id']);
 			include('addresses/print-address-table.php');
 		}
 		?>


### PR DESCRIPTION
Avoid redundant expensive call to $Addresses->fetch_subnet_addresses_recursive.
This function adds 10+ seconds to subnet detail page load time with large nested data-sets.
memory_get_peak_usage() for the subnet detail page is also reduced from 63Mb to 38Mb by
avoiding loading nested IP addresses details into memory (php7.1).

Avoid duplicate call of Subnets->calculate_subnet_usage. Function is called directly
from the included php files.