### PR TITLE
Performance fix for multiple locations #1415

### DIFF
--- a/functions/classes/class.Tools.php
+++ b/functions/classes/class.Tools.php
@@ -2778,6 +2778,7 @@ class Tools extends Common_functions {
     public function fetch_location_objects ($id = false, $count = false) {
         // check
         if(is_numeric($id)) {
+            $id = $this->Database->escape ($id);
             // count ?
             $select = $count ? "count(*) as cnt " : "*";
             // query
@@ -2787,36 +2788,47 @@ class Tools extends Common_functions {
                         FROM devices d
                         JOIN locations l
                         ON d.location = l.id
+                        WHERE l.id = $id
+
                         UNION ALL
                         SELECT r.id, r.name, '' as mask, 'racks' as type, '' as sectionId, r.location, r.description
                         FROM racks r
                         JOIN locations l
                         ON r.location = l.id
+                        WHERE l.id = $id
+
                         UNION ALL
                         SELECT s.id, s.subnet as name, s.mask, 'subnets' as type, s.sectionId, s.location, s.description
                         FROM subnets s
                         JOIN locations l
                         ON s.location = l.id
+                        WHERE l.id = $id
+
                         UNION ALL
                         SELECT a.id, a.ip_addr as name, 'mask', 'addresses' as type, a.subnetId as sectionId, a.location, a.dns_name as description
                         FROM ipaddresses a
                         JOIN locations l
                         ON a.location = l.id
+                        WHERE l.id = $id
+
                         UNION ALL
                         SELECT c.id, c.cid as name, 'mask', 'circuit' as type, 'none' as sectionId, c.location2, 'none' as description
                         FROM circuits c
                         JOIN locations l
                         ON c.location1 = l.id
+                        WHERE l.id = $id
+
                         UNION ALL
                         SELECT c.id, c.cid as name, 'mask', 'circuit' as type, 'none' as sectionId, c.location2, '' as description
                         FROM circuits c
                         JOIN locations l
                         ON c.location2 = l.id
+                        WHERE l.id = $id
                         )
-                        as linked where location = ?;";
+                        as linked;";
 
      		// fetch
-    		try { $objects = $this->Database->getObjectsQuery($query, array($id)); }
+    		try { $objects = $this->Database->getObjectsQuery($query); }
     		catch (Exception $e) { $this->Result->show("danger", $e->getMessage(), true); }
 
     		// return


### PR DESCRIPTION
Fix for #1415

To avoid pulling in a UNION ALL of every row in the database and
then filtering the combined results move the WHERE clause into each
SQL sub-query to only fetch the rows we actually need.

Best performance when location is indexed.

	ALTER TABLE `devices` ADD INDEX (`location`);
	ALTER TABLE `racks` ADD INDEX (`location`);
	ALTER TABLE `subnets` ADD INDEX (`location`);
	ALTER TABLE `ipaddresses` ADD INDEX (`location`);
	ALTER TABLE `circuits` ADD INDEX (`location1`);
	ALTER TABLE `circuits` ADD INDEX (`location2`);