### PR TITLE
Replace DEPRECATED split() function.

### DIFF
--- a/functions/PEAR/Spreadsheet/Excel/Writer/Parser.php
+++ b/functions/PEAR/Spreadsheet/Excel/Writer/Parser.php
@@ -679,9 +679,9 @@ class Spreadsheet_Excel_Writer_Parser extends PEAR
         // TODO: possible class value 0,1,2 check Formula.pm
         // Split the range into 2 cell refs
         if (preg_match("/^([A-Ia-i]?[A-Za-z])(\d+)\:([A-Ia-i]?[A-Za-z])(\d+)$/", $range)) {
-            list($cell1, $cell2) = split(':', $range);
+            list($cell1, $cell2) = preg_split('/:/', $range);
         } elseif (preg_match("/^([A-Ia-i]?[A-Za-z])(\d+)\.\.([A-Ia-i]?[A-Za-z])(\d+)$/", $range)) {
-            list($cell1, $cell2) = split('\.\.', $range);
+            list($cell1, $cell2) = preg_split('/\.\./', $range);
 
         } else {
             // TODO: use real error codes
@@ -727,7 +727,7 @@ class Spreadsheet_Excel_Writer_Parser extends PEAR
         $class = 2; // as far as I know, this is magick.
 
         // Split the ref at the ! symbol
-        list($ext_ref, $range) = split('!', $token);
+        list($ext_ref, $range) = preg_split('/!/', $token);
 
         // Convert the external reference part (different for BIFF8)
         if ($this->_BIFF_version == 0x0500) {
@@ -743,7 +743,7 @@ class Spreadsheet_Excel_Writer_Parser extends PEAR
         }
 
         // Split the range into 2 cell refs
-        list($cell1, $cell2) = split(':', $range);
+        list($cell1, $cell2) = preg_split('/:/', $range);
 
         // Convert the cell references
         if (preg_match("/^(\$)?[A-Ia-i]?[A-Za-z](\$)?(\d+)$/", $cell1)) {
@@ -824,7 +824,7 @@ class Spreadsheet_Excel_Writer_Parser extends PEAR
         $class = 2; // as far as I know, this is magick.
 
         // Split the ref at the ! symbol
-        list($ext_ref, $cell) = split('!', $cell);
+        list($ext_ref, $cell) = preg_split('/!/', $cell);
 
         // Convert the external reference part (different for BIFF8)
         if ($this->_BIFF_version == 0x0500) {
@@ -871,7 +871,7 @@ class Spreadsheet_Excel_Writer_Parser extends PEAR
 
         // Check if there is a sheet range eg., Sheet1:Sheet2.
         if (preg_match("/:/", $ext_ref)) {
-            list($sheet_name1, $sheet_name2) = split(':', $ext_ref);
+            list($sheet_name1, $sheet_name2) = preg_split('/:/', $ext_ref);
 
             $sheet1 = $this->_getSheetIndex($sheet_name1);
             if ($sheet1 == -1) {
@@ -917,7 +917,7 @@ class Spreadsheet_Excel_Writer_Parser extends PEAR
 
         // Check if there is a sheet range eg., Sheet1:Sheet2.
         if (preg_match("/:/", $ext_ref)) {
-            list($sheet_name1, $sheet_name2) = split(':', $ext_ref);
+            list($sheet_name1, $sheet_name2) = preg_split('/:/', $ext_ref);
 
             $sheet1 = $this->_getSheetIndex($sheet_name1);
             if ($sheet1 == -1) {

--- a/functions/PEAR/Spreadsheet/Excel/Writer/Worksheet.php
+++ b/functions/PEAR/Spreadsheet/Excel/Writer/Worksheet.php
@@ -1349,7 +1349,7 @@ class Spreadsheet_Excel_Writer_Worksheet extends Spreadsheet_Excel_Writer_BIFFwr
         $row     = $match[2];
 
         // Convert base26 column string to number
-        $chars = split('', $col);
+        $chars = preg_split('//', $col);
         $expn  = 0;
         $col   = 0;
 
@@ -2068,7 +2068,7 @@ class Spreadsheet_Excel_Writer_Worksheet extends Spreadsheet_Excel_Writer_BIFFwr
         // parameters accordingly.
         // Split the dir name and sheet name (if it exists)
         /*if (preg_match("/\#/", $url)) {
-            list($dir_long, $sheet) = split("\#", $url);
+            list($dir_long, $sheet) = preg_split('/\#/', $url);
         } else {
             $dir_long = $url;
         }
@@ -2076,7 +2076,7 @@ class Spreadsheet_Excel_Writer_Worksheet extends Spreadsheet_Excel_Writer_BIFFwr
         if (isset($sheet)) {
             $link_type |= 0x08;
             $sheet_len  = pack("V", strlen($sheet) + 0x01);
-            $sheet      = join("\0", split('', $sheet));
+            $sheet      = join("\0", preg_split('//', $sheet));
             $sheet     .= "\0\0\0";
         } else {
             $sheet_len   = '';
@@ -2100,7 +2100,7 @@ class Spreadsheet_Excel_Writer_Worksheet extends Spreadsheet_Excel_Writer_BIFFwr
         $dir_short   = preg_replace("/\.\.\\\/", '', $dir_long) . "\0";
 
         // Store the long dir name as a wchar string (non-null terminated)
-        //$dir_long       = join("\0", split('', $dir_long));
+        //$dir_long       = join("\0", preg_split('//', $dir_long));
         $dir_long       = $dir_long . "\0";
 
         // Pack the lengths of the dir strings

--- a/functions/php-excel-reader/excel_reader2.php
+++ b/functions/php-excel-reader/excel_reader2.php
@@ -76,7 +76,7 @@ function GetInt4d($data, $pos) {
 // http://uk.php.net/manual/en/function.getdate.php
 function gmgetdate($ts = null){
 	$k = array('seconds','minutes','hours','mday','wday','mon','year','yday','weekday','month',0);
-	return(array_comb($k,split(":",gmdate('s:i:G:j:w:n:Y:z:l:F:U',is_null($ts)?time():$ts))));
+	return(array_comb($k,preg_split('/:/',gmdate('s:i:G:j:w:n:Y:z:l:F:U',is_null($ts)?time():$ts))));
 	}
 
 // Added for PHP4 compatibility
@@ -841,7 +841,7 @@ class Spreadsheet_Excel_Reader {
 
 		// Custom pattern can be POSITIVE;NEGATIVE;ZERO
 		// The "text" option as 4th parameter is not handled
-		$parts = split(";",$format);
+		$parts = preg_split('/;/',$format);
 		$pattern = $parts[0];
 		// Negative pattern
 		if (count($parts)>2 && $num==0) {


### PR DESCRIPTION
Replace DEPRECATED split() function.
http://php.net/manual/en/function.split.php

This function was DEPRECATED in PHP 5.3.0, and REMOVED in PHP 7.0.0.