### PR TITLE
Misc Bugfixes

### DIFF
--- a/functions/classes/class.Common.php
+++ b/functions/classes/class.Common.php
@@ -645,7 +645,7 @@ class Common_functions  {
 	    elseif (strpos($address, ".")) 	{ return 'IPv4'; }
 	    # numeric representation
 	    elseif (is_numeric($address)) {
-	    	if(4294967295 > $address)	{ return 'IPv4'; }
+	    	if($address <= 4294967295)	{ return 'IPv4'; }	// 4294967295 = '255.255.255.255'
 	    	else 						{ return 'IPv6'; }
 	    }
 	    # decimal representation

--- a/functions/classes/class.Common.php
+++ b/functions/classes/class.Common.php
@@ -257,8 +257,8 @@ class Common_functions  {
 				$this->Result->show("danger", _("Error: ").$e->getMessage());
 				return false;
 			}
-			# save to cach
-			if (sizeof($res)>0) {
+			# save to cache
+			if ($result_fields==="*" && is_array($res)) { // Only cache objects containing all fields
     			foreach ($res as $r) {
         			$this->cache_write ($table, $r->id, $r);
     			}

--- a/functions/classes/class.Subnets.php
+++ b/functions/classes/class.Subnets.php
@@ -1040,19 +1040,10 @@ class Subnets extends Common_functions {
 	 * @return array|false
 	 */
 	public function fetch_subnet_slaves ($subnetId, $result_fields = "*") {
-    	// fetch
+		// fetch
 		$slaves = $this->fetch_multiple_objects ("subnets", "masterSubnetId", $subnetId, "subnet", true, false, $result_fields);
-		# save to subnets cache
-        if ($slaves!==false) {
-			foreach($slaves as $slave) {
-                $this->cache_write ("subnets", $slave->id, $slave);
-			}
-			return $slaves;
-		}
-		else {
-    		# no subnets
-    		return false;
-		}
+		//$slaves are saved to cache by Common_functions::fetch_multiple_objects()
+		return $slaves;
 	}
 
 	/**


### PR DESCRIPTION
- identify_address('255.255.255.255') should return 'IPv4'.

- Don't cache fetch_multiple_objects() requested with partial result fields (i.e not “*”). 
Future requests for these objects will be pulled from the cache and may require the missing fields. 
This is difficult to debug!

- Don't double cache results in fetch_subnet_slaves()
$slaves results can be large and are already saved to the cache by Common_functions::fetch_multiple_objects()