### PR TITLE
Ignore local changes to the git submodule directories by default

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,9 +3,12 @@
 [submodule "functions/php-saml"]
 	path = functions/php-saml
 	url = https://github.com/onelogin/php-saml.git
+	ignore = all
 [submodule "functions/PHPMailer"]
 	path = functions/PHPMailer
 	url = https://github.com/PHPMailer/PHPMailer.git
+	ignore = all
 [submodule "app/login/captcha"]
 	path = app/login/captcha
 	url = https://github.com/dapphp/securimage.git
+	ignore = all


### PR DESCRIPTION
This avoids accidentally including local submodule changes in PRs using "git add -a" and de-clutters "git status". Changes to submodules can still be explicitly added and commited if required:

	git add app/login/captcha
	git add functions/PHPMailer
	git add functions/php-saml