### PR TITLE
AJAX mastersubnet dropdown menu

### DIFF
--- a/app/admin/subnets/edit.php
+++ b/app/admin/subnets/edit.php
@@ -141,7 +141,7 @@ $('.slider').slider().on('slide', function(ev){
 // mastersubnet Ajax
 $("input[name='subnet']").change(function() {
 	var $masterdopdown = $("select[name='masterSubnetId']");
-	$masterdopdown.load('<?php print BASE.'app/subnets/mastersubnet-dropdown.php?section='.$_POST['sectionId'].'&cidr='; ?>' + $(this).val() + '&prev=' + $masterdopdown.val());
+	$masterdopdown.load('<?php print BASE.'app/subnets/mastersubnet-dropdown.php?section='.(int) $_POST['sectionId'].'&cidr='; ?>' + $(this).val() + '&prev=' + $masterdopdown.val());
 });
 
 });

--- a/app/admin/subnets/edit.php
+++ b/app/admin/subnets/edit.php
@@ -141,7 +141,7 @@ $('.slider').slider().on('slide', function(ev){
 // mastersubnet Ajax
 $("input[name='subnet']").change(function() {
 	var $masterdopdown = $("select[name='masterSubnetId']");
-	$masterdopdown.load('<?php print BASE.'app/subnets/mastersubnet-dropdown.php?section='.(int) $_POST['sectionId'].'&cidr='; ?>' + $(this).val() + '&prev=' + $masterdopdown.val());
+	$masterdopdown.load('<?php print BASE.'app/subnets/mastersubnet-dropdown.php?section='.urlencode($_POST['sectionId']).'&cidr='; ?>' + $(this).val() + '&prev=' + $masterdopdown.val());
 });
 
 });

--- a/app/admin/subnets/edit.php
+++ b/app/admin/subnets/edit.php
@@ -138,6 +138,12 @@ $('.slider').slider().on('slide', function(ev){
 });
 <?php } ?>
 
+// mastersubnet Ajax
+$("input[name='subnet']").change(function() {
+	var $masterdopdown = $("select[name='masterSubnetId']");
+	$masterdopdown.load('<?php print BASE.'app/subnets/mastersubnet-dropdown.php?section='.$_POST['sectionId'].'&cidr='; ?>' + $(this).val() + '&prev=' + $masterdopdown.val());
+});
+
 });
 </script>
 

--- a/app/subnets/mastersubnet-dropdown.php
+++ b/app/subnets/mastersubnet-dropdown.php
@@ -1,0 +1,96 @@
+<?php
+//  /app/subnets/mastersubnet-dropdown.php?section=<integer>&cidr=<string>&prev=<integer>
+
+/* functions */
+require( dirname(__FILE__) . '/../../functions/functions.php');
+
+# initialize user object
+$Database = new Database_PDO;
+$User     = new User ($Database);
+// $Admin    = new Admin ($Database, false);
+$Sections = new Sections ($Database);
+$Subnets  = new Subnets ($Database);
+// $Tools    = new Tools ($Database);
+// $Result   = new Result ();
+
+# verify that user is logged in
+$User->check_user_session();
+
+
+/**
+ * Return array of valid subnets satisfying strict subnet requirements
+ * @param  Subnets $Subnets [description]
+ * @param  array $search  [description]
+ * @param  string $cidr    [description]
+ * @return array          [description]
+ */
+function get_strict_subnets($Subnets, $search, $cidr) {
+	$strict_subnets = array();
+	if ( $Subnets->verify_cidr_address($cidr) !== true) { return array(); }
+
+	list($cidr_addr, $cidr_mask) = explode('/', $cidr);
+
+	$bmask = $Subnets->get_network_bitmasks();
+
+	$cidr_decimal = $Subnets->transform_to_decimal($cidr_addr);
+	$cidr_type = $Subnets->identify_address($cidr_addr);
+
+	// Calculate what the parent subnet decimal address would be for each mask and check if it exists
+	$search_mask = $cidr_mask - 1;
+	while($search_mask >= 0) {
+		 $search_subnet= gmp_strval(gmp_and($cidr_decimal, $bmask[$cidr_type][$search_mask]['lo']));
+
+		if (is_array($search[$cidr_type][$search_mask][$search_subnet])) {
+			$strict_subnets = array_merge($strict_subnets, $search[$cidr_type][$search_mask][$search_subnet]);
+		}
+		$search_mask--;
+	}
+
+	return $strict_subnets;
+}
+
+
+
+$sectionId = isset($_GET['section']) ? (int) $_GET['section'] : 0;
+$cidr = isset($_GET['cidr']) ? $_GET['cidr'] : '';
+$previously_selected =  isset($_GET['prev']) ? (int) $_GET['prev'] : -1;
+
+$section = $Sections->fetch_section('id', $sectionId);
+if (!is_object($section)) { return ''; }
+
+$folders = array();
+$search = array();
+$all_subnets = $Subnets->fetch_section_subnets ($sectionId, array('id','masterSubnetId','isFolder','subnet','mask','description'));
+
+foreach($all_subnets as $subnet) {
+	if ($subnet->isFolder) {
+		$folders[] = clone $subnet;
+		$subnet->disabled = 1;
+	} else {
+		$subnet->type = $Subnets->identify_address($subnet->subnet);
+		$search[$subnet->type][$subnet->mask][$subnet->subnet][] = $subnet;
+	}
+}
+
+$strict_subnets = get_strict_subnets($Subnets, $search, $cidr);
+
+
+// Generate HTML <options> dropdown menu
+$dropdown = new MasterSubnetDropDown($Subnets, $previously_selected);
+
+if (!empty($strict_subnets)) {
+	$dropdown->optgroup_open(_('Strict Subnets'));
+	foreach($strict_subnets as $subnet) { $dropdown->subnets_add_object($subnet); }
+}
+
+$dropdown->optgroup_open(_('Folders'));
+foreach($folders as $folder) { $dropdown->subnets_tree_add($folder); }
+$dropdown->subnets_tree_render(true);
+
+if ($section->strictMode == 0) {
+	$dropdown->optgroup_open(_('Subnets'));
+	foreach($all_subnets as $subnet) { $dropdown->subnets_tree_add($subnet); }
+	$dropdown->subnets_tree_render(false);
+}
+
+echo $dropdown->html();

--- a/app/subnets/mastersubnet-dropdown.php
+++ b/app/subnets/mastersubnet-dropdown.php
@@ -61,6 +61,7 @@ if (!is_object($section)) { return ''; }
 $folders = array();
 $search = array();
 $all_subnets = $Subnets->fetch_section_subnets ($sectionId, array('id','masterSubnetId','isFolder','subnet','mask','description'));
+if (!is_array($all_subnets)) $all_subnets = array();
 
 foreach($all_subnets as $subnet) {
 	if ($subnet->isFolder) {
@@ -71,6 +72,7 @@ foreach($all_subnets as $subnet) {
 		$search[$subnet->type][$subnet->mask][$subnet->subnet][] = $subnet;
 	}
 }
+
 
 $strict_subnets = get_strict_subnets($Subnets, $search, $cidr);
 

--- a/functions/classes/class.Menu.php
+++ b/functions/classes/class.Menu.php
@@ -1,0 +1,178 @@
+<?php
+
+/**
+ * SubnetsDropDown, Generate HTML dropdown <options> list from subnet objects
+ */
+class MasterSubnetDropDown {
+	/**
+	 * Subnets Class Object
+	 * @var Subnets
+	 */
+	private $Subnets;
+
+	/**
+	 * Array to store generated HTML code
+	 * @var array
+	 */
+	private $html = array();
+
+	/**
+	 * Name of current <optgroup>
+	 * @var string|null
+	 */
+	private $options_group = null;
+
+	/**
+	 * previously selected subnet id.
+	 * @var integer
+	 */
+	private $previously_selected;
+
+	/**
+	 * Lookup array, subnets by id.
+	 * @var array
+	 */
+	private $subnets_by_id;
+
+	/**
+	 * Lookup array, child subnet id's by parent id.
+	 * @var array
+	 */
+	private $children_by_parent_id;
+
+	/**
+	 * Class Constructor
+	 * @param stdObject $Subnets
+	 * @param integer $previously_selected
+	 */
+	public function __construct($Subnets, $previously_selected = -1) {
+		$this->Subnets = $Subnets;
+		$this->previously_selected = $previously_selected;
+		$this->subnets_tree_reset();
+	}
+
+	/**
+	 * Return generated HTML
+	 * @return string
+	 */
+	public function html() {
+		$this->optgroup_close();
+		return implode("\n", $this->html);
+	}
+
+	/**
+	 * Start a new html <optgroup>
+	 * @param string $name
+	 */
+	public function optgroup_open($name) {
+		$this->optgroup_close();
+		$this->options_group = $name;
+		$this->html[] = '<optgroup label="'.$name.'">';
+	}
+
+	/**
+	 *  Close an open html </optgroup>
+	 */
+	public function optgroup_close() {
+		if ($this->options_group) { $this->html[] = '</optgroup>'; }
+		$this->options_group = null;
+	}
+
+	/**
+	 * Return <option> customisations
+	 * @param  stdObject|null $subnet
+	 * @return string
+	 */
+	private function get_subnet_options($subnet) {
+		$options = array();
+
+		// selected="selected"
+		$id = is_object($subnet) ? $subnet->id : 0;
+		if ($id == $this->previously_selected) {
+			$this->previously_selected = -1;
+			$options[] = 'selected="selected"';
+		}
+
+		// disabled
+		if (is_object($subnet) && isset($subnet->disabled) && $subnet->disabled == 1) {
+			$options[] = 'disabled';
+		}
+
+		return implode(' ', $options);
+	}
+
+	/**
+	 * Generate menu item from subnet object
+	 * @param stdObject|null $subnet
+	 * @param integer $level (de)
+	 */
+	 public function subnets_add_object($subnet, $level = 0) {
+		 $options = $this->get_subnet_options($subnet);
+
+ 		if (!is_object($subnet)) {
+ 			$this->html[] = "<option $options value='0'>"._("Root folder")."</option>";
+			return;
+ 		}
+
+ 		if (strlen($subnet->description)>34) $subnet->description = substr($subnet->description, 0, 31) . '...';
+		$prefix = str_repeat(' - ', $level);
+
+ 		if ($subnet->isFolder) {
+ 			$this->html[] = "<option $options value='$subnet->id'>$prefix $subnet->description</option>";
+ 			return;
+ 		}
+
+ 		$ip = $this->Subnets->transform_to_dotted($subnet->subnet).'/'.$subnet->mask;
+
+ 		if (empty($subnet->description)) {
+ 			$this->html[] = "<option $options value='$subnet->id'>$prefix $ip</option>";
+ 		} else {
+ 			$this->html[] = "<option $options value='$subnet->id'>$prefix $ip ($subnet->description)</option>";
+ 		}
+ 	}
+
+	/* options-menu Subnets tree-view functions */
+
+	/**
+	 * Add subnet object to internal tree structures
+	 * @param stdObject $subnet
+	 */
+	public function subnets_tree_add($subnet) {
+		if(is_object($subnet)) {
+			$this->children_by_parent_id[$subnet->masterSubnetId][] = $subnet->id;
+			$this->subnets_by_id[$subnet->id] = $subnet;
+		}
+	}
+
+	/**
+	 * Reset subnets internal tree structures
+	 */
+	public function subnets_tree_reset() {
+		$this->children_by_parent_id = array();
+		$this->subnets_by_id = array(null);
+	}
+
+	/**
+	 * Walk subnets tree structures and generate html[]
+	 * @param  boolean $show_root
+	 */
+	public function subnets_tree_render($show_root = true) {
+		$this->subnets_tree_recursive_render(0, 0, $show_root);
+		$this->subnets_tree_reset();
+	}
+
+	/**
+	 * Recursively walk subnets tree structures and generate html[]
+	 * @param  integer $id
+	 * @param  string $prefix
+	 * @param  bool $show_root
+	 */
+	private function subnets_tree_recursive_render($id, $level, $show_root) {
+		if ($id != 0 || $show_root === true) $this->subnets_add_object($this->subnets_by_id[$id], $level++);
+
+		if (!is_array($this->children_by_parent_id[$id])) return;
+
+		$children = $this->children_by_parent_id[$id];
+		foreach($children as $child_id) $this->subnets_tree_recursive_render($child_id, $level, $show_root);
+	}
+}

--- a/functions/classes/class.Menu.php
+++ b/functions/classes/class.Menu.php
@@ -42,7 +42,7 @@ class MasterSubnetDropDown {
 
 	/**
 	 * Class Constructor
-	 * @param stdObject $Subnets
+	 * @param Subnets $Subnets
 	 * @param integer $previously_selected
 	 */
 	public function __construct($Subnets, $previously_selected = -1) {

--- a/functions/classes/class.Subnets.php
+++ b/functions/classes/class.Subnets.php
@@ -3598,6 +3598,7 @@ class Subnets extends Common_functions {
 
 		$folders = array();
 		$section_subnets = $this->fetch_section_subnets ($sectionId, array("id", "masterSubnetId", "isFolder", "subnet", "mask", "description"));
+		if (!is_array($section_subnets)) $section_subnets = array();
 
 		foreach($section_subnets as $subnet) {
 			if ($subnet->isFolder) {

--- a/functions/functions.php
+++ b/functions/functions.php
@@ -50,6 +50,7 @@ require( dirname(__FILE__) . '/classes/class.Rackspace.php' );	//Class for Racks
 require( dirname(__FILE__) . '/classes/class.SNMP.php' );	    //Class for SNMP queries
 require( dirname(__FILE__) . '/classes/class.DHCP.php' );	    //Class for DHCP
 require( dirname(__FILE__) . '/classes/class.Rewrite.php' );	    //Class for DHCP
+require( dirname(__FILE__) . '/classes/class.Menu.php' );	    //Class for generating HTML menus
 
 # save settings to constant
 if(@$_GET['page']!="install" ) {

--- a/js/1.3.1/magic.js
+++ b/js/1.3.1/magic.js
@@ -2127,6 +2127,7 @@ $(document).on("click", ".dropdown-subnets li a", function() {
 	var inputfield = $('form#editSubnetDetails input[name=subnet]');
 	// fill
 	$(inputfield).val(subnet);
+	$(inputfield).change();
 	// hide
 	$('.dropdown-subnets').parent().removeClass("open");	return false;
 });


### PR DESCRIPTION
+ Re-factor mastersubnetsdropdown code into dedicated Menu class.

+ Populating the input[name='subnet'] form field will dynamically update the mastersubnet dropdown select list.

  When section strict mode is enabled only overlapping subnets and folders are displayed in the menu.
 
  When section strict mode is disabled an additional overlapping subnets sections is displayed at the top of the list.

![screenshot from 2017-12-28 20-08-38](https://user-images.githubusercontent.com/18753294/34422187-cbdc09b8-ec0b-11e7-9066-a6800a10fd4e.png)

![screenshot from 2017-12-28 20-09-16](https://user-images.githubusercontent.com/18753294/34422200-e993439a-ec0b-11e7-92e9-679c89e52e8b.png)
