### PR TITLE
trim trailing spaces on import field names

### DIFF
--- a/app/admin/import-export/import-load-data.php
+++ b/app/admin/import-export/import-load-data.php
@@ -31,8 +31,8 @@ $hiddenfields="";
 
 # read field mapping from previous window
 foreach ($expfields as $expfield) {
-	if (isset($_GET['importFields__'.str_replace(" ", "_",$expfield)])) {
-		$impfield = $_GET['importFields__'.str_replace(" ", "_",$expfield)];
+	if (isset($_GET['importFields__'.str_replace(" ", "_",trim($expfield))])) {
+		$impfield = $_GET['importFields__'.str_replace(" ", "_",trim($expfield))];
 		if (in_array($expfield,$reqfields) && ($impfield == "-")) {
 			$Result->show('danger', _("Error: missing required field mapping for expected field")." <b>".$expfield."</b>."._("Please check field matching in previous window."), true, true);
 		} else {
@@ -44,7 +44,7 @@ foreach ($expfields as $expfield) {
 	# prepare header row for preview table
 	$hrow.="<th>".$expfield."</th>";
 	# prepare select field to transfer to actual import file
-	$hiddenfields.="<input name='importFields__".str_replace(" ", "_",$expfield)."' type='hidden' value='".$impfield."' style='display:none;'>";
+	$hiddenfields.="<input name='importFields__".str_replace(" ", "_",trim($expfield))."' type='hidden' value='".$impfield."' style='display:none;'>";
 }
 
 $data = array();


### PR DESCRIPTION
Had an employee spend a good 20 minutes troubleshooting why the import wouldn't work just to find out that there was a trailing space behind "subnet " causing it to be turned into "subnet_" and not matching.

This change works well for us, so perhaps others can use it too.