### PR TITLE
Fix PHP Warning.

### DIFF
--- a/app/admin/racks/edit-rack-devices.php
+++ b/app/admin/racks/edit-rack-devices.php
@@ -143,10 +143,12 @@ $(document).ready(function(){
                             }
                         }
                         // back side
-                        foreach ($rack_devices as $d) {
-                            for($m=$d->rack_start; $m<=($d->rack_start+($d->rack_size-1)); $m++) {
-                                if(array_key_exists($m, $available_back)) {
-                                    unset($available_back[$m]);
+                        if($rack->hasBack!="0") {
+                            foreach ($rack_devices as $d) {
+                                for($m=$d->rack_start; $m<=($d->rack_start+($d->rack_size-1)); $m++) {
+                                    if(array_key_exists($m, $available_back)) {
+                                        unset($available_back[$m]);
+                                    }
                                 }
                             }
                         }


### PR DESCRIPTION
Fix PHP warnings.

We can't use the "available_back" variable on racks that only have a front side as this variable is undefined.

PHP Warning:  array_key_exists() expects parameter 2 to be array, null given in phpipam/app/admin/racks/edit-rack-devices.php on line 148,