### PR TITLE
Use defaults for custom fields when using all-add

### DIFF
--- a/app/subnets/addresses/address-modify.php
+++ b/app/subnets/addresses/address-modify.php
@@ -528,7 +528,7 @@ function validate_mac (ip, mac, sectionId, vlanId, id) {
 			else						{ $required = ""; }
 
 			# set default value !
-			if ($_POST['action']=="add")	{ $address[$field['name']] = $field['Default']; }
+			if ($_POST['action']=="add" || $_POST['action']=="all-add")	{ $address[$field['name']] = $field['Default']; }
 
 			print '<tr>'. "\n";
 			print '	<td>'. $Tools->print_custom_field_name ($field['name']) .' '.$required.'</td>'. "\n";


### PR DESCRIPTION
Without this, when you do a "all-add", custom fields do not get their default values.