### PR TITLE
Bugfix for issue 1132 - Recompute logic 32bit php

### DIFF
--- a/app/admin/import-export/import-recompute-logic.php
+++ b/app/admin/import-export/import-recompute-logic.php
@@ -142,8 +142,19 @@ foreach ($rlist as $sect_id => $sect_check) {
 			$search_subnet = gmp_strval(gmp_and($c_subnet['subnet'], $masks[$search_type][$search_mask]));
 
 			if (isset($candidates[$sect_id][$search_type][$search_mask][$search_subnet])) {
-				$m_candidate = $candidates[$sect_id][$search_type][$search_mask][$search_subnet];
-				break;
+				$t_candidate = $candidates[$sect_id][$search_type][$search_mask][$search_subnet];
+
+				# Skip subnets from other VRFs if cross VRF reordering is not wanted (default is on)
+				if (!$sect_check["CVRF"]) {
+					foreach($t_candidate as $i => $t_subnet) {
+						if ($t_subnet['vrfId'] != $c_subnet['vrfId']) { unset($t_candidate[$i]);}
+					}
+				}
+
+				if (sizeof($t_candidate) > 0) {
+					$m_candidate = $t_candidate;
+					break;
+				}
 			};
 		}
 

--- a/app/admin/import-export/import-recompute.php
+++ b/app/admin/import-export/import-recompute.php
@@ -32,34 +32,30 @@ $rows = "";
 
 # Update Subnet masters
 foreach($edata as $sect_id => $a) {
-	foreach($edata[$sect_id] as $e_type => $b) {
-		foreach($edata[$sect_id][$e_type] as $e_mask => $c) {
-			foreach($edata[$sect_id][$e_type][$e_mask] as &$c_subnet) {
+	foreach($edata[$sect_id] as &$c_subnet) {
 
-				if ($c_subnet['action'] != "edit") { continue; }
+		if ($c_subnet['action'] != "edit") { continue; }
 
-				# We only need id and new master
-				$values = array("id"=>$c_subnet['id'], "masterSubnetId"=>$c_subnet['new_masterSubnetId']);
+		# We only need id and new master
+		$values = array("id"=>$c_subnet['id'], "masterSubnetId"=>$c_subnet['new_masterSubnetId']);
 
-				# update
-				$c_subnet['result'] = $Admin->object_modify("subnets", $c_subnet['action'], "id", $values);
+		# update
+		$c_subnet['result'] = $Admin->object_modify("subnets", $c_subnet['action'], "id", $values);
 
-				if ($c_subnet['result']) {
-					$trc = $colors[$c_subnet['action']];
-					$msg = "Master ".$c_subnet['action']." successful.";
-				} else {
-					$trc = "danger";
-					$msg = "Master ".$c_subnet['action']." failed.";
-				}
-
-				$rows.="<tr class='".$trc."'><td><i class='fa ".$icons[$c_subnet['action']]."' rel='tooltip' data-placement='bottom' title='"._($msg)."'></i></td>";
-				$rows.="<td>".$sect_names[$sect_id]."</td><td>".$c_subnet['ip']."/".$c_subnet['mask']."</td>";
-				$rows.="<td>".$c_subnet['description']."</td><td>".$vrf_name[$c_subnet['vrfId']]."</td><td>";
-				$rows.=$c_subnet['new_master']."</td><td>"._($msg)."</td></tr>\n";
-			}
-			unset($c_subnet);
+		if ($c_subnet['result']) {
+			$trc = $colors[$c_subnet['action']];
+			$msg = "Master ".$c_subnet['action']." successful.";
+		} else {
+			$trc = "danger";
+			$msg = "Master ".$c_subnet['action']." failed.";
 		}
+
+		$rows.="<tr class='".$trc."'><td><i class='fa ".$icons[$c_subnet['action']]."' rel='tooltip' data-placement='bottom' title='"._($msg)."'></i></td>";
+		$rows.="<td>".$sect_names[$sect_id]."</td><td>".$c_subnet['ip']."/".$c_subnet['mask']."</td>";
+		$rows.="<td>".$c_subnet['description']."</td><td>".$vrf_name[$c_subnet['vrfId']]."</td><td>";
+		$rows.=$c_subnet['new_master']."</td><td>"._($msg)."</td></tr>\n";
 	}
+	unset($c_subnet);
 }
 
 print "<table class='table table-condensed table-hover' id='resultstable'><tbody>";


### PR DESCRIPTION
Bugfix for #1132 : Recompute logic under php 32bit.

192.168.0.0 has a subnet representation of "3232235520" but php 32bit integer ranges are -2147483648 to 2147483647 so this triggers an overflow on 32 bit systems when we compute a bitwise mask. Manipulating 10.0.0.0/8 subnets doesn't trigger the overflow.

    # Main logic here - check if subnet within subnet
    if (($c_subnet['andip'] & $masks[$c_subnet['type']][$m_subnet['mask']]) == $m_subnet['andip'])

I've re-written to use gmp_ math functions and I've optimised the inner loop away with a hash lookup so as a bonus it is faster too. (RaspberryPi3, Recompute 7100 subnets ~ 5 seconds.)