### PR TITLE
use x-real-ip in logs

### DIFF
--- a/functions/classes/class.Log.php
+++ b/functions/classes/class.Log.php
@@ -595,7 +595,7 @@ class Logging extends Common_functions {
 	    			"severity"=>$this->log_severity,
 	    			"date"=>$this->Database->toDate(),
 	    			"username"=>$this->log_username,
-	    			"ipaddr"=>@$_SERVER['REMOTE_ADDR'],
+	    			"ipaddr"=> array_key_exists('HTTP_X_REAL_IP', $_SERVER) ? $_SERVER['HTTP_X_REAL_IP'] : @$_SERVER['REMOTE_ADDR'],
 	    			"details"=>$this->log_details
 					);
 		# null empty values


### PR DESCRIPTION
Our phpipam is behind a proxy, I expect many others have similar setups - this means the actual source IP is stored in the logs