### PR TITLE
Fix off-by-one and index lookup errors in discoveryCheck.php and pingCheck.php

### DIFF
--- a/functions/scripts/discoveryCheck.php
+++ b/functions/scripts/discoveryCheck.php
@@ -109,27 +109,24 @@ if($scan_subnets===false || !count($scan_subnets)) { die("No subnets are marked 
 if($Scan->debugging)							{ print "Using $Scan->icmp_type\n--------------------\n\n"; }
 
 
-$z = 0;			//addresses array index
-
 // let's just reindex the subnets array to save future issues
 $scan_subnets   = array_values($scan_subnets);
-$size_subnets   = count($scan_subnets);
-$size_addresses = max(array_keys($addresses));
 
 //different scan for fping
 if($Scan->icmp_type=="fping") {
 	//run per MAX_THREADS
-	for ($m=0; $m<=$size_subnets; $m += $Scan->settings->scanMaxThreads) {
+	$size_subnets = sizeof($scan_subnets);
+	for ($m=0; $m<$size_subnets; $m += $Scan->settings->scanMaxThreads) {
 	    // create threads
 	    $threads = array();
 	    //fork processes
-	    for ($i = 0; $i <= $Scan->settings->scanMaxThreads && $i <= $size_subnets; $i++) {
+	    for ($i = 0; $i < $Scan->settings->scanMaxThreads; $i++) {
+	    	$z = $m + $i;
 	    	//only if index exists!
 	    	if(isset($scan_subnets[$z])) {
 				//start new thread
 	            $threads[$z] = new PingThread( 'fping_subnet' );
 				$threads[$z]->start_fping( $Subnets->transform_to_dotted($scan_subnets[$z]->subnet)."/".$scan_subnets[$z]->mask );
-	            $z++;				//next index
 			}
 	    }
 	    // wait for all the threads to finish
@@ -172,18 +169,19 @@ if($Scan->icmp_type=="fping") {
 //ping, pear
 else {
 	//run per MAX_THREADS
+    $size_addresses = max(array_keys($addresses));
     for ($m=0; $m<=$size_addresses; $m += $Scan->settings->scanMaxThreads) {
         // create threads
         $threads = array();
 
         //fork processes
-        for ($i = 0; $i <= $Scan->settings->scanMaxThreads && $i <= $size_addresses; $i++) {
+        for ($i = 0; $i < $Scan->settings->scanMaxThreads; $i++) {
+        	$z = $m + $i;
         	//only if index exists!
         	if(isset($addresses[$z])) {
 				//start new thread
 	            $threads[$z] = new PingThread( 'ping_address' );
 	            $threads[$z]->start( $Subnets->transform_to_dotted($addresses[$z]['ip_addr']) );
-				$z++;			//next index
 			}
         }
 

--- a/functions/scripts/pingCheck.php
+++ b/functions/scripts/pingCheck.php
@@ -155,22 +155,21 @@ if(!isset($addresses))							{ die("No addresses to check"); }
 
 /* scan */
 
-$z = 0;			//addresses array index
-
 //different scan for fping
 if($Scan->icmp_type=="fping") {
 	//run per MAX_THREADS
-	for ($m=0; $m<=sizeof($subnets); $m += $Scan->settings->scanMaxThreads) {
+	$size_subnets = sizeof($subnets);
+	for ($m=0; $m<$size_subnets; $m += $Scan->settings->scanMaxThreads) {
 	    // create threads
 	    $threads = array();
 	    //fork processes
-	    for ($i = 0; $i <= $Scan->settings->scanMaxThreads && $i <= sizeof($subnets); $i++) {
+	    for ($i = 0; $i < $Scan->settings->scanMaxThreads; $i++) {
+			$z = $m + $i;
 	    	//only if index exists!
 	    	if(isset($subnets[$z])) {
 				//start new thread
 	            $threads[$z] = new PingThread( 'fping_subnet' );
 	            $threads[$z]->start_fping( $subnets[$z]['cidr'] );
-	            $z++;				//next index
 			}
 	    }
 	    // wait for all the threads to finish
@@ -238,17 +237,18 @@ if($Scan->icmp_type=="fping") {
 //ping, pear
 else {
 	//run per MAX_THREADS
-	for ($m=0; $m<=sizeof($addresses); $m += $Scan->settings->scanMaxThreads) {
+	$size_addresses = max(array_keys($addresses));
+	for ($m=0; $m<=$size_addresses; $m += $Scan->settings->scanMaxThreads) {
 	    // create threads
 	    $threads = array();
 	    //fork processes
-	    for ($i = 0; $i <= $Scan->settings->scanMaxThreads && $i <= sizeof($addresses); $i++) {
+	    for ($i = 0; $i < $Scan->settings->scanMaxThreads; $i++) {
+			$z = $m + $i;
 	    	//only if index exists!
 	    	if(isset($addresses[$z])) {
 				//start new thread
 	            $threads[$z] = new PingThread( 'ping_address' );
 	            $threads[$z]->start($Subnets->transform_to_dotted($addresses[$z]['ip_addr']));
-	            $z++;				//next index
 			}
 	    }
 	    // wait for all the threads to finish


### PR DESCRIPTION
Fix off-by-one indexing and thread-spawning counting issues.

Running pingCheck without these fixes consumes 100% CPU and quickly kills the RaspberryPI test box requiring a hard reset. I suspect that critical system processes are killed due to memory exhaustion (1Gig)