### PR TITLE
Import ipaddr frontend improvements

### DIFF
--- a/app/admin/import-export/import-button.php
+++ b/app/admin/import-export/import-button.php
@@ -122,7 +122,7 @@ $(function(){
 						var s = $('<select name="importFields__' + expfield.replace(/\s/g,"_") + '" class="form-control input-sm input-w-auto" rel="tooltip" data-placement="bottom" title="<?php print _("Pick import colum for"); ?> ' + expfield + ' <?php print _("field"); ?>"/>');
 						$('<option />', {value: "-", text: "-"}).appendTo(s);
 						resp.impfields.forEach(function(impfield) {
-							if (expfield.toUpperCase() === impfield.toUpperCase()) {
+                                                        if (expfield.toUpperCase() === impfield.toUpperCase().replace("IP ADDRESS", "IP_ADDR").replace("HOSTNAME", "DNS_NAME")) {
 								$('<option />', {value: impfield, text: impfield, selected: true}).appendTo(s);
 								matches++;
 							} else {

--- a/app/admin/import-export/import-ipaddr-select.php
+++ b/app/admin/import-export/import-ipaddr-select.php
@@ -47,13 +47,13 @@ $extfields["tag"]["pname"] = "tag";
 ## using the extra fields as a trick to display some nicer names for these regular fields
 $extfields["ip_addr"]["table"] = "ipaddresses";
 $extfields["ip_addr"]["field"] = "ip_addr";
-$extfields["ip_addr"]["pname"] = "IP address";
+$extfields["ip_addr"]["pname"] = "ip address";
 $extfields["dns_name"]["table"] = "ipaddresses";
 $extfields["dns_name"]["field"] = "dns_name";
-$extfields["dns_name"]["pname"] = "Hostname";
+$extfields["dns_name"]["pname"] = "hostname";
 $extfields["gateway"]["table"] = "ipaddresses";
 $extfields["gateway"]["field"] = "is_gateway";
-$extfields["gateway"]["pname"] = "Gateway";
+$extfields["gateway"]["pname"] = "gateway";
 
 # required fields without which we will not continue
 $reqfields = array("section","ip_addr","subnet");

--- a/app/admin/import-export/import-template.php
+++ b/app/admin/import-export/import-template.php
@@ -48,16 +48,16 @@ elseif ($type == 'ipaddr'){
 	// "section","ip_addr","dns_name","description","vrf","subnet","mac","owner","device","note","tag","gateway"
 	$worksheet->write($lineCount, 0, _('Section'));
 	$worksheet->write($lineCount, 1, _('IP address'));
-	$worksheet->write($lineCount, 2, _('DNS Hostname'));
+	$worksheet->write($lineCount, 2, _('Hostname'));
 	$worksheet->write($lineCount, 3, _('Description'));
 	$worksheet->write($lineCount, 4, _('VRF'));
-	$worksheet->write($lineCount, 4, _('Subnet'));
-	$worksheet->write($lineCount, 5, _('MAC'));
-	$worksheet->write($lineCount, 6, _('Owner'));
-	$worksheet->write($lineCount, 7, _('Device'));
-	$worksheet->write($lineCount, 8, _('Note'));
-	$worksheet->write($lineCount, 9, _('Tag'));
-	$worksheet->write($lineCount, 10, _('Gateway'));
+	$worksheet->write($lineCount, 5, _('Subnet'));
+	$worksheet->write($lineCount, 6, _('MAC'));
+	$worksheet->write($lineCount, 7, _('Owner'));
+	$worksheet->write($lineCount, 8, _('Device'));
+	$worksheet->write($lineCount, 9, _('Note'));
+	$worksheet->write($lineCount, 10, _('Tag'));
+	$worksheet->write($lineCount, 11, _('Gateway'));
 	$fc =7 ;
 	foreach($custom_address_fields as $k=>$f) {
 		$worksheet->write($lineCount, $fc, $k);


### PR DESCRIPTION
New employees have a bit of trouble figuring out the ip address import functionality due to inconsistencies between what the frontend said, what the backend expected, and the broken template file that was missing a column and used the wrong naming convention.

I made a couple of changes in each respective file to make the overall ip address import process more intuitive.