### PR TITLE
Disable injecting Google Maps javascript unless gmaps api-key is defined in config.php.

### DIFF
--- a/app/tools/locations/all-locations-map.php
+++ b/app/tools/locations/all-locations-map.php
@@ -28,7 +28,7 @@ $User->check_user_session();
 if ($User->settings->enableLocations!="1") {
     $Result->show("danger", _("Locations module disabled."), false);
 }
-elseif ($User->settings->enableLocations=="1" && isset($gmaps_api_key) && strlen($gmaps_api_key)==0) {
+elseif ($User->settings->enableLocations=="1" && (!isset($gmaps_api_key) || strlen($gmaps_api_key)==0)) {
     $Result->show("warning text-center nomargin", _("Location module Google Maps API key is unset. Please configure config.php \$gmaps_api_key."));
 }
 else {

--- a/app/tools/locations/all-locations-map.php
+++ b/app/tools/locations/all-locations-map.php
@@ -29,7 +29,7 @@ if ($User->settings->enableLocations!="1") {
     $Result->show("danger", _("Locations module disabled."), false);
 }
 elseif ($User->settings->enableLocations=="1" && (!isset($gmaps_api_key) || strlen($gmaps_api_key)==0)) {
-    $Result->show("warning text-center nomargin", _("Location module Google Maps API key is unset. Please configure config.php \$gmaps_api_key."));
+    $Result->show("info text-center nomargin", _("Location: Google Maps API key is unset. Please configure config.php \$gmaps_api_key to enable."));
 }
 else {
     # fetch all locations

--- a/app/tools/locations/all-locations-map.php
+++ b/app/tools/locations/all-locations-map.php
@@ -28,6 +28,9 @@ $User->check_user_session();
 if ($User->settings->enableLocations!="1") {
     $Result->show("danger", _("Locations module disabled."), false);
 }
+elseif ($User->settings->enableLocations=="1" && isset($gmaps_api_key) && strlen($gmaps_api_key)==0) {
+    $Result->show("warning text-center nomargin", _("Location module Google Maps API key is unset. Please configure config.php \$gmaps_api_key."));
+}
 else {
     # fetch all locations
     $all_locations = $Tools->fetch_all_objects("locations", "name");

--- a/app/tools/locations/single-location-map.php
+++ b/app/tools/locations/single-location-map.php
@@ -16,7 +16,9 @@ if(!$location) {
 if($location===false) {
     $Result->show("info","Invalid location", false);
 }
-else {
+elseif (!isset($gmaps_api_key) || strlen($gmaps_api_key)==0) {
+      $Result->show("info text-center nomargin", _("Location: Google Maps API key is unset. Please configure config.php \$gmaps_api_key to enable."));
+}else {
     // recode
     if (strlen($location->long)==0 && strlen($location->lat)==0 && strlen($location->address)>0) {
         $latlng = $Tools->get_latlng_from_address ($location->address);

--- a/db/SCHEMA.sql
+++ b/db/SCHEMA.sql
@@ -149,7 +149,7 @@ CREATE TABLE `settings` (
   `enableSNMP` TINYINT(1)  NULL  DEFAULT '0',
   `enableThreshold` TINYINT(1)  NULL  DEFAULT '1',
   `enableRACK` TINYINT(1)  NULL  DEFAULT '1',
-  `enableLocations` TINYINT(1)  NULL  DEFAULT '1',
+  `enableLocations` TINYINT(1)  NULL  DEFAULT '0',
   `enablePSTN` TINYINT(1)  NULL  DEFAULT '0',
   `link_field` VARCHAR(32)  NULL  DEFAULT '0',
   `version` varchar(5) DEFAULT NULL,

--- a/db/SCHEMA.sql
+++ b/db/SCHEMA.sql
@@ -149,7 +149,7 @@ CREATE TABLE `settings` (
   `enableSNMP` TINYINT(1)  NULL  DEFAULT '0',
   `enableThreshold` TINYINT(1)  NULL  DEFAULT '1',
   `enableRACK` TINYINT(1)  NULL  DEFAULT '1',
-  `enableLocations` TINYINT(1)  NULL  DEFAULT '0',
+  `enableLocations` TINYINT(1)  NULL  DEFAULT '1',
   `enablePSTN` TINYINT(1)  NULL  DEFAULT '0',
   `link_field` VARCHAR(32)  NULL  DEFAULT '0',
   `version` varchar(5) DEFAULT NULL,

--- a/index.php
+++ b/index.php
@@ -118,11 +118,9 @@ else {
 	<!--[if lt IE 9]>
 	<script type="text/javascript" src="js/<?php print SCRIPT_PREFIX; ?>/dieIE.js"></script>
 	<![endif]-->
-	<?php if ($User->settings->enableLocations=="1") { ?>
-	<?php	if(isset($gmaps_api_key) && strlen($gmaps_api_key)>0) { ?>
+	<?php if ($User->settings->enableLocations=="1" && isset($gmaps_api_key) && strlen($gmaps_api_key)>0) { ?>
 	<script type="text/javascript" src="https://maps.google.com/maps/api/js<?php print "?key=".$gmaps_api_key; ?>"></script>
 	<script type="text/javascript" src="js/<?php print SCRIPT_PREFIX; ?>/gmaps.js"></script>
-	<?php } else { $Result->show("warning text-center nomargin", _("Location module API key is unset. Please configure config.php \$gmaps_api_key")); }	?>
 	<?php }	?>
 
 </head>

--- a/index.php
+++ b/index.php
@@ -119,14 +119,10 @@ else {
 	<script type="text/javascript" src="js/<?php print SCRIPT_PREFIX; ?>/dieIE.js"></script>
 	<![endif]-->
 	<?php if ($User->settings->enableLocations=="1") { ?>
-	<?php
-	# API key check
-	if(isset($gmaps_api_key)) {
-	    $key = strlen($gmaps_api_key)>0 ? "?key=".$gmaps_api_key : "";
-	}
-	?>
-	<script type="text/javascript" src="https://maps.google.com/maps/api/js<?php print $key; ?>"></script>
+	<?php	if(isset($gmaps_api_key) && strlen($gmaps_api_key)>0) { ?>
+	<script type="text/javascript" src="https://maps.google.com/maps/api/js<?php print "?key=".$gmaps_api_key; ?>"></script>
 	<script type="text/javascript" src="js/<?php print SCRIPT_PREFIX; ?>/gmaps.js"></script>
+	<?php } else { $Result->show("warning text-center nomargin", _("Location module API key is unset. Please configure config.php \$gmaps_api_key")); }	?>
 	<?php }	?>
 
 </head>


### PR DESCRIPTION
Add warning to Locations Map screen if location module is enabled but api-key is unset.

![image](https://cloud.githubusercontent.com/assets/18753294/26025534/e3952ab4-37e1-11e7-9ae1-89ba7e2ff3eb.png)

Also don't inject maps.google.com javascript in index.php unless the location module is enabled and api key is defined. Displaying locations on gmaps requires a valid api-key in config.php and the javascript can be blocked in corporate environments causing page loading issues. Only inject the js if they've gone to the trouble of getting a valid key to enable this feature.

![image](https://cloud.githubusercontent.com/assets/18753294/26025527/a8c2e44e-37e1-11e7-9c53-e220df9f68f0.png)