### PR TITLE
Improved error message for bad subnet in IP import

### DIFF
--- a/app/admin/import-export/import-ipaddr-check.php
+++ b/app/admin/import-export/import-ipaddr-check.php
@@ -153,7 +153,7 @@ foreach ($data as &$cdata) {
 	# Check if Subnet is provided and valid and link it if it is
 	if ((!empty($cdata['subnet'])) and (!empty($cdata['mask']))) {
 		if (!isset($subnet_data[$cdata['sectionId']][$cdata['vrfId']][$cdata['subnet']][$cdata['mask']])) {
-			$msg.= "Invalid Subnet."; $action = "error";
+			$msg.= "Invalid Subnet. Confirm that the subnet exists before importing into it."; $action = "error";
 		} else {
 			$cdata['subnetId'] = $subnet_data[$cdata['sectionId']][$cdata['vrfId']][$cdata['subnet']][$cdata['mask']]['id'];
 		}


### PR DESCRIPTION
Provided more information in case a bad subnet is given during IP address import. 

We found that this often happens because the user forgot to create the subnet before trying to import the IPs into the subnet and this helps them remember.