### PR TITLE
Allow DNS wildcard records

### DIFF
--- a/functions/classes/class.PowerDNS.php
+++ b/functions/classes/class.PowerDNS.php
@@ -1223,6 +1223,11 @@ class PowerDNS extends Common_functions {
             { return $name; }
         }
 
+        // DNS wildcard records are OK (https://tools.ietf.org/html/rfc4592#section-2.1.1)
+        if (preg_match("/^\*\..*$/", $name) && $this->validate_hostname(substr($name, 2))) {
+            return $name;
+        }
+
         // for all other record types null is ok, otherwise URI is required
         if (strlen($name)>0 && !$this->validate_hostname($name)){ $this->Result->show("danger", _("Invalid record name"), true); }
         // ok


### PR DESCRIPTION
As a DNS wildcard record starts with "\*."
(https://tools.ietf.org/html/rfc4592#section-2.1.1) this proposes
an additional validate_record_name check to allow for such
records. To pass the check a record's name has to begin with "*."
and its remaining substring has to pass function
"validate_hostname".