### PR TITLE
Order IP Request dropdown menu by subnet instead of table ID

### DIFF
--- a/functions/classes/class.Tools.php
+++ b/functions/classes/class.Tools.php
@@ -930,7 +930,7 @@ class Tools extends Common_functions {
 	 * @return array|null
 	 */
 	public function requests_fetch_available_subnets () {
-		try { $subnets = $this->Database->getObjectsQuery("SELECT * FROM `subnets` where `allowRequests`=1 and `isFull` != 1;"); }
+		try { $subnets = $this->Database->getObjectsQuery("SELECT * FROM `subnets` where `allowRequests`=1 and `isFull` != 1 ORDER BY `subnet`;"); }
 		catch (Exception $e) { $this->Result->show("danger", $e->getMessage(), false);	return false; }
 
 		# save


### PR DESCRIPTION
Added "ORDER BY 'subnet'" to the SQL statement that populates the IP Request Form dropdown menu, so that IP ranges that are near each other will be listed together regardless of when they were added. The previous ordering defaulted to the table's primary column, which made the menu look random if subnets numerically near each other were added to the database at different times.