### PR TITLE
Mysql inner joins

### DIFF
--- a/db/SCHEMA.sql
+++ b/db/SCHEMA.sql
@@ -253,7 +253,10 @@ CREATE TABLE `subnets` (
   `lastScan` TIMESTAMP  NULL,
   `lastDiscovery` TIMESTAMP  NULL,
   PRIMARY KEY (`id`),
-  KEY `location` (`location`)
+  KEY `location` (`location`),
+  KEY `masterSubnetId` (`masterSubnetId`),
+  KEY `sectionId` (`sectionId`),
+  KEY `vrfId` (`vrfId`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 /* insert default values */
 INSERT INTO `subnets` (`id`, `subnet`, `mask`, `sectionId`, `description`, `vrfId`, `masterSubnetId`, `allowRequests`, `vlanId`, `showName`, `permissions`, `isFolder`)

--- a/db/UPDATE.sql
+++ b/db/UPDATE.sql
@@ -905,3 +905,7 @@ ALTER TABLE `settings` ADD `IPrequired` VARCHAR(128)  NULL  DEFAULT NULL;
 ALTER TABLE `ipaddresses` CHANGE `dns_name` `hostname` VARCHAR(255)  CHARACTER SET utf8  COLLATE utf8_general_ci  NULL  DEFAULT NULL;
 ALTER TABLE `requests` CHANGE `dns_name` `hostname` VARCHAR(255)  CHARACTER SET utf8  COLLATE utf8_general_ci  NULL  DEFAULT NULL;
 
+/* Subnet table indexes: has_slaves(), fetch_section_subnets(), subnet_familytree_*(), verify_subnet_overlapping(), verify_vrf_overlapping()... */
+ALTER TABLE `subnets` ADD INDEX (`masterSubnetId`);
+ALTER TABLE `subnets` ADD INDEX (`sectionId`);
+ALTER TABLE `subnets` ADD INDEX (`vrfId`);

--- a/functions/classes/class.Subnets.php
+++ b/functions/classes/class.Subnets.php
@@ -976,19 +976,17 @@ class Subnets extends Common_functions {
 	 * Deletes temporary table containing slave ids for a given subnetId
 	 *
 	 * @access private
-	 * @param int $subnetId
-	 * @param int $level ()default: null
+	 * @param integer $subnetId
+	 * @param integer $level (default: 0)
 	 * @return void
 	 */
-	private function reset_subnet_familytree_table ($subnetId, $level = null) {
+	private function reset_subnet_familytree_table ($subnetId, $level = 0) {
 		try {
-				if (!is_numeric($subnetId)) { throw new Exception(_('Invalid subnetId')); }
-				// set table name
-				$table_name = is_null($level) ? "`tmp_subnet_familytree_$subnetId`" : "`tmp_subnet_familytree_${subnetId}_${level}`";
-				// execute
-			$this->Database->runQuery("DROP TABLE IF EXISTS $table_name;");
-		}
-		catch (Exception $e) {
+			$subnetId = filter_var($subnetId, FILTER_VALIDATE_INT);
+			if ($subnetId === false) { throw new Exception(_('Invalid subnetId')); }
+			// execute
+			$this->Database->runQuery('DROP TABLE IF EXISTS tmp_subnet_familytree_' . (int) $subnetId . '_' . (int) $level);
+		} catch (Exception $e) {
 			$this->Result->show("danger", _("Error: ").$e->getMessage());
 		}
 	}
@@ -997,8 +995,8 @@ class Subnets extends Common_functions {
 	 * Generates temporary table containing slave ids for a given subnetId
 	 *
 	 * @access private
-	 * @param int $subnetId
-	 * @return void
+	 * @param integer $subnetId
+	 * @return string
 	 */
 	private function create_subnet_familytree ($subnetId) {
 
@@ -1011,12 +1009,14 @@ class Subnets extends Common_functions {
 		// Work around the 'wont-fix' limitation by using a temporary table per iteration and consolidate the results.
 
 		try {
-			if (!is_numeric($subnetId)) { throw new Exception(_('Invalid subnetId')); }
+			$subnetId = filter_var($subnetId, FILTER_VALIDATE_INT);
+			if ($subnetId === false) { throw new Exception(_('Invalid subnetId')); }
 
 			// set engine type
 			$this->set_tmptable_engine_type ();
-			// remove old temporary table
-			$this->reset_subnet_familytree_table ($subnetId);
+
+			// tmp table name
+			$base_table_name = 'tmp_subnet_familytree_'.$subnetId;
 
 			// set default count
 			$rowCount = 0;
@@ -1025,7 +1025,8 @@ class Subnets extends Common_functions {
 			// remove old temp table with level
 			$this->reset_subnet_familytree_table ($subnetId, $level);
 			// create new temp table
-			$query = "CREATE TEMPORARY TABLE tmp_subnet_familytree_${subnetId}_${level} (id int(11) PRIMARY KEY) ENGINE = ".$this->tmptable_engine_type." SELECT id FROM subnets AS slaves WHERE slaves.masterSubnetId = $subnetId;";
+			$query = 'CREATE TEMPORARY TABLE '.$base_table_name.'_'.$level.' (id int(11) PRIMARY KEY) ENGINE = '.$this->tmptable_engine_type.
+				' SELECT subnets.id FROM subnets WHERE subnets.masterSubnetId = '."'$subnetId'";
 			$result = $this->Database->runQuery($query, null, $rowCount);
 
 			// Fetch next level of slaves.
@@ -1034,20 +1035,17 @@ class Subnets extends Common_functions {
 
 				// remove old
 				$this->reset_subnet_familytree_table ($subnetId, $level);
-
-				$query = "CREATE TEMPORARY TABLE tmp_subnet_familytree_${subnetId}_${level} (id int(11) PRIMARY KEY) ENGINE = ".$this->tmptable_engine_type." SELECT id FROM subnets AS slaves WHERE slaves.masterSubnetId IN (SELECT id FROM tmp_subnet_familytree_${subnetId}_${lastlevel});";
+				$query = 'CREATE TEMPORARY TABLE '.$base_table_name.'_'.$level.' (id int(11) PRIMARY KEY) ENGINE = '.$this->tmptable_engine_type.
+					' SELECT subnets.id FROM subnets INNER JOIN '.$base_table_name.'_'.$lastlevel.' AS parents ON subnets.masterSubnetId = parents.id';
 				$result = $this->Database->runQuery($query, null, $rowCount);
 			}
 
 			// Consolidate results into single temporary table.
-			$query = "CREATE TEMPORARY TABLE tmp_subnet_familytree_${subnetId} (id int(11) PRIMARY KEY) ENGINE = ".$this->tmptable_engine_type.";";
-			$this->Database->runQuery($query);
-
-			while (--$level >= 0) {
-				$query = "INSERT IGNORE INTO tmp_subnet_familytree_${subnetId} SELECT id FROM tmp_subnet_familytree_${subnetId}_${level};";
+			while (--$level >= 1) {
+				$query = 'INSERT IGNORE INTO '.$base_table_name.'_0 SELECT id FROM '.$base_table_name.'_'.$level;
 				$this->Database->runQuery($query);
 
-				// remove old
+				// remove old table
 				$this->reset_subnet_familytree_table ($subnetId, $level);
 			}
 		}
@@ -1055,6 +1053,7 @@ class Subnets extends Common_functions {
 			$this->Result->show("danger", _("Error: ").$e->getMessage());
 			throw $e;
 		}
+		return $base_table_name.'_0';
 	}
 
 	/**
@@ -1102,10 +1101,11 @@ class Subnets extends Common_functions {
 
 		try {
 			// Create temporary table 'tmp_subnet_familytree_${subnetId}' containing all slave ids.
-			$this->create_subnet_familytree($subnetId);
+			$tmp_table_name = $this->create_subnet_familytree($subnetId);
 
 			// Fetch all slaves
-			$slaves = $this->Database->getObjectsQuery("SELECT * FROM subnets AS slaves WHERE slaves.id IN (SELECT id FROM tmp_subnet_familytree_${subnetId});");
+			$query = 'SELECT subnets.* FROM subnets INNER JOIN `'.$tmp_table_name.'` AS slaves ON subnets.id = slaves.id';
+			$slaves = $this->Database->getObjectsQuery($query);
 
 			$this->slaves[] = $subnetId;
 


### PR DESCRIPTION
- Update Subnets::create_subnet_familytree() to require fewer temporary tables.

- Rewrite SQL used within Subnets::fetch_subnet_slaves_recursive() and Subnets::create_subnet_familytree() to use INNER JOINS in place of WHERE IN (SELECT id FROM $table) sub-queries. This improves the performance of these functions under MySQL 5.1/5.5.
      MySQL   5.1.73  (x86)   +500-750%
      MySQL   5.5.57  (ARMv7) +500-850%
      MariaDB 10.1.25 (x64)   +10-20%

- Add Subnet table indexes for masterSubnetId, sectionId and vrfId.    
    Indexes used by functions; has_slaves(), fetch_section_subnets(), subnet_familytree_*(), verify_subnet_overlapping(), verify_vrf_overlapping(), findObjectsQuery(), fetch_subnet_slaves(), fetch_subnet_slaves_recursive(), fetch_overlapping_subnets() ...
