### PR TITLE
Display subnet usage on subnet details page.

### DIFF
--- a/app/subnets/subnet-details/subnet-details.php
+++ b/app/subnets/subnet-details/subnet-details.php
@@ -90,7 +90,6 @@ else {
 		<th><?php print _('Permission'); ?></th>
 		<td><?php print $Subnets->parse_permissions($subnet_permission); ?></td>
 	</tr>
-	<?php if(!$slaves) { ?>
 	<tr>
 		<th><?php print _('Subnet Usage'); ?></th>
 		<td>
@@ -101,6 +100,7 @@ else {
 			?>
 		</td>
 	</tr>
+	<?php if(!$slaves) { ?>
 
 	<!-- gateway -->
 	<?php


### PR DESCRIPTION
Can we display usage details on the subnet details page for all subnets?
(We've already called $Subnets->calculate_subnet_usage in index.php to calculate them.)

![image](https://user-images.githubusercontent.com/18753294/26990806-e11bae10-4d4f-11e7-943e-1815863972eb.png)

