### PR TITLE
class.Tools.php verify table/index fixes

### DIFF
--- a/db/SCHEMA.sql
+++ b/db/SCHEMA.sql
@@ -781,6 +781,8 @@ CREATE TABLE `pstnNumbers` (
 
 # Dump of table circuitProviders
 # ------------------------------------------------------------
+DROP TABLE IF EXISTS `circuitProviders`;
+
 CREATE TABLE `circuitProviders` (
   `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
   `name` varchar(256) DEFAULT NULL,
@@ -793,6 +795,8 @@ CREATE TABLE `circuitProviders` (
 
 # Dump of table circuits
 # ------------------------------------------------------------
+DROP TABLE IF EXISTS `circuits`;
+
 CREATE TABLE `circuits` (
   `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
   `cid` varchar(128) DEFAULT NULL,

--- a/functions/classes/class.Tools.php
+++ b/functions/classes/class.Tools.php
@@ -818,6 +818,18 @@ class Tools extends Common_functions {
 	}
 
 	/**
+	 * Read the SCHEMA.sql file and enforce UNIX LF
+	 *
+	 * @access private
+	 * @return array
+	 */
+	private function read_db_schema() {
+		$fh = fopen(dirname(__FILE__) . '/../../db/SCHEMA.sql', 'r');
+		$schema = str_replace("\r\n", "\n", fread($fh, 100000));
+		return $schema;
+	}
+
+	/**
 	 * Fetches standard database fields from SCHEMA.sql file
 	 *
 	 * @access public
@@ -826,9 +838,7 @@ class Tools extends Common_functions {
 	 */
 	public function fetch_standard_fields ($table) {
 		# get SCHEMA.SQL file
-		$schema = fopen(dirname(__FILE__) . "/../../db/SCHEMA.sql", "r");
-		$schema = fread($schema, 100000);
-		$schema = str_replace("\r\n", "\n", $schema);
+		$schema = $this->read_db_schema();
 
 		# get definition
 		$definition = strstr($schema, "CREATE TABLE `$table` (");
@@ -857,8 +867,7 @@ class Tools extends Common_functions {
 	 */
 	public function fetch_standard_tables () {
 		# get SCHEMA.SQL file
-		$schema = fopen(dirname(__FILE__) . "/../../db/SCHEMA.sql", "r");
-		$schema = fread($schema, 100000);
+		$schema = $this->read_db_schema();
 
 		# get definitions to array, explode with CREATE TABLE `
 		$creates = explode("CREATE TABLE `", $schema);
@@ -1356,8 +1365,7 @@ class Tools extends Common_functions {
 	 * @return false|string
 	 */
 	public function get_table_fix ($table) {
-		$res = fopen(dirname(__FILE__) . "/../../db/SCHEMA.sql", "r");
-		$file = fread($res, 100000);
+		$file = $this->read_db_schema();
 
 		//go from delimiter on
 		$file = strstr($file, "DROP TABLE IF EXISTS `$table`;");
@@ -1377,9 +1385,7 @@ class Tools extends Common_functions {
 	 * @return string|false
 	 */
 	public function get_field_fix ($table, $field) {
-		$res = fopen(dirname(__FILE__) . "/../../db/SCHEMA.sql", "r");
-		$file = fread($res, 100000);
-		$file = str_replace("\r\n", "\n", $file);
+		$file = $this->read_db_schema();
 
 		//go from delimiter on
 		$file = strstr($file, "DROP TABLE IF EXISTS `$table`;");
@@ -1531,9 +1537,7 @@ class Tools extends Common_functions {
 	 */
 	private function fix_missing_index ($table, $index_name) {
 		// get definition
-		$res = fopen(dirname(__FILE__) . "/../../db/SCHEMA.sql", "r");
-		$file = fread($res, 100000);
-		$file = str_replace("\r\n", "\n", $file);
+		$file = $this->read_db_schema();
 
 		//go from delimiter on
 		$file = strstr($file, "DROP TABLE IF EXISTS `$table`;");

--- a/functions/classes/class.Tools.php
+++ b/functions/classes/class.Tools.php
@@ -1481,17 +1481,26 @@ class Tools extends Common_functions {
 	 * @return array
 	 */
 	private function get_schema_indexes () {
-		// indexes required for phpipam
+		// Discover indexes required for phpipam
+		$schema = $this->read_db_schema();
+
+		# get definitions to array, explode with CREATE TABLE `
+		$creates = explode("CREATE TABLE `", $schema);
+
 		$indexes = array ();
-		$indexes['ipaddresses']   = array ("sid_ip_unique", "subnetid");
-		$indexes['sections']      = array ("id_2");
-		$indexes['devices']       = array ("hostname");
-		$indexes['users']         = array ("id_2");
-		$indexes['api']           = array ("app_id");
-		$indexes['changelog']     = array ("coid", "ctype");
-		$indexes['loginAttempts'] = array ("ip");
-		$indexes['scanAgents']    = array ("code");
-		// return
+		foreach($creates as $k=>$c) {
+			if($k == 0) continue;
+			$c = trim(strstr($c, ";" . "\n", true));
+
+			$table = strstr($c, "`", true);
+
+			$definitions = explode("\n", $c);
+			foreach($definitions as $definition) {
+				if (preg_match('/(KEY|UNIQUE KEY) +`(.*)` +\(/', $definition, $matches)) {
+					$indexes[$table][] = $matches[2];
+				}
+			}
+		}
 		return $indexes;
 	}
 


### PR DESCRIPTION
- Add missing DROP TABLE IF EXISTS lines in db/SCHEMA.sql.
class.Tools.php table and index verification functions expect the following lines in db/SCHEMA.sql for each table.

```
# Dump of table <tablename>
# ------------------------------------------------------------
DROP TABLE IF EXISTS `<tablename>`;
 

//go from delimiter on
$file = strstr($file, "DROP TABLE IF EXISTS `$table`;");
$file = trim(strstr($file, "# Dump of table", true));
```

- Factor out repeated read_db_schema() code to read db/SCHEMA.sql file and consistently enforce UNIX LF.

- Update Tools->get_schema_indexes()
Generate list of required index dynamically from db/SCHEMA.sql instead of using a static array().

@phpipam Can you please review?