### PR TITLE
Introduce mcrypt AES compatibility...

### DIFF
--- a/api/index.php
+++ b/api/index.php
@@ -24,6 +24,7 @@ require( dirname(__FILE__) . '/controllers/Responses.php');			// exception, head
 
 # settings
 $enable_authentication = true;
+$aes_compliant_crypt   = false;         // Default to false for backward compatibility. Use true to use AES-256 compliant RIJNDAEL algorythm (rijndael-128)
 $time_response         = true;          // adds [time] to response
 $lock_file             = "";            // (optional) file to write lock to
 
@@ -71,7 +72,7 @@ try {
 		}
 		// decrypt request - form_encoded
         if(strpos($_SERVER['CONTENT_TYPE'], "application/x-www-form-urlencoded")!==false) {
-        	$decoded = trim(mcrypt_decrypt(MCRYPT_RIJNDAEL_256, $app->app_code, base64_decode($_GET['enc_request']), MCRYPT_MODE_ECB));
+        	$decoded = trim(mcrypt_decrypt($aes_compliant_crypt?MCRYPT_RIJNDAEL_128:MCRYPT_RIJNDAEL_256, $app->app_code, base64_decode($_GET['enc_request']), MCRYPT_MODE_ECB));
         	$decoded = $decoded[0]=="?" ? substr($decoded, 1) : $decoded;
 			parse_str($decoded, $params);
 			$params = (object) $params;


### PR DESCRIPTION
...using rijndael-128 algorythm, while preserving backward compatibility. 

According to http://php.net/manual/en/function.mcrypt-encrypt.php#117667, MCRYPT_RIJNDAEL_256 is not AES-256 while MCRYPT_RIJNDAEL_128 with 32bit key is.

Moreover it is very difficult to find and use a stable and working implementation of rijndael-256 in python, as discussed in #1463.
