### PR TITLE
Update phpipam.po

### DIFF
--- a/functions/locale/fr_FR.UTF-8/LC_MESSAGES/phpipam.po
+++ b/functions/locale/fr_FR.UTF-8/LC_MESSAGES/phpipam.po
@@ -4602,7 +4602,7 @@ msgid "Discover"
 msgstr "Découvrir"
 
 msgid "Back"
-msgstr "Retour"
+msgstr "Back"
 
 msgid "l2 domain"
 msgstr "Domaine l2"


### PR DESCRIPTION
Translation error for Rack, replacing "Retour" by "Back" of rack (=> front / back)