### PR TITLE
Further fix #1381 - Location name 1+ characters

### DIFF
--- a/app/admin/locations/edit-result.php
+++ b/app/admin/locations/edit-result.php
@@ -29,7 +29,7 @@ if($_POST['action']=="delete" || $_POST['action']=="edit") {
 }
 if($_POST['action']=="add" || $_POST['action']=="edit") {
     // name
-    if(strlen($_POST['name'])<2)                                            {  $Result->show("danger",  _("Name must have at least 2 characters"), true); }
+    if(strlen($_POST['name'])<1)                                            {  $Result->show("danger",  _("Name must have at least 1 character"), true); }
     // lat, long
     if($_POST['action']!=="delete") {
         // lat


### PR DESCRIPTION
Allow locations names to be as short as a single character. The limit was recently adjusted from 3 to 2, this is to be even less restrictive.