### PR TITLE
Performance + bug fixes

### DIFF
--- a/app/admin/import-export/import-recompute-logic.php
+++ b/app/admin/import-export/import-recompute-logic.php
@@ -51,9 +51,6 @@ if (!$all_vrfs) { $all_vrfs = array(); }
 array_splice($all_vrfs,0,0,(object) array(array('vrfId' => '0', 'name' => 'default', 'rd' => '0:0')));
 foreach ($all_vrfs as $vrf) { $vrf = (array) $vrf; $vrf_name[$vrf['vrfId']] = $vrf['name']; }
 
-# Precompute masks values, to avoid too much CPU load
-$bmask = $Subnets->get_network_bitmasks();
-
 $rows = ""; $counters = array(); $subnetbyid = array();
 
 /**
@@ -90,7 +87,7 @@ foreach ($rlist as $sect_id => $sect_check) {
 		$edata[$sect_id][] = &$subnet;
 		$subnetbyid[$subnet['id']] = &$subnet;
 		if (!$subnet['isFolder']) {
-			$andip = gmp_strval(gmp_and($subnet['subnet'], $bmask[$type][$mask]['lo']));
+			$andip = $Subnets->decimal_network_address($subnet['subnet'], $mask);
 			$candidates[$sect_id][$type][$mask][$andip][] = &$subnet;
 		}
 	}
@@ -109,7 +106,7 @@ foreach ($rlist as $sect_id => $sect_check) {
 		$search_type = $c_subnet['type'];
 
 		while (--$search_mask >= 0) {
-			$search_subnet = gmp_strval(gmp_and($c_subnet['subnet'], $bmask[$search_type][$search_mask]['lo']));
+			$search_subnet = $Subnets->decimal_network_address($c_subnet['subnet'], $search_mask);
 
 			if (!isset($candidates[$sect_id][$search_type][$search_mask][$search_subnet])) { continue; }
 

--- a/app/admin/subnets/edit.php
+++ b/app/admin/subnets/edit.php
@@ -141,7 +141,7 @@ $('.slider').slider().on('slide', function(ev){
 // mastersubnet Ajax
 $("input[name='subnet']").change(function() {
 	var $masterdopdown = $("select[name='masterSubnetId']");
-	$masterdopdown.load('<?php print BASE.'app/subnets/mastersubnet-dropdown.php?section='.$_POST['sectionId'].'&cidr='; ?>' + $(this).val() + '&prev=' + $masterdopdown.val());
+	$masterdopdown.load('<?php print BASE.'app/subnets/mastersubnet-dropdown.php?section='.(int) $_POST['sectionId'].'&cidr='; ?>' + $(this).val() + '&prev=' + $masterdopdown.val());
 });
 
 });

--- a/app/admin/subnets/edit.php
+++ b/app/admin/subnets/edit.php
@@ -141,7 +141,7 @@ $('.slider').slider().on('slide', function(ev){
 // mastersubnet Ajax
 $("input[name='subnet']").change(function() {
 	var $masterdopdown = $("select[name='masterSubnetId']");
-	$masterdopdown.load('<?php print BASE.'app/subnets/mastersubnet-dropdown.php?section='.(int) $_POST['sectionId'].'&cidr='; ?>' + $(this).val() + '&prev=' + $masterdopdown.val());
+	$masterdopdown.load('<?php print BASE.'app/subnets/mastersubnet-dropdown.php?section='.urlencode($_POST['sectionId']).'&cidr='; ?>' + $(this).val() + '&prev=' + $masterdopdown.val());
 });
 
 });

--- a/app/admin/subnets/edit.php
+++ b/app/admin/subnets/edit.php
@@ -138,6 +138,12 @@ $('.slider').slider().on('slide', function(ev){
 });
 <?php } ?>
 
+// mastersubnet Ajax
+$("input[name='subnet']").change(function() {
+	var $masterdopdown = $("select[name='masterSubnetId']");
+	$masterdopdown.load('<?php print BASE.'app/subnets/mastersubnet-dropdown.php?section='.$_POST['sectionId'].'&cidr='; ?>' + $(this).val() + '&prev=' + $masterdopdown.val());
+});
+
 });
 </script>
 

--- a/app/subnets/mastersubnet-dropdown.php
+++ b/app/subnets/mastersubnet-dropdown.php
@@ -16,39 +16,27 @@ $Subnets  = new Subnets ($Database);
 # verify that user is logged in
 $User->check_user_session();
 
-
 /**
  * Return array of valid subnets satisfying strict subnet requirements
- * @param  Subnets $Subnets [description]
- * @param  array $search  [description]
- * @param  string $cidr    [description]
- * @return array          [description]
+ * @param  Subnets      $Subnets
+ * @param  integer      $sectionId
+ * @param  string       $cidr
+ * @param  array|string $result_fields
+ * @return array
  */
-function get_strict_subnets($Subnets, $search, $cidr) {
-	$strict_subnets = array();
+function get_strict_subnets($Subnets, $sectionId, $cidr, $result_fields="*") {
 	if ( $Subnets->verify_cidr_address($cidr) !== true) { return array(); }
 
 	list($cidr_addr, $cidr_mask) = explode('/', $cidr);
 
-	$bmask = $Subnets->get_network_bitmasks();
+	$strict_subnets = $Subnets->fetch_overlapping_subnets($cidr, 'sectionId', $sectionId, $result_fields);
+	if (!array($strict_subnets)) return array();
 
-	$cidr_decimal = $Subnets->transform_to_decimal($cidr_addr);
-	$cidr_type = $Subnets->identify_address($cidr_addr);
-
-	// Calculate what the parent subnet decimal address would be for each mask and check if it exists
-	$search_mask = $cidr_mask - 1;
-	while($search_mask >= 0) {
-		 $search_subnet= gmp_strval(gmp_and($cidr_decimal, $bmask[$cidr_type][$search_mask]['lo']));
-
-		if (is_array($search[$cidr_type][$search_mask][$search_subnet])) {
-			$strict_subnets = array_merge($strict_subnets, $search[$cidr_type][$search_mask][$search_subnet]);
-		}
-		$search_mask--;
+	foreach ($strict_subnets as $i => $subnet) {
+		if ($subnet->mask >= $cidr_mask) unset($strict_subnets[$i]); else break;
 	}
-
 	return $strict_subnets;
 }
-
 
 
 $sectionId = isset($_GET['section']) ? (int) $_GET['section'] : 0;
@@ -58,38 +46,39 @@ $previously_selected =  isset($_GET['prev']) ? (int) $_GET['prev'] : -1;
 $section = $Sections->fetch_section('id', $sectionId);
 if (!is_object($section)) { return ''; }
 
-$folders = array();
-$search = array();
-$all_subnets = $Subnets->fetch_section_subnets ($sectionId, array('id','masterSubnetId','isFolder','subnet','mask','description'));
-if (!is_array($all_subnets)) $all_subnets = array();
+// Don't fetch all fields
+$fields = array('id','masterSubnetId','isFolder','subnet','mask','description');
 
-foreach($all_subnets as $subnet) {
-	if ($subnet->isFolder) {
-		$folders[] = clone $subnet;
-		$subnet->disabled = 1;
-	} else {
-		$subnet->type = $Subnets->identify_address($subnet->subnet);
-		$search[$subnet->type][$subnet->mask][$subnet->subnet][] = $subnet;
-	}
-}
+$strict_subnets = get_strict_subnets($Subnets, $sectionId, $cidr, $fields);
 
-
-$strict_subnets = get_strict_subnets($Subnets, $search, $cidr);
-
+$folders = $Subnets->fetch_multiple_objects('subnets', 'isFolder', '1', 'id', true, null, $fields);
+if (!is_array($folders)) $folders = array();
 
 // Generate HTML <options> dropdown menu
 $dropdown = new MasterSubnetDropDown($Subnets, $previously_selected);
 
+// Show overlapping subnets (possible parents)
 if (!empty($strict_subnets)) {
 	$dropdown->optgroup_open(_('Strict Subnets'));
 	foreach($strict_subnets as $subnet) { $dropdown->subnets_add_object($subnet); }
 }
 
+// Show folders
 $dropdown->optgroup_open(_('Folders'));
 foreach($folders as $folder) { $dropdown->subnets_tree_add($folder); }
 $dropdown->subnets_tree_render(true);
 
+
 if ($section->strictMode == 0) {
+	// Strict mode is disabled, allow nested chaos....
+	$all_subnets = $Subnets->fetch_section_subnets($sectionId, $fields);
+	if (!is_array($all_subnets)) $all_subnets = array();
+
+	foreach($all_subnets as $subnet) {
+		if ($subnet->isFolder) $subnet->disabled = 1; else break;
+	}
+
+	// Show all subnets
 	$dropdown->optgroup_open(_('Subnets'));
 	foreach($all_subnets as $subnet) { $dropdown->subnets_tree_add($subnet); }
 	$dropdown->subnets_tree_render(false);

--- a/app/subnets/mastersubnet-dropdown.php
+++ b/app/subnets/mastersubnet-dropdown.php
@@ -28,6 +28,8 @@ function get_strict_subnets($Subnets, $sectionId, $cidr, $result_fields="*") {
 	$strict_subnets = $Subnets->fetch_overlapping_subnets($cidr, 'sectionId', $sectionId, $result_fields);
 	if (!is_array($strict_subnets)) return array();
 
+	list(,$cidr_mask) = explode('/', $cidr);
+
 	foreach ($strict_subnets as $i => $subnet) {
 		if ($subnet->mask >= $cidr_mask) unset($strict_subnets[$i]); else break;
 	}

--- a/app/subnets/mastersubnet-dropdown.php
+++ b/app/subnets/mastersubnet-dropdown.php
@@ -25,12 +25,8 @@ $User->check_user_session();
  * @return array
  */
 function get_strict_subnets($Subnets, $sectionId, $cidr, $result_fields="*") {
-	if ( $Subnets->verify_cidr_address($cidr) !== true) { return array(); }
-
-	list($cidr_addr, $cidr_mask) = explode('/', $cidr);
-
 	$strict_subnets = $Subnets->fetch_overlapping_subnets($cidr, 'sectionId', $sectionId, $result_fields);
-	if (!array($strict_subnets)) return array();
+	if (!is_array($strict_subnets)) return array();
 
 	foreach ($strict_subnets as $i => $subnet) {
 		if ($subnet->mask >= $cidr_mask) unset($strict_subnets[$i]); else break;
@@ -51,7 +47,7 @@ $fields = array('id','masterSubnetId','isFolder','subnet','mask','description');
 
 $strict_subnets = get_strict_subnets($Subnets, $sectionId, $cidr, $fields);
 
-$folders = $Subnets->fetch_multiple_objects('subnets', 'isFolder', '1', 'id', true, null, $fields);
+$folders = $Subnets->fetch_multiple_objects('subnets', 'isFolder', '1', 'id', true, false, $fields);
 if (!is_array($folders)) $folders = array();
 
 // Generate HTML <options> dropdown menu

--- a/app/subnets/mastersubnet-dropdown.php
+++ b/app/subnets/mastersubnet-dropdown.php
@@ -1,0 +1,96 @@
+<?php
+//  /app/subnets/mastersubnet-dropdown.php?section=<integer>&cidr=<string>&prev=<integer>
+
+/* functions */
+require( dirname(__FILE__) . '/../../functions/functions.php');
+
+# initialize user object
+$Database = new Database_PDO;
+$User     = new User ($Database);
+// $Admin    = new Admin ($Database, false);
+$Sections = new Sections ($Database);
+$Subnets  = new Subnets ($Database);
+// $Tools    = new Tools ($Database);
+// $Result   = new Result ();
+
+# verify that user is logged in
+$User->check_user_session();
+
+
+/**
+ * Return array of valid subnets satisfying strict subnet requirements
+ * @param  Subnets $Subnets [description]
+ * @param  array $search  [description]
+ * @param  string $cidr    [description]
+ * @return array          [description]
+ */
+function get_strict_subnets($Subnets, $search, $cidr) {
+	$strict_subnets = array();
+	if ( $Subnets->verify_cidr_address($cidr) !== true) { return array(); }
+
+	list($cidr_addr, $cidr_mask) = explode('/', $cidr);
+
+	$bmask = $Subnets->get_network_bitmasks();
+
+	$cidr_decimal = $Subnets->transform_to_decimal($cidr_addr);
+	$cidr_type = $Subnets->identify_address($cidr_addr);
+
+	// Calculate what the parent subnet decimal address would be for each mask and check if it exists
+	$search_mask = $cidr_mask - 1;
+	while($search_mask >= 0) {
+		 $search_subnet= gmp_strval(gmp_and($cidr_decimal, $bmask[$cidr_type][$search_mask]['lo']));
+
+		if (is_array($search[$cidr_type][$search_mask][$search_subnet])) {
+			$strict_subnets = array_merge($strict_subnets, $search[$cidr_type][$search_mask][$search_subnet]);
+		}
+		$search_mask--;
+	}
+
+	return $strict_subnets;
+}
+
+
+
+$sectionId = isset($_GET['section']) ? (int) $_GET['section'] : 0;
+$cidr = isset($_GET['cidr']) ? $_GET['cidr'] : '';
+$previously_selected =  isset($_GET['prev']) ? (int) $_GET['prev'] : -1;
+
+$section = $Sections->fetch_section('id', $sectionId);
+if (!is_object($section)) { return ''; }
+
+$folders = array();
+$search = array();
+$all_subnets = $Subnets->fetch_section_subnets ($sectionId, array('id','masterSubnetId','isFolder','subnet','mask','description'));
+
+foreach($all_subnets as $subnet) {
+	if ($subnet->isFolder) {
+		$folders[] = clone $subnet;
+		$subnet->disabled = 1;
+	} else {
+		$subnet->type = $Subnets->identify_address($subnet->subnet);
+		$search[$subnet->type][$subnet->mask][$subnet->subnet][] = $subnet;
+	}
+}
+
+$strict_subnets = get_strict_subnets($Subnets, $search, $cidr);
+
+
+// Generate HTML <options> dropdown menu
+$dropdown = new MasterSubnetDropDown($Subnets, $previously_selected);
+
+if (!empty($strict_subnets)) {
+	$dropdown->optgroup_open(_('Strict Subnets'));
+	foreach($strict_subnets as $subnet) { $dropdown->subnets_add_object($subnet); }
+}
+
+$dropdown->optgroup_open(_('Folders'));
+foreach($folders as $folder) { $dropdown->subnets_tree_add($folder); }
+$dropdown->subnets_tree_render(true);
+
+if ($section->strictMode == 0) {
+	$dropdown->optgroup_open(_('Subnets'));
+	foreach($all_subnets as $subnet) { $dropdown->subnets_tree_add($subnet); }
+	$dropdown->subnets_tree_render(false);
+}
+
+echo $dropdown->html();

--- a/app/subnets/mastersubnet-dropdown.php
+++ b/app/subnets/mastersubnet-dropdown.php
@@ -61,6 +61,7 @@ if (!is_object($section)) { return ''; }
 $folders = array();
 $search = array();
 $all_subnets = $Subnets->fetch_section_subnets ($sectionId, array('id','masterSubnetId','isFolder','subnet','mask','description'));
+if (!is_array($all_subnets)) $all_subnets = array();
 
 foreach($all_subnets as $subnet) {
 	if ($subnet->isFolder) {
@@ -71,6 +72,7 @@ foreach($all_subnets as $subnet) {
 		$search[$subnet->type][$subnet->mask][$subnet->subnet][] = $subnet;
 	}
 }
+
 
 $strict_subnets = get_strict_subnets($Subnets, $search, $cidr);
 

--- a/app/tools/powerDNS/domains-print.php
+++ b/app/tools/powerDNS/domains-print.php
@@ -96,9 +96,9 @@ elseif ($domains === false) {$Result->show("info alert-absolute", _("No domains 
 <!-- Headers -->
 <thead>
 <tr>
-	<?if ($admin): ?>
+	<?php if ($admin): ?>
 	<th style="width:80px;"></th>
-	<?endif;?>
+	<?php endif;?>
     <th><?php print _('Domain');?></th>
     <th><?php print _('Type');?></th>
     <th><?php print _('Master NS');?></th>

--- a/functions/classes/class.Common.php
+++ b/functions/classes/class.Common.php
@@ -138,6 +138,11 @@ class Common_functions  {
 	 */
 	protected $debugging;
 
+	/**
+	 * Cache mac vendor objects
+	 * @var array|null
+	 */
+	private $mac_address_vendors = null;
 
 
 
@@ -1440,7 +1445,6 @@ class Common_functions  {
 	 * @param  mixed $mac
 	 * @return string
 	 */
-	private $mac_address_vendors = NULL;
 	public function get_mac_address_vendor_details ($mac) {
 		// set default arrays
 		$matches = array();
@@ -1452,27 +1456,29 @@ class Common_functions  {
 		$mac_partial = explode(":", $mac);
 		// get mac XML database
 
-	if ($this->mac_address_vendors === NULL)
-	{
-		//populate mac vendors array
+		if (is_null($this->mac_address_vendors)) {
+			//populate mac vendors array
+			$this->mac_address_vendors = array();
 
-		$this->mac_address_vendors = array();
+			$data = file_get_contents(dirname(__FILE__)."/../vendormacs.xml");
 
-		$data = file_get_contents(dirname(__FILE__)."/../vendormacs.xml");
-
-		if (preg_match_all('/\<VendorMapping\smac_prefix="([0-9a-fA-F]{2})[:-]([0-9a-fA-F]{2})[:-]([0-9a-fA-F]{2})"\svendor_name="(.*)"\/\>/', $data, $matches, PREG_SET_ORDER)) {
-			foreach ($matches as $match) {
-				$this->mac_address_vendors[strtoupper($match[1] . ':' . $match[2] . ':' . $match[3])] = $match[4];
+			if (preg_match_all('/\<VendorMapping\smac_prefix="([0-9a-fA-F]{2})[:-]([0-9a-fA-F]{2})[:-]([0-9a-fA-F]{2})"\svendor_name="(.*)"\/\>/', $data, $matches, PREG_SET_ORDER)) {
+				if (is_array($matches)) {
+					foreach ($matches as $match) {
+						$mac_vendor = strtoupper($match[1] . ':' . $match[2] . ':' . $match[3]);
+						$this->mac_address_vendors[$mac_vendor] = $match[4];
+					}
+				}
 			}
-                }
-        }
+		}
 
-	if (isset($this->mac_address_vendors[strtoupper($mac_partial[0] . ':' . $mac_partial[1] . ':' . $mac_partial[2])]))
-	{
-            return $this->mac_address_vendors[strtoupper($mac_partial[0] . ':' . $mac_partial[1] . ':' . $mac_partial[2])];
-        } else {
-            return "";
-        }
+		$mac_vendor = strtoupper($mac_partial[0] . ':' . $mac_partial[1] . ':' . $mac_partial[2]);
+
+		if (isset($this->mac_address_vendors[$mac_vendor])) {
+			return $this->mac_address_vendors[$mac_vendor];
+		} else {
+			return "";
+		}
 	}
 
 

--- a/functions/classes/class.Common.php
+++ b/functions/classes/class.Common.php
@@ -640,21 +640,18 @@ class Common_functions  {
 	 * @return mixed IP version
 	 */
 	public function identify_address ($address) {
-	    # dotted representation
-	    if (strpos($address, ":")) 		{ return 'IPv6'; }
-	    elseif (strpos($address, ".")) 	{ return 'IPv4'; }
-	    # numeric representation
-	    elseif (is_numeric($address)) {
-	    	if($address <= 4294967295)	{ return 'IPv4'; }	// 4294967295 = '255.255.255.255'
-	    	else 						{ return 'IPv6'; }
-	    }
-	    # decimal representation
-	    else  {
-	        # IPv4 address
-	        if(strlen($address) < 12) 	{ return 'IPv4'; }
-	        # IPv6 address
-	    	else 						{ return 'IPv6'; }
-	    }
+		# dotted representation
+		if (strpos($address, ':') !== false) return 'IPv6';
+		if (strpos($address, '.') !== false) return 'IPv4';
+		# numeric representation
+		if (is_numeric($address)) {
+			if($address <= 4294967295) return 'IPv4'; // 4294967295 = '255.255.255.255'
+			return 'IPv6';
+		} else {
+			# decimal representation
+			if(strlen($address) < 12) return 'IPv4';
+			return 'IPv6';
+		}
 	}
 
 	/**

--- a/functions/classes/class.Common.php
+++ b/functions/classes/class.Common.php
@@ -1029,25 +1029,10 @@ class Common_functions  {
 	 * @return mixed
 	 */
 	public function long2ip6($ipv6long) {
-	    $bin = gmp_strval(gmp_init($ipv6long,10),2);
-	    $ipv6 = "";
-
-	    if (strlen($bin) < 128) {
-	        $pad = 128 - strlen($bin);
-	        for ($i = 1; $i <= $pad; $i++) {
-	            $bin = "0".$bin;
-	        }
-	    }
-
-	    $bits = 0;
-	    while ($bits <= 7)
-	    {
-	        $bin_part = substr($bin,($bits*16),16);
-	        $ipv6 .= dechex(bindec($bin_part)).":";
-	        $bits++;
-	    }
-	    // compress result
-	    return inet_ntop(inet_pton(substr($ipv6,0,-1)));
+		$hex = sprintf('%032s', gmp_strval(gmp_init($ipv6long, 10), 16));
+		$ipv6 = implode(':', str_split($hex, 4));
+		// compress result
+		return inet_ntop(inet_pton($ipv6));
 	}
 
 	/**

--- a/functions/classes/class.Common.php
+++ b/functions/classes/class.Common.php
@@ -622,6 +622,18 @@ class Common_functions  {
 	}
 
 	/**
+	 * Detect the encoding used for a string and convert to UTF-8
+	 *
+	 * @method convert_encoding_to_UTF8
+	 * @param  string $string
+	 * @return string
+	 */
+	public function convert_encoding_to_UTF8($string) {
+		//convert encoding if necessary
+		return mb_convert_encoding($string, 'UTF-8', mb_detect_encoding($string, 'ASCII, UTF-8, ISO-8859-1, auto', true));
+	}
+
+	/**
 	 * Function to verify checkbox if 0 length
 	 *
 	 * @access public

--- a/functions/classes/class.Common.php
+++ b/functions/classes/class.Common.php
@@ -1446,6 +1446,7 @@ class Common_functions  {
 	 * @param  mixed $mac
 	 * @return string
 	 */
+	private $mac_address_vendors = NULL;
 	public function get_mac_address_vendor_details ($mac) {
 		// set default arrays
 		$matches = array();
@@ -1456,17 +1457,25 @@ class Common_functions  {
 		$mac = strtoupper($this->reformat_mac_address ($mac, $format = 1));
 		$mac_partial = explode(":", $mac);
 		// get mac XML database
-        $data = file_get_contents(dirname(__FILE__)."/../vendormacs.xml");
-        // check
-        if (preg_match_all('/\<VendorMapping\smac_prefix="([0-9a-fA-F]{2})[:-]([0-9a-fA-F]{2})[:-]([0-9a-fA-F]{2})"\svendor_name="(.*)"\/\>/', $data, $matches, PREG_SET_ORDER)) {
-            foreach ($matches as $match) {
-            	//check for provided mac
-                if(strtoupper($mac_partial[0] . ':' . $mac_partial[1] . ':' . $mac_partial[2]) == strtoupper($match[1] . ':' . $match[2] . ':' . $match[3])) {
-                	return $match[4];
+
+	if ($this->mac_address_vendors === NULL)
+	{
+		//populate mac vendors array
+
+		$this->mac_address_vendors = array();
+
+		$data = file_get_contents(dirname(__FILE__)."/../vendormacs.xml");
+
+		if (preg_match_all('/\<VendorMapping\smac_prefix="([0-9a-fA-F]{2})[:-]([0-9a-fA-F]{2})[:-]([0-9a-fA-F]{2})"\svendor_name="(.*)"\/\>/', $data, $matches, PREG_SET_ORDER)) {
+			foreach ($matches as $match) {
+				$this->mac_address_vendors[strtoupper($match[1] . ':' . $match[2] . ':' . $match[3])] = $match[4];
+			}
                 }
-            }
-            // not matched
-            return "";
+        }
+
+	if (isset($this->mac_address_vendors[strtoupper($mac_partial[0] . ':' . $mac_partial[1] . ':' . $mac_partial[2])]))
+	{
+            return $this->mac_address_vendors[strtoupper($mac_partial[0] . ':' . $mac_partial[1] . ':' . $mac_partial[2])];
         } else {
             return "";
         }

--- a/functions/classes/class.Menu.php
+++ b/functions/classes/class.Menu.php
@@ -1,0 +1,178 @@
+<?php
+
+/**
+ * SubnetsDropDown, Generate HTML dropdown <options> list from subnet objects
+ */
+class MasterSubnetDropDown {
+	/**
+	 * Subnets Class Object
+	 * @var Subnets
+	 */
+	private $Subnets;
+
+	/**
+	 * Array to store generated HTML code
+	 * @var array
+	 */
+	private $html = array();
+
+	/**
+	 * Name of current <optgroup>
+	 * @var string|null
+	 */
+	private $options_group = null;
+
+	/**
+	 * previously selected subnet id.
+	 * @var integer
+	 */
+	private $previously_selected;
+
+	/**
+	 * Lookup array, subnets by id.
+	 * @var array
+	 */
+	private $subnets_by_id;
+
+	/**
+	 * Lookup array, child subnet id's by parent id.
+	 * @var array
+	 */
+	private $children_by_parent_id;
+
+	/**
+	 * Class Constructor
+	 * @param stdObject $Subnets
+	 * @param integer $previously_selected
+	 */
+	public function __construct($Subnets, $previously_selected = -1) {
+		$this->Subnets = $Subnets;
+		$this->previously_selected = $previously_selected;
+		$this->subnets_tree_reset();
+	}
+
+	/**
+	 * Return generated HTML
+	 * @return string
+	 */
+	public function html() {
+		$this->optgroup_close();
+		return implode("\n", $this->html);
+	}
+
+	/**
+	 * Start a new html <optgroup>
+	 * @param string $name
+	 */
+	public function optgroup_open($name) {
+		$this->optgroup_close();
+		$this->options_group = $name;
+		$this->html[] = '<optgroup label="'.$name.'">';
+	}
+
+	/**
+	 *  Close an open html </optgroup>
+	 */
+	public function optgroup_close() {
+		if ($this->options_group) { $this->html[] = '</optgroup>'; }
+		$this->options_group = null;
+	}
+
+	/**
+	 * Return <option> customisations
+	 * @param  stdObject|null $subnet
+	 * @return string
+	 */
+	private function get_subnet_options($subnet) {
+		$options = array();
+
+		// selected="selected"
+		$id = is_object($subnet) ? $subnet->id : 0;
+		if ($id == $this->previously_selected) {
+			$this->previously_selected = -1;
+			$options[] = 'selected="selected"';
+		}
+
+		// disabled
+		if (is_object($subnet) && isset($subnet->disabled) && $subnet->disabled == 1) {
+			$options[] = 'disabled';
+		}
+
+		return implode(' ', $options);
+	}
+
+	/**
+	 * Generate menu item from subnet object
+	 * @param stdObject|null $subnet
+	 * @param integer $level (de)
+	 */
+	 public function subnets_add_object($subnet, $level = 0) {
+		 $options = $this->get_subnet_options($subnet);
+
+ 		if (!is_object($subnet)) {
+ 			$this->html[] = "<option $options value='0'>"._("Root folder")."</option>";
+			return;
+ 		}
+
+ 		if (strlen($subnet->description)>34) $subnet->description = substr($subnet->description, 0, 31) . '...';
+		$prefix = str_repeat(' - ', $level);
+
+ 		if ($subnet->isFolder) {
+ 			$this->html[] = "<option $options value='$subnet->id'>$prefix $subnet->description</option>";
+ 			return;
+ 		}
+
+ 		$ip = $this->Subnets->transform_to_dotted($subnet->subnet).'/'.$subnet->mask;
+
+ 		if (empty($subnet->description)) {
+ 			$this->html[] = "<option $options value='$subnet->id'>$prefix $ip</option>";
+ 		} else {
+ 			$this->html[] = "<option $options value='$subnet->id'>$prefix $ip ($subnet->description)</option>";
+ 		}
+ 	}
+
+	/* options-menu Subnets tree-view functions */
+
+	/**
+	 * Add subnet object to internal tree structures
+	 * @param stdObject $subnet
+	 */
+	public function subnets_tree_add($subnet) {
+		if(is_object($subnet)) {
+			$this->children_by_parent_id[$subnet->masterSubnetId][] = $subnet->id;
+			$this->subnets_by_id[$subnet->id] = $subnet;
+		}
+	}
+
+	/**
+	 * Reset subnets internal tree structures
+	 */
+	public function subnets_tree_reset() {
+		$this->children_by_parent_id = array();
+		$this->subnets_by_id = array(null);
+	}
+
+	/**
+	 * Walk subnets tree structures and generate html[]
+	 * @param  boolean $show_root
+	 */
+	public function subnets_tree_render($show_root = true) {
+		$this->subnets_tree_recursive_render(0, 0, $show_root);
+		$this->subnets_tree_reset();
+	}
+
+	/**
+	 * Recursively walk subnets tree structures and generate html[]
+	 * @param  integer $id
+	 * @param  string $prefix
+	 * @param  bool $show_root
+	 */
+	private function subnets_tree_recursive_render($id, $level, $show_root) {
+		if ($id != 0 || $show_root === true) $this->subnets_add_object($this->subnets_by_id[$id], $level++);
+
+		if (!is_array($this->children_by_parent_id[$id])) return;
+
+		$children = $this->children_by_parent_id[$id];
+		foreach($children as $child_id) $this->subnets_tree_recursive_render($child_id, $level, $show_root);
+	}
+}

--- a/functions/classes/class.Menu.php
+++ b/functions/classes/class.Menu.php
@@ -166,7 +166,7 @@ class MasterSubnetDropDown {
 	/**
 	 * Recursively walk subnets tree structures and generate html[]
 	 * @param  integer $id
-	 * @param  string $prefix
+	 * @param  integer $level
 	 * @param  bool $show_root
 	 */
 	private function subnets_tree_recursive_render($id, $level, $show_root) {

--- a/functions/classes/class.Menu.php
+++ b/functions/classes/class.Menu.php
@@ -42,7 +42,7 @@ class MasterSubnetDropDown {
 
 	/**
 	 * Class Constructor
-	 * @param stdObject $Subnets
+	 * @param Subnets $Subnets
 	 * @param integer $previously_selected
 	 */
 	public function __construct($Subnets, $previously_selected = -1) {

--- a/functions/classes/class.Menu.php
+++ b/functions/classes/class.Menu.php
@@ -65,6 +65,8 @@ class MasterSubnetDropDown {
 	 * @param string $name
 	 */
 	public function optgroup_open($name) {
+		if (empty($name)) return;
+
 		$this->optgroup_close();
 		$this->options_group = $name;
 		$this->html[] = '<optgroup label="'.$name.'">';
@@ -74,27 +76,26 @@ class MasterSubnetDropDown {
 	 *  Close an open html </optgroup>
 	 */
 	public function optgroup_close() {
-		if ($this->options_group) { $this->html[] = '</optgroup>'; }
+		if (!empty($this->options_group)) $this->html[] = '</optgroup>';
 		$this->options_group = null;
 	}
 
 	/**
 	 * Return <option> customisations
-	 * @param  stdObject|null $subnet
+	 * @param  stdObject $subnet
 	 * @return string
 	 */
 	private function get_subnet_options($subnet) {
 		$options = array();
 
 		// selected="selected"
-		$id = is_object($subnet) ? $subnet->id : 0;
-		if ($id == $this->previously_selected) {
+		if ($subnet->id == $this->previously_selected) {
 			$this->previously_selected = -1;
 			$options[] = 'selected="selected"';
 		}
 
 		// disabled
-		if (is_object($subnet) && isset($subnet->disabled) && $subnet->disabled == 1) {
+		if (isset($subnet->disabled) && $subnet->disabled == 1) {
 			$options[] = 'disabled';
 		}
 
@@ -103,33 +104,30 @@ class MasterSubnetDropDown {
 
 	/**
 	 * Generate menu item from subnet object
-	 * @param stdObject|null $subnet
-	 * @param integer $level (de)
+	 * @param stdObject $subnet
+	 * @param integer $level
 	 */
-	 public function subnets_add_object($subnet, $level = 0) {
-		 $options = $this->get_subnet_options($subnet);
+	public function subnets_add_object($subnet, $level = 0) {
+		if (!is_object($subnet)) return;
 
- 		if (!is_object($subnet)) {
- 			$this->html[] = "<option $options value='0'>"._("Root folder")."</option>";
-			return;
- 		}
+		$options = $this->get_subnet_options($subnet);
 
- 		if (strlen($subnet->description)>34) $subnet->description = substr($subnet->description, 0, 31) . '...';
+		if (strlen($subnet->description)>34) $subnet->description = substr($subnet->description, 0, 31) . '...';
 		$prefix = str_repeat(' - ', $level);
 
- 		if ($subnet->isFolder) {
- 			$this->html[] = "<option $options value='$subnet->id'>$prefix $subnet->description</option>";
- 			return;
- 		}
+		if ($subnet->isFolder) {
+			$this->html[] = "<option $options value='$subnet->id'>$prefix $subnet->description</option>";
+			return;
+		}
 
- 		$ip = $this->Subnets->transform_to_dotted($subnet->subnet).'/'.$subnet->mask;
+		$ip = $this->Subnets->transform_to_dotted($subnet->subnet).'/'.$subnet->mask;
 
- 		if (empty($subnet->description)) {
- 			$this->html[] = "<option $options value='$subnet->id'>$prefix $ip</option>";
- 		} else {
- 			$this->html[] = "<option $options value='$subnet->id'>$prefix $ip ($subnet->description)</option>";
- 		}
- 	}
+		if (empty($subnet->description)) {
+			$this->html[] = "<option $options value='$subnet->id'>$prefix $ip</option>";
+		} else {
+			$this->html[] = "<option $options value='$subnet->id'>$prefix $ip ($subnet->description)</option>";
+		}
+	}
 
 	/* options-menu Subnets tree-view functions */
 
@@ -149,7 +147,11 @@ class MasterSubnetDropDown {
 	 */
 	public function subnets_tree_reset() {
 		$this->children_by_parent_id = array();
-		$this->subnets_by_id = array(null);
+		$root = new stdClass ();
+		$root->id = 0;
+		$root->isFolder = 1;
+		$root->description = _("Root folder");
+		$this->subnets_by_id = array(0 => $root);
 	}
 
 	/**

--- a/functions/classes/class.PDO.php
+++ b/functions/classes/class.PDO.php
@@ -706,7 +706,7 @@ abstract class DB {
         		$result_fields_arr[] = "`$f`";
     		}
     		// implode
-    		$result_fields = implode(",", $result_fields);
+    		$result_fields = implode(",", $result_fields_arr);
 		}
 
     // subnets

--- a/functions/classes/class.PDO.php
+++ b/functions/classes/class.PDO.php
@@ -681,6 +681,23 @@ abstract class DB {
 	}
 
 	/**
+	 * Escape $result_fields parameter
+	 *
+	 * @access public
+	 * @param string|array $result_fields
+	 * @return string
+	 */
+	public function escape_result_fields($result_fields) {
+		if (empty($result_fields)) return "*";
+
+		if (is_array($result_fields)) {
+			foreach ($result_fields as $i => $f) $result_fields[$i] = "`$f`";
+			$result_fields = implode(',', $result_fields);
+		}
+		return $result_fields;
+	}
+
+	/**
 	 * Searches for object in database
 	 *
 	 * @access public
@@ -691,6 +708,7 @@ abstract class DB {
 	 * @param bool $sortAsc (default: true)
 	 * @param bool $like (default: false)
 	 * @param bool $negate (default: false)
+	 * @param string|array $result_fields (default: "*")
 	 * @return void
 	 */
 	public function findObjects($table, $field, $value, $sortField = 'id', $sortAsc = true, $like = false, $negate = false, $result_fields = "*") {
@@ -700,15 +718,7 @@ abstract class DB {
 		$like === true ? $operator = "LIKE" : $operator = "=";
 		$negate === true ? $negate_operator = "NOT " : $negate_operator = "";
 
-		// set fields
-		if($result_fields!="*") {
-    		$result_fields_arr = array();
-    		foreach ($result_fields as $f) {
-        		$result_fields_arr[] = "`$f`";
-    		}
-    		// implode
-    		$result_fields = implode(",", $result_fields_arr);
-		}
+		$result_fields = $this->escape_result_fields($result_fields);
 
     // subnets
     if ($table=='subnets' && $sortField=='subnet') {

--- a/functions/classes/class.PDO.php
+++ b/functions/classes/class.PDO.php
@@ -249,6 +249,7 @@ abstract class DB {
 	 * @access public
 	 * @param mixed $query
 	 * @param array $values (default: array())
+	 * @param integer|null &$rowCount (default: null)
 	 * @return void
 	 */
 	public function runQuery($query, $values = array(), &$rowCount = null) {

--- a/functions/classes/class.Subnets.php
+++ b/functions/classes/class.Subnets.php
@@ -629,7 +629,7 @@ class Subnets extends Common_functions {
 		}
 
 		// set fields
-		if($result_fields!=='*') {
+		if(is_array($result_fields)) {
 			$result_fields_arr = array();
 			foreach ($result_fields as $f) $result_fields_arr[] = "`$f`";
 			$result_fields = implode(',', $result_fields_arr);
@@ -1641,11 +1641,12 @@ class Subnets extends Common_functions {
 	 * Calculate network address for provided decimal IP and mask (supports IPv4 & IPv6 decimals).
 	 *
 	 * @access public
-	 * @param string $decimalIP	[Decimal format, IPv4/IPv6]
-	 * @param integer $mask     [IPv4 0-32, IPv6 0-128]
-	 * @return string           [Decimal format, IPv4/IPv6]
+	 * @param string|false  $decimalIP  [Decimal format, IPv4/IPv6]
+	 * @param integer       $mask       [IPv4 0-32, IPv6 0-128]
+	 * @return string|false             [Decimal format, IPv4/IPv6]
 	 */
 	public function decimal_network_address($decimalIP, $mask) {
+		if ($decimalIP === false) return false;
 		$type = ($decimalIP <= 4294967295) ? 'IPv4' : 'IPv6';
 		// Calculate network address (decimal) by clearing the /mask bits
 		$network_address = gmp_and($decimalIP, $this->gmp_bitmasks[$type][$mask]['network']);
@@ -1656,11 +1657,12 @@ class Subnets extends Common_functions {
 	 * Calculate broadcast address for provided decimal IP and mask (supports IPv4 & IPv6 decimals).
 	 *
 	 * @access public
-	 * @param string $decimalIP [Decimal format, IPv4/IPv6]
-	 * @param integer $mask     [IPv4 0-32, IPv6 0-128]
-	 * @return string           [Decimal format, IPv4/IPv6]
+	 * @param string|false  $decimalIP  [Decimal format, IPv4/IPv6]
+	 * @param integer       $mask       [IPv4 0-32, IPv6 0-128]
+	 * @return string|false             [Decimal format, IPv4/IPv6]
 	 */
 	public function decimal_broadcast_address($decimalIP, $mask) {
+		if ($decimalIP === false) return false;
 		$type = ($decimalIP <= 4294967295) ? 'IPv4' : 'IPv6';
 		// Calculate broadcast address (decimal) by setting the /mask bits
 		$network_broadcast = gmp_or($decimalIP, $this->gmp_bitmasks[$type][$mask]['broadcast']);

--- a/functions/classes/class.Subnets.php
+++ b/functions/classes/class.Subnets.php
@@ -560,7 +560,7 @@ class Subnets extends Common_functions {
 			return false;
 		}
 		# save to subnets cache
-		if ($result_fields==="*" && is_array($res)) { // Only cache objects containing all fields
+		if ($result_fields==="*" && is_array($subnets)) { // Only cache objects containing all fields
 			foreach($subnets as $subnet) {
 				$this->cache_write ("subnets", $subnet->id, $subnet);
 			}

--- a/functions/classes/class.Subnets.php
+++ b/functions/classes/class.Subnets.php
@@ -612,6 +612,58 @@ class Subnets extends Common_functions {
 	}
 
 	/**
+	 * Fetches all subnets averlapping with CIDR
+	 *
+	 * @access public
+	 * @param  string       $cidr
+	 * @param  string|null  $method
+	 * @param  string|null  $value
+	 * @param  string|array $result_fields
+	 * @return array|false
+	 */
+	public function fetch_overlapping_subnets ($cidr, $method=null, $value=null, $result_fields = '*') {
+		$err = $this->verify_cidr_address($cidr);
+		if ($err !== true) {
+			$this->Result->show("danger", _("Error: ").$err);
+			return false;
+		}
+
+		// set fields
+		if($result_fields!=='*') {
+			$result_fields_arr = array();
+			foreach ($result_fields as $f) $result_fields_arr[] = "`$f`";
+			$result_fields = implode(',', $result_fields_arr);
+		}
+
+		list($cidr, $cidr_mask) = explode('/', $cidr);
+		$cidr_decimal = $this->transform_to_decimal($cidr);
+		$cidr_network = $this->decimal_network_address($cidr_decimal, $cidr_mask);
+		$cidr_broadcast = $this->decimal_broadcast_address($cidr_decimal, $cidr_mask);
+
+		$possible_parents = array();
+		for ($mask=0; $mask<=$cidr_mask; $mask++) {
+			$parent = $this->decimal_network_address($cidr_decimal, $mask);
+			$possible_parents[] = "('$parent','$mask')";
+		}
+		$possible_parents = implode(',', $possible_parents);
+
+		$query = "SELECT $result_fields FROM `subnets` WHERE isFolder = 0 AND ";
+		if (!is_null($method)) $query .= " `$method` = '".$this->Database->escape($value)."' AND ";
+		$query .= " (   ( LPAD(`subnet`,39,0) >= LPAD('$cidr_network',39,0) AND LPAD(`subnet`,39,0) <= LPAD('$cidr_broadcast',39,0) )";
+		$query .= "  OR (`subnet`,`mask`) IN ($possible_parents)  ) ";
+		$query .= "ORDER BY CAST(`mask` AS UNSIGNED) DESC, LPAD(`subnet`,39,0);";
+
+		try {
+			$overlaping_subnets = $this->Database->getObjectsQuery($query);
+		} catch (Exception $e) {
+			$this->Result->show("danger", _("Error: ").$e->getMessage());
+			return false;
+		}
+
+		return $overlaping_subnets;
+	}
+
+	/**
 	 * This function fetches id, subnet and mask for all subnets
 	 *
 	 *	Needed for pingCheck script

--- a/functions/classes/class.Subnets.php
+++ b/functions/classes/class.Subnets.php
@@ -610,7 +610,7 @@ class Subnets extends Common_functions {
 	}
 
 	/**
-	 * Fetches all subnets averlapping with CIDR
+	 * Fetches all subnets overlapping with CIDR
 	 *
 	 * @access public
 	 * @param  string       $cidr

--- a/functions/classes/class.Subnets.php
+++ b/functions/classes/class.Subnets.php
@@ -3598,6 +3598,7 @@ class Subnets extends Common_functions {
 
 		$folders = array();
 		$section_subnets = $this->fetch_section_subnets ($sectionId, array("id", "masterSubnetId", "isFolder", "subnet", "mask", "description"));
+		if (!is_array($section_subnets)) $section_subnets = array();
 
 		foreach($section_subnets as $subnet) {
 			if ($subnet->isFolder) {

--- a/functions/classes/class.Tools.php
+++ b/functions/classes/class.Tools.php
@@ -3224,6 +3224,10 @@ class Tools extends Common_functions {
     	# present ?
     	if (sizeof($outFile)>0) {
             foreach($outFile as $k=>$line) {
+
+		//convert encoding if necessary
+		$line = mb_convert_encoding($line, 'UTF-8', mb_detect_encoding($line, 'UTF-8, ISO-8859-1', true));
+
             	//put it to array
             	$field = str_getcsv ($line, $this->csv_delimiter);
 

--- a/functions/classes/class.Tools.php
+++ b/functions/classes/class.Tools.php
@@ -3225,8 +3225,8 @@ class Tools extends Common_functions {
     	if (sizeof($outFile)>0) {
             foreach($outFile as $k=>$line) {
 
-		//convert encoding if necessary
-		$line = mb_convert_encoding($line, 'UTF-8', mb_detect_encoding($line, 'UTF-8, ISO-8859-1', true));
+            	//convert encoding if necessary
+            	$line = $this->convert_encoding_to_UTF8($line);
 
             	//put it to array
             	$field = str_getcsv ($line, $this->csv_delimiter);

--- a/functions/functions.php
+++ b/functions/functions.php
@@ -50,6 +50,7 @@ require( dirname(__FILE__) . '/classes/class.Rackspace.php' );	//Class for Racks
 require( dirname(__FILE__) . '/classes/class.SNMP.php' );	    //Class for SNMP queries
 require( dirname(__FILE__) . '/classes/class.DHCP.php' );	    //Class for DHCP
 require( dirname(__FILE__) . '/classes/class.Rewrite.php' );	    //Class for DHCP
+require( dirname(__FILE__) . '/classes/class.Menu.php' );	    //Class for generating HTML menus
 
 # save settings to constant
 if(@$_GET['page']!="install" ) {

--- a/js/1.3.1/magic.js
+++ b/js/1.3.1/magic.js
@@ -2127,6 +2127,7 @@ $(document).on("click", ".dropdown-subnets li a", function() {
 	var inputfield = $('form#editSubnetDetails input[name=subnet]');
 	// fill
 	$(inputfield).val(subnet);
+	$(inputfield).change();
 	// hide
 	$('.dropdown-subnets').parent().removeClass("open");	return false;
 });


### PR DESCRIPTION
- Performance fix for Subnets->verify_vrf_overlapping().
  Switch to fetch_overlapping_subnets() to minimize the search.
  
  Fixes performance when adding a new subnet with "Require unique subnets across all sections" enabled with large data sets.

- Update Subnets->verify_vrf_overlapping() to display the section name of overlapping entries.

- Performance fix for Subnets->verify_subnet_overlapping().
  Switch to fetch_overlapping_subnets() to minimize the search.
    
- Update Subnets->verify_subnet_overlapping() to display the section name of overlapping entries.

- Add function Subnets->fetch_overlapping_subnets

        /*
         * Fetches all subnets overlapping with CIDR
         *
         * @access public
         * @param  string       $cidr
         * @param  string|null  $method
         * @param  string|null  $value
         * @param  string|array $result_fields
         * @return array|false
         */
         public function fetch_overlapping_subnets ($cidr, $method=null, $value=null, $result_fields = '*')

- BugFix and cleanup for $Subnets->get_max_hosts() on 32 bit platforms.

       php > var_dump( $Subnets->get_max_hosts(0, 'IPv4', false) );
       int(0)
       php > var_dump( $Subnets->get_max_hosts(1, 'IPv4', false) );
       int(-2147483648)
               
- Cleanup $bmask[][][] code to provide two new self documenting functions.
  Calculates the network and broadcast addresses of a subnet of size $mask
  e.g 10.10.10.10/8 => 10.0.0.0 & 10.255.255.255 (but in decimal format)
               
     $Subnets->decimal_network_address($decimalIP, $mask)
     $Subnets->decimal_broadcast_address($decimalIP, $mask)

- Cleanup and document/comment $Subnets freespacemap functions.
               
- Remove the unused subnet_dropdown_ipv6_decimal_add_one($decimalIpv6) function.
  Function can be replaced by gmp_strval(gmp_add($decimalIpv6, 1));

- misc small bug fixes.