### PR TITLE
Bug fixes

### DIFF
--- a/functions/classes/class.Addresses.php
+++ b/functions/classes/class.Addresses.php
@@ -1301,8 +1301,8 @@ class Addresses extends Common_functions {
 		else 					{ $order_addr = array("ip_addr", "asc"); }
 
 		# escape ordering
-		$order[0] = $this->Database->escape ($order[0]);
-		$order[1] = $this->Database->escape ($order[1]);
+		$order_addr[0] = $this->Database->escape ($order_addr[0]);
+		$order_addr[1] = $this->Database->escape ($order_addr[1]);
 
 		$ids = array();
 		$ids[] = $subnetId;

--- a/functions/classes/class.Subnets.php
+++ b/functions/classes/class.Subnets.php
@@ -1108,14 +1108,11 @@ class Subnets extends Common_functions {
             $out["maxhosts"]          = gmp_strval($this->get_max_hosts ($subnet->mask, $ip_version, $strict_mode));
             // slaves fix for reducing subnet and broadcast address
             if($ip_version=="IPv4" && $is_slave) {
-                if($subnet->mask==32 && $out["used"]==0) {
-                     $out["used"]++;
+                if($subnet->mask==32) {
+                     $out["used"] = 1;
                 }
-                elseif($subnet->mask==31 &&  $out["used"]==0) {
-                    $out["used"] = $out["used"]+2;
-                }
-                elseif($subnet->mask==31 &&  $out["used"]==1) {
-                    $out["used"]++;
+                elseif($subnet->mask==31) {
+                    $out["used"] = 2;
                 }
                 else {
                     $out["used"] = $out["used"]+2;

--- a/functions/classes/class.Subnets.php
+++ b/functions/classes/class.Subnets.php
@@ -892,7 +892,6 @@ class Subnets extends Common_functions {
 				foreach($slaves2 as $slave) {
 					# save to full array of slaves
 					$this->slaves_full[$slave->id] = $slave;
-					$this->slaves[] = $slave->id;
 					# fetch possible new slaves
 					$this->fetch_subnet_slaves_recursive ($slave->id);
 					$end = true;


### PR DESCRIPTION
Hi,

When comparing the generated output of optimised functions to the unmodified code I've found edge cases where they generate different results. On investigation this is due to bugs in the original functions.


**Bugfix for fetch_subnet_slaves_recursive()**

When called fetch_subnet_slaves_recursive() saves the argument $subnetId into $this->slaves[] cast to (int).

    $this->slaves[] = (int) $subnetId;              //id

We then find slaves of $subnetId, push them into $this->slaves[] and recursively call fetch_subnet_slaves_recursive($slave->id). This recursive call will also push $slave->id into $this->slaves[] due to the line above.

    foreach($slaves2 as $slave) {
      # save to full array of slaves
      $this->slaves_full[$slave->id] = $slave;
      $this->slaves[] = $slave->id;          # $slave->id saved as type String()
      # fetch possible new slaves
      $this->fetch_subnet_slaves_recursive ($slave->id); # saved again as int()

The result is slave ids are duplicated in the $this->slaves[] array. Code calling foreach($this->slaves AS $slave) will invoke code paths twice for each slave id with unknown side effects.

    var_dump($this->slaves) == array(10566) {
    [1]=> string(4) "1007" [2]=> int(1007)
    [3]=> string(4) "1160" [4]=> int(1160)
    [5]=> string(4) "1161" [6]=> int(1161)
    [7]=> string(4) "1162" [8]=> int(1162)
    [9]=> string(4) "1163" [10]=> int(1163)
    ...

**Bugfix for calculate_single_subnet_details()**

Program flow for /32 subnets containing one IP falls through to the else block as mask==32 but used==1. This causes the following values to calculated for /32 subnets with 1 IP.

    var_dump($out) == array(2) { ["used"]=> int(3) ["maxhosts"]=> string(1) "1" }

    if($ip_version=="IPv4" && $is_slave) {
        if($subnet->mask==32 && $out["used"]==0) {
            $out["used"]++;
        }
        elseif($subnet->mask==31 &&  $out["used"]==0) {
            $out["used"] = $out["used"]+2;
        }
        elseif($subnet->mask==31 &&  $out["used"]==1) {
            $out["used"]++;
        }
        else {
            $out["used"] = $out["used"]+2;
        }
    }

**Bugfix for fetch_subnet_addresses_recursive()**

Unsafe function inputs are Database-escape() and copied into the order[] array and we then build the SQL query using the original un-escaped order_addr[] values.

Database-escape() the order_addr[] values used to build the query.