### PR TITLE
Fix Net:Ping deprecated class constructor warnings

### DIFF
--- a/functions/PEAR/Net/Ping.php
+++ b/functions/PEAR/Net/Ping.php
@@ -125,7 +125,7 @@ class Net_Ping
     *
     * @access private
     */
-    function Net_Ping($ping_path, $sysname)
+    function __construct($ping_path, $sysname)
     {
         $this->_ping_path = $ping_path;
         $this->_sysname   = $sysname;
@@ -661,7 +661,7 @@ class Net_Ping_Result
     *
     * @access private
     */
-    function Net_Ping_Result($result, $sysname)
+    function __construct($result, $sysname)
     {
         $this->_raw_data = $result;
 


### PR DESCRIPTION
Fix Net:Ping deprecated: Methods with the same name as their class will not be constructors in a future version of PHP warnings

 ```
function Net_Ping($ping_path, $sysname)     -> function __construct($ping_path, $sysname)
 function Net_Ping_Result($result, $sysname) -> function __construct($result, $sysname)
```