### PR TITLE
fix slow mac address vendor decoding for subnet detail view

### DIFF
--- a/functions/classes/class.Common.php
+++ b/functions/classes/class.Common.php
@@ -1446,6 +1446,7 @@ class Common_functions  {
 	 * @param  mixed $mac
 	 * @return string
 	 */
+	private $mac_address_vendors = NULL;
 	public function get_mac_address_vendor_details ($mac) {
 		// set default arrays
 		$matches = array();
@@ -1456,17 +1457,25 @@ class Common_functions  {
 		$mac = strtoupper($this->reformat_mac_address ($mac, $format = 1));
 		$mac_partial = explode(":", $mac);
 		// get mac XML database
-        $data = file_get_contents(dirname(__FILE__)."/../vendormacs.xml");
-        // check
-        if (preg_match_all('/\<VendorMapping\smac_prefix="([0-9a-fA-F]{2})[:-]([0-9a-fA-F]{2})[:-]([0-9a-fA-F]{2})"\svendor_name="(.*)"\/\>/', $data, $matches, PREG_SET_ORDER)) {
-            foreach ($matches as $match) {
-            	//check for provided mac
-                if(strtoupper($mac_partial[0] . ':' . $mac_partial[1] . ':' . $mac_partial[2]) == strtoupper($match[1] . ':' . $match[2] . ':' . $match[3])) {
-                	return $match[4];
+
+	if ($this->mac_address_vendors === NULL)
+	{
+		//populate mac vendors array
+
+		$this->mac_address_vendors = array();
+
+		$data = file_get_contents(dirname(__FILE__)."/../vendormacs.xml");
+
+		if (preg_match_all('/\<VendorMapping\smac_prefix="([0-9a-fA-F]{2})[:-]([0-9a-fA-F]{2})[:-]([0-9a-fA-F]{2})"\svendor_name="(.*)"\/\>/', $data, $matches, PREG_SET_ORDER)) {
+			foreach ($matches as $match) {
+				$this->mac_address_vendors[strtoupper($match[1] . ':' . $match[2] . ':' . $match[3])] = $match[4];
+			}
                 }
-            }
-            // not matched
-            return "";
+        }
+
+	if (isset($this->mac_address_vendors[strtoupper($mac_partial[0] . ':' . $mac_partial[1] . ':' . $mac_partial[2])]))
+	{
+            return $this->mac_address_vendors[strtoupper($mac_partial[0] . ':' . $mac_partial[1] . ':' . $mac_partial[2])];
         } else {
             return "";
         }


### PR DESCRIPTION
Loading of the subnet detail view takes a lot longer if mac decoding is enabled. Reason was that it iterates over the whole mac vendors list for every mac to check.

This PR reads the vendor list only once and puts them into an array so the following queries are served a lot faster.