### PR TITLE
Ensure password filds is correct file/size

### DIFF
--- a/db/UPDATE.sql
+++ b/db/UPDATE.sql
@@ -1,4 +1,9 @@
 /* VERSION 1.1 */
+
+/* Old version only had a VARCHAR(32) password */
+
+ALTER TABLE `users` MODIFY COLUMN `password` CHAR(128) COLLATE utf8_bin DEFAULT NULL ;
+
 /* VERSION 1.11 */
 UPDATE `settings` set `version` = '1.11';
 


### PR DESCRIPTION
Old versions (1.0 for eg) had the passwords stored as a VARCHAR(32).

This ensure that the password column in the users table is the same size and type as the current schema, allowing upgrades from old versions.