### PR TITLE
Custom fields can not be deleted

### DIFF
--- a/app/admin/custom-fields/edit-result.php
+++ b/app/admin/custom-fields/edit-result.php
@@ -28,6 +28,8 @@ $User->csrf_cookie ("validate", "custom_field", $_POST['csrf_cookie']) === false
 /* checks */
 if($_POST['action'] == "delete") {
 	# no cecks
+	# set name to oldname so custom field can be dropped
+	$_POST['name'] = $_POST['oldname'];
 }
 else {
 	# remove spaces


### PR DESCRIPTION
Fixes an error where custom fields can not be deleted because it uses the database field name without the 'custom_' prefix.