### PR TITLE
Fix phpIP{AM proxying to nonstandard port on backend

### DIFF
--- a/functions/classes/class.Common.php
+++ b/functions/classes/class.Common.php
@@ -817,7 +817,7 @@ class Common_functions  {
 			$url = "https://$_SERVER[SERVER_NAME]";
 		}
 		// custom port
-		elseif($_SERVER['SERVER_PORT']!="80") {
+		elseif($_SERVER['SERVER_PORT']!="80" && (isset($_SERVER['HTTP_X_FORWARDED_PORT']) && $_SERVER['HTTP_X_FORWARDED_PORT']!="80")) {
 			$url = "http://$_SERVER[SERVER_NAME]:$_SERVER[SERVER_PORT]";
 		}
 		// normal http


### PR DESCRIPTION
When running phpIP{AM behind a reverse proxy with the backend nonstandard port the custom port rule will trigger. This PR fixes that case and causes phpIP{AM to use the normal http rule.