### PR TITLE
Fix for #1528

### DIFF
--- a/app/subnets/addresses/address-details/address-details.php
+++ b/app/subnets/addresses/address-details/address-details.php
@@ -119,7 +119,7 @@ if(sizeof($address)>1) {
         // get MAC vendor
         if($User->settings->decodeMAC=="1") {
             $mac_vendor = $User->get_mac_address_vendor_details ($address['mac']);
-            $mac_vendor = $mac_vendor=="" ? : " <span class='text-muted'>(".$mac_vendor.")</span>";
+            $mac_vendor = $mac_vendor==""||is_bool($mac_vendor) ? "" : " <span class='text-muted'>(".$mac_vendor.")</span>";
         }
         else {
             $mac_vendor = "";


### PR DESCRIPTION
Fix for #1528. If the vendor of an MAC can not be decoded, the number 1 is added as the last digit of the mac.
