### PR TITLE
Fix link created on IPv6 subnet details page

### DIFF
--- a/app/subnets/subnet-details/subnet-details.php
+++ b/app/subnets/subnet-details/subnet-details.php
@@ -404,7 +404,12 @@ else {
 			if ($domain!==false) {
 				if ($User->is_admin (false) || $User->user->pdns=="Yes") {
 				$btns[] = "<div class='btn-group'>";
-				$btns[] = " <a class='btn btn-default btn-xs' href='". create_link ("tools", "powerDNS", "reverse_v4", "records", $domain->name)."'><i class='fa fa-eye'></i></a>";
+            if (preg_match("/^.*ip6.arpa$/", $domain->name)) {
+				   $btns[] = " <a class='btn btn-default btn-xs' href='". create_link ("tools", "powerDNS", "reverse_v6", "records", $domain->name)."'><i class='fa fa-eye'></i></a>";
+            }
+            else {
+				   $btns[] = " <a class='btn btn-default btn-xs' href='". create_link ("tools", "powerDNS", "reverse_v4", "records", $domain->name)."'><i class='fa fa-eye'></i></a>";
+            }
 				$btns[] = "	<a class='btn btn-default btn-xs refreshPTRsubnet' data-subnetid='$subnet[id]'><i class='fa fa-refresh'></i></a>";
 				$btns[] = "</div>";
 				$btns = implode("\n", $btns);


### PR DESCRIPTION
Check whether the reverse DNS zone of the subnet is in ip6.arpa and if so, use reverse_v6 in the link
Fixes #1535