### PR TITLE
Fix PHP Notice Errors

### DIFF
--- a/config.dist.php
+++ b/config.dist.php
@@ -85,7 +85,10 @@ define('MCUNIQUE', "section");
 /**
  * SAML mappings
  ******************************/
+if(!defined('MAP_SAML_USER'))
 define('MAP_SAML_USER', true);    // Enable SAML username mapping
+
+if(!defined('SAML_USERNAME'))
 define('SAML_USERNAME', 'admin'); // Map SAML to explicit user
 
 

--- a/functions/functions.php
+++ b/functions/functions.php
@@ -1,7 +1,7 @@
 <?php
 
 /* @config file ------------------ */
-require( dirname(__FILE__) . '/../config.php' );
+require_once( dirname(__FILE__) . '/../config.php' );
 
 /* @http only cookies ------------------- */
 ini_set('session.cookie_httponly', 1);


### PR DESCRIPTION
PHP Notice:  Constant MAP_SAML_USER already defined in /var/www/html/phpipam/config.php on line 88
PHP Stack trace:
PHP   1. {main}() /var/www/html/phpipam/index.php:0
PHP   2. require() /var/www/html/phpipam/index.php:9
PHP   3. require() /var/www/html/phpipam/functions/functions.php:4
PHP   4. define() /var/www/html/phpipam/config.php:88
PHP Notice:  Constant SAML_USERNAME already defined in /var/www/html/phpipam/config.php on line 89
PHP Stack trace:
PHP   1. {main}() /var/www/html/phpipam/index.php:0
PHP   2. require() /var/www/html/phpipam/index.php:9
PHP   3. require() /var/www/html/phpipam/functions/functions.php:4
PHP   4. define() /var/www/html/phpipam/config.php:89