### PR TITLE
Edit Sections: delegate permissions speedup

### DIFF
--- a/functions/classes/class.Log.php
+++ b/functions/classes/class.Log.php
@@ -747,10 +747,10 @@ class Logging extends Common_functions {
 		// check if syslog globally enabled and write log
 	    if($this->settings->enableChangelog==1) {
 		    # get user details and initialize required objects
-			$this->Addresses = new Addresses ($this->Database);
-			$this->Subnets   = new Subnets ($this->Database);
-			$this->Sections  = new Sections ($this->Database);
-			$this->Tools     = new Tools ($this->Database);
+		    if (!is_object($this->Addresses)) $this->Addresses = new Addresses ($this->Database);
+		    if (!is_object($this->Subnets))   $this->Subnets   = new Subnets ($this->Database);
+		    if (!is_object($this->Sections))  $this->Sections  = new Sections ($this->Database);
+		    if (!is_object($this->Tools))     $this->Tools     = new Tools ($this->Database);
 
 		    # unset unneeded values and format
 		    $this->changelog_unset_unneeded_values ();
@@ -1618,8 +1618,8 @@ class Logging extends Common_functions {
 	public function fetch_subnet_addresses_changelog_recursive ($subnetId, $limit = 50) {
 	    # get all addresses ids
 	    $ips  = array();
-		$Addresses = new Addresses ($this->Database);
-	    $ips = $Addresses->fetch_subnet_addresses_recursive ($subnetId, false);
+	    if (!is_object($this->Addresses)) $this->Addresses = new Addresses ($this->Database);
+	    $ips = $this->Addresses->fetch_subnet_addresses_recursive ($subnetId, false);
 
 	    # fetch changelog for IPs
 	    if(sizeof($ips) > 0) {
@@ -1717,22 +1717,22 @@ class Logging extends Common_functions {
     	if(!is_numeric($subnetId))     { $this->Result->show("danger", "Invalid subnet Id", true);	return false; }
 
 		# fetch all slave subnet ids
-		$Subnets = new Subnets ($this->Database);
-		$Subnets->reset_subnet_slaves_recursive ();
-		$Subnets->fetch_subnet_slaves_recursive ($subnetId);
+		if (!is_object($this->Subnets)) $this->Subnets = new Subnets ($this->Database);
+		$this->Subnets->reset_subnet_slaves_recursive ();
+		$this->Subnets->fetch_subnet_slaves_recursive ($subnetId);
 		# remove master subnet ID
-		$key = array_search($subnetId, $Subnets->slaves);
-		unset($Subnets->slaves[$key]);
-		$Subnets->slaves = array_unique($Subnets->slaves);
+		$key = array_search($subnetId, $this->Subnets->slaves);
+		unset($this->Subnets->slaves[$key]);
+		$this->Subnets->slaves = array_unique($this->Subnets->slaves);
 
 	    # if some slaves are present get changelog
-	    if(sizeof($Subnets->slaves) > 0) {
+	    if(sizeof($this->Subnets->slaves) > 0) {
 		    # set query
 		    $query  = "select
 						`u`.`real_name`,`o`.`sectionId`,`o`.`subnet`,`o`.`mask`,`o`.`isFolder`,`o`.`description`,`o`.`id`,`c`.`caction`,`c`.`cresult`,`c`.`cdate`,`c`.`cdiff`  from `changelog` as `c`, `users` as `u`, `subnets` as `o`
 						where `c`.`cuser` = `u`.`id` and `c`.`coid`=`o`.`id`
 						and (";
-			foreach($Subnets->slaves as $slaveId) {
+			foreach($this->Subnets->slaves as $slaveId) {
 			if(!isset($args)) $args = array();
 			$query .= "`c`.`coid` = ? or ";
 			$args[] = $slaveId;							//set keys
@@ -1778,7 +1778,7 @@ class Logging extends Common_functions {
 	public function changelog_send_mail ($changelog) {
 
 		# initialize tools class
-		$this->Tools = new Tools ($this->Database);
+		if (!is_object($this->Tools)) $this->Tools = new Tools ($this->Database);
 
 		# set object
 		$obj_details = $this->object_action == "add" ? $this->object_new : $this->object_old;

--- a/functions/classes/class.PDO.php
+++ b/functions/classes/class.PDO.php
@@ -827,6 +827,36 @@ abstract class DB {
 		//execute
 		return $this->runQuery('TRUNCATE TABLE `'.$tableName.'`;');
 	}
+
+	/**
+	 * Begin SQL Transaction
+	 *
+	 * @access public
+	 * @return bool
+	 */
+	public function beginTransaction() {
+		return $this->pdo->beginTransaction();
+	}
+
+	/**
+	 * Commit SQL Transaction
+	 *
+	 * @access public
+	 * @return bool
+	 */
+	public function commit() {
+		return $this->pdo->commit();
+	}
+
+	/**
+	 * Commit SQL Transaction
+	 *
+	 * @access public
+	 * @return bool
+	 */
+	public function rollBack() {
+		return $this->pdo->rollBack();
+	}
 }
 
 


### PR DESCRIPTION
- Performance: Update delegate_section_permissions() to use SQL transactions.
    
    Delegating permissions will inspect each subnet within the section. For each subnet (1000's+) the subnet permissions are updated, the users last activity time updated and informational + change log records are generated.
    
    SQL transactions ensure the associated table indexes are updated only once at the final commit() instead of at every record update/insert.
    
    This also prevents a partial application of requested changes.
    
    delegate_section_permissions(), section containing ~8000 subnets.
    105 seconds -> 7 seconds.

- Feature: Expose PDO SQL transaction functions in class.PDO

 - Performance: Don't overwrite existing class.Log internal classes on every write_changelog call.
    ... $this->Subnets = new Subnets,  $this->Tools = new Tools
   This eats CPU and means we can't use take advantage of caching in $this->Subnets.