### PR TITLE
Rename class Thread to PingThread to avoid naming conflict with pthreads Thread class

### DIFF
--- a/functions/classes/class.Thread.php
+++ b/functions/classes/class.Thread.php
@@ -7,7 +7,7 @@
 * @author Tudor Barbu <miau@motane.lu>
 * @copyright MIT
 */
-class Thread {
+class PingThread {
     const FUNCTION_NOT_CALLABLE = 10;
     const COULD_NOT_FORK = 15;
 
@@ -17,8 +17,8 @@ class Thread {
 	* @var array
 	*/
     private $errors = array(
-        Thread::FUNCTION_NOT_CALLABLE => 'You must specify a valid function name that can be called from the current scope.',
-        Thread::COULD_NOT_FORK => 'pcntl_fork() returned a status of -1. No new process was created',
+        PingThread::FUNCTION_NOT_CALLABLE => 'You must specify a valid function name that can be called from the current scope.',
+        PingThread::COULD_NOT_FORK => 'pcntl_fork() returned a status of -1. No new process was created',
     );
 
 	/**
@@ -89,7 +89,7 @@ class Thread {
             $this->runnable = $_runnable;
         }
         else {
-            throw new Exception( $this->getError( Thread::FUNCTION_NOT_CALLABLE ), Thread::FUNCTION_NOT_CALLABLE );
+            throw new Exception( $this->getError( PingThread::FUNCTION_NOT_CALLABLE ), PingThread::FUNCTION_NOT_CALLABLE );
         }
     }
 
@@ -162,7 +162,7 @@ class Thread {
     public function start() {
         $pid = @ pcntl_fork();
         if( $pid == -1 ) {
-            throw new Exception( $this->getError( Thread::COULD_NOT_FORK ), Thread::COULD_NOT_FORK );
+            throw new Exception( $this->getError( PingThread::COULD_NOT_FORK ), PingThread::COULD_NOT_FORK );
         }
         if( $pid ) {
             // parent
@@ -197,7 +197,7 @@ class Thread {
 		$pid = pcntl_fork();
 
 		if( $pid == -1 ) { //error forking, no child is created
-			throw new Exception( $this->getError( Thread::COULD_NOT_FORK ), Thread::COULD_NOT_FORK );
+			throw new Exception( $this->getError( PingThread::COULD_NOT_FORK ), PingThread::COULD_NOT_FORK );
 		}else if ( $pid ) {// parent
 			$this->pid = $pid;
 

--- a/functions/scan/subnet-scan-icmp-execute.php
+++ b/functions/scan/subnet-scan-icmp-execute.php
@@ -51,7 +51,7 @@ if(php_sapi_name()!="cli") 								{ die(json_encode(array("status"=>1, "error"=
 if(!isset($argv[1]) || !isset($argv[2]))				{ die(json_encode(array("status"=>1, "error"=>"Missing required input parameters"))); }
 // test to see if threading is available
 if($Scan->settings->scanPingType!="fping")
-if( !Thread::available() ) 								{ die(json_encode(array("status"=>1, "error"=>"Threading is required for scanning subnets. Please recompile PHP with pcntl extension"))); }
+if( !PingThread::available() ) 								{ die(json_encode(array("status"=>1, "error"=>"Threading is required for scanning subnets. Please recompile PHP with pcntl extension"))); }
 //check script
 if($argv[1]!="update"&&$argv[1]!="discovery")			{ die(json_encode(array("status"=>1, "error"=>"Invalid scan type!"))); }
 //verify cidr
@@ -142,7 +142,7 @@ else {
 	    	//only if index exists!
 	    	if(isset($scan_addresses[$z])) {
 				//start new thread
-	            $threads[$z] = new Thread( "ping_address" );
+	            $threads[$z] = new PingThread( "ping_address" );
 	            $threads[$z]->start( $Subnets->transform_to_dotted($scan_addresses[$z], true) );
 
 	            $z++;				//next index

--- a/functions/scan/subnet-scan-telnet-execute.php
+++ b/functions/scan/subnet-scan-telnet-execute.php
@@ -42,7 +42,7 @@ if(php_sapi_name()!="cli") 								{ die(json_encode(array("status"=>1, "error"=
 //check input parameters
 if(!isset($argv[1]) || !isset($argv[2]))				{ die(json_encode(array("status"=>1, "error"=>"Missing required input parameters"))); }
 // test to see if threading is available
-if( !Thread::available() ) 								{ die(json_encode(array("status"=>1, "error"=>"Threading is required for scanning subnets. Please recompile PHP with pcntl extension"))); }
+if( !PingThread::available() ) 								{ die(json_encode(array("status"=>1, "error"=>"Threading is required for scanning subnets. Please recompile PHP with pcntl extension"))); }
 
 /**
  *	Create array of addresses to scan
@@ -76,7 +76,7 @@ for ($m=0; $m<=sizeof($addresses); $m += $Scan->settings->scanMaxThreads) {
     	//only if index exists!
     	if(isset($addresses[$z])) {
 			//start new thread
-            $threads[$z] = new Thread( 'telnet_address' );
+            $threads[$z] = new PingThread( 'telnet_address' );
             $threads[$z]->start( $Subnets->transform_to_dotted($addresses[$z]['ip']), $addresses[$z]['port'], 2);
             $z++;				//next index
 		}

--- a/functions/scripts/discoveryCheck.php
+++ b/functions/scripts/discoveryCheck.php
@@ -61,7 +61,7 @@ $hostnames      = array();			// Array with detected hostnames
 // script can only be run from cli
 if(php_sapi_name()!="cli") 						{ die("This script can only be run from cli!"); }
 // test to see if threading is available
-if(!Thread::available()) 						{ die("Threading is required for scanning subnets. Please recompile PHP with pcntl extension"); }
+if(!PingThread::available()) 						{ die("Threading is required for scanning subnets. Please recompile PHP with pcntl extension"); }
 // verify ping path
 if ($Scan->icmp_type=="ping") {
 if(!file_exists($Scan->settings->scanPingPath)) { die("Invalid ping path!"); }
@@ -127,7 +127,7 @@ if($Scan->icmp_type=="fping") {
 	    	//only if index exists!
 	    	if(isset($scan_subnets[$z])) {
 				//start new thread
-	            $threads[$z] = new Thread( 'fping_subnet' );
+	            $threads[$z] = new PingThread( 'fping_subnet' );
 				$threads[$z]->start_fping( $Subnets->transform_to_dotted($scan_subnets[$z]->subnet)."/".$scan_subnets[$z]->mask );
 	            $z++;				//next index
 			}
@@ -181,7 +181,7 @@ else {
         	//only if index exists!
         	if(isset($addresses[$z])) {
 				//start new thread
-	            $threads[$z] = new Thread( 'ping_address' );
+	            $threads[$z] = new PingThread( 'ping_address' );
 	            $threads[$z]->start( $Subnets->transform_to_dotted($addresses[$z]['ip_addr']) );
 				$z++;			//next index
 			}

--- a/functions/scripts/pingCheck.php
+++ b/functions/scripts/pingCheck.php
@@ -71,7 +71,7 @@ $nowdate = date ("Y-m-d H:i:s");
 // script can only be run from cli
 if(php_sapi_name()!="cli") 						{ die("This script can only be run from cli!"); }
 // test to see if threading is available
-if(!Thread::available()) 						{ die("Threading is required for scanning subnets. Please recompile PHP with pcntl extension"); }
+if(!PingThread::available()) 						{ die("Threading is required for scanning subnets. Please recompile PHP with pcntl extension"); }
 // verify ping path
 if ($Scan->icmp_type=="ping") {
 if(!file_exists($Scan->settings->scanPingPath)) { die("Invalid ping path!"); }
@@ -139,7 +139,7 @@ if($Scan->icmp_type=="fping") {
 	    	//only if index exists!
 	    	if(isset($subnets[$z])) {
 				//start new thread
-	            $threads[$z] = new Thread( 'fping_subnet' );
+	            $threads[$z] = new PingThread( 'fping_subnet' );
 	            $threads[$z]->start_fping( $subnets[$z]['cidr'] );
 	            $z++;				//next index
 			}
@@ -205,7 +205,7 @@ else {
 	    	//only if index exists!
 	    	if(isset($addresses[$z])) {
 				//start new thread
-	            $threads[$z] = new Thread( 'ping_address' );
+	            $threads[$z] = new PingThread( 'ping_address' );
 	            $threads[$z]->start($Subnets->transform_to_dotted($addresses[$z]['ip_addr']));
 	            $z++;				//next index
 			}


### PR DESCRIPTION
Rename class Thread to PingThread to avoid naming conflict with pthreads builtin class.
http://php.net/manual/en/class.thread.php

    > phpcompatinfo analyser:run phpipam migration
    Cannot redeclare class Thread() provided by extension pthreads is added since 5.3.0