### PR TITLE
Issue 1440 fix: CSV Import fails when delimiter is different from coma.

### DIFF
--- a/app/admin/import-export/import-load-data.php
+++ b/app/admin/import-export/import-load-data.php
@@ -54,12 +54,11 @@ if (strtolower($filetype) == "csv") {
 	# open CSV file
 	$filehdl = fopen('upload/data_import.csv', 'r');
 
-	# set delimiter
-	$Tools->set_csv_delimiter ($filehdl);
-
 	# read header row
 	$row = 0;$col = 0;
 	$line = fgets($filehdl);
+	# set delimiter
+	$Tools->set_csv_delimiter ($line);
 	$row++;
 	$line = str_replace( array("\r\n","\r","\n") , "" , $line);	//remove line break
 	$cols = str_getcsv ($line, $Tools->csv_delimiter);

--- a/app/admin/import-export/import-verify.php
+++ b/app/admin/import-export/import-verify.php
@@ -60,7 +60,8 @@ if(isset($_FILES['file']) && $_FILES['file']['error'] == 0) {
 		fclose($filehdl);
 
 		# set delimiter
-		$Tools->set_csv_delimiter ($filehdl);
+		#$Tools->set_csv_delimiter ($filehdl);
+		$Tools->set_csv_delimiter ($data);
 
 		/* format file */
 		$data = str_replace( array("\r\n","\r","\n") , "" , $data);	//remove line break


### PR DESCRIPTION
Fixes an error that occurs when importing a csv file using a delimiter different from coma.