### PR TITLE
class.Thread.php: Use streams for IPC & pingCheck.php/discoveryCheck.php cleanup

### DIFF
--- a/functions/classes/class.Thread.php
+++ b/functions/classes/class.Thread.php
@@ -79,6 +79,16 @@ class PingThread {
     }
 
 	/**
+	* class destructor
+	*/
+	public function __destruct() {
+		if ( $this->isAlive() ) {
+			//and kill the child using posix_kill ( exit(0) duplicates headers!! )
+			posix_kill($this->pid, SIGKILL);
+		}
+	}
+
+	/**
 	* sets the callback
 	*
 	* @param callback $_runnable

--- a/functions/classes/class.Thread.php
+++ b/functions/classes/class.Thread.php
@@ -86,11 +86,13 @@ class PingThread {
 
 		/* On Windows we need to use AF_INET */
 		$domain = (strtoupper(substr(PHP_OS, 0, 3)) == 'WIN') ?  STREAM_PF_INET : STREAM_PF_UNIX;
-		$this->sockets = stream_socket_pair($domain, STREAM_SOCK_STREAM, 0);
+		$this->sockets = stream_socket_pair($domain, STREAM_SOCK_STREAM, STREAM_IPPROTO_IP);
 
 		if ($this->sockets === false) {
 			throw new Exception( $this->getError( PingThread::IPC_SOCKET_FAILED ), PingThread::IPC_SOCKET_FAILED );
 		}
+		stream_set_blocking($this->sockets[0], 1);
+		stream_set_blocking($this->sockets[1], 1);
     }
 
 	/**
@@ -197,6 +199,7 @@ class PingThread {
             // child
             $this->pid = posix_getpid();//pid (child)
             $this->ppid = posix_getppid();//pid (parent)
+            proc_nice(9);
 
             pcntl_signal( SIGTERM, array( $this, 'signalHandler' ) );
             $arguments = func_get_args();
@@ -232,6 +235,7 @@ class PingThread {
 		} else { // child
 			$this->pid = posix_getpid();//pid (child)
 			$this->ppid = posix_getppid();//pid (parent)
+			proc_nice(9);
 
 			pcntl_signal( SIGTERM, array( $this, 'signalHandler' ) );
 			$array_args = func_get_args();

--- a/functions/scripts/discoveryCheck.php
+++ b/functions/scripts/discoveryCheck.php
@@ -113,24 +113,23 @@ $z = 0;			//addresses array index
 
 // let's just reindex the subnets array to save future issues
 $scan_subnets   = array_values($scan_subnets);
-$size_subnets   = count($scan_subnets);
-$size_addresses = max(array_keys($addresses));
 
 //different scan for fping
 if($Scan->icmp_type=="fping") {
 	//run per MAX_THREADS
-	for ($m=0; $m<=$size_subnets; $m += $Scan->settings->scanMaxThreads) {
+	$size_subnets = sizeof($scan_subnets);
+	for ($m=0; $m < $size_subnets; $m += $Scan->settings->scanMaxThreads) {
 	    // create threads
 	    $threads = array();
 	    //fork processes
-	    for ($i = 0; $i <= $Scan->settings->scanMaxThreads && $i <= $size_subnets; $i++) {
+	    for ($i = 0; $i < $Scan->settings->scanMaxThreads; $i++) {
 	    	//only if index exists!
 	    	if(isset($scan_subnets[$z])) {
 				//start new thread
 	            $threads[$z] = new PingThread( 'fping_subnet' );
 				$threads[$z]->start_fping( $Subnets->transform_to_dotted($scan_subnets[$z]->subnet)."/".$scan_subnets[$z]->mask );
-	            $z++;				//next index
 			}
+			$z++;				//next index
 	    }
 		// wait for all the threads to finish
 		foreach($threads as $index => $thread) {
@@ -161,19 +160,20 @@ if($Scan->icmp_type=="fping") {
 //ping, pear
 else {
 	//run per MAX_THREADS
-    for ($m=0; $m<=$size_addresses; $m += $Scan->settings->scanMaxThreads) {
+    $size_addresses = sizeof($addresses);
+    for ($m=0; $m < $size_addresses; $m += $Scan->settings->scanMaxThreads) {
         // create threads
         $threads = array();
 
         //fork processes
-        for ($i = 0; $i <= $Scan->settings->scanMaxThreads && $i <= $size_addresses; $i++) {
+        for ($i = 0; $i < $Scan->settings->scanMaxThreads; $i++) {
         	//only if index exists!
         	if(isset($addresses[$z])) {
 				//start new thread
 	            $threads[$z] = new PingThread( 'ping_address' );
 	            $threads[$z]->start( $Subnets->transform_to_dotted($addresses[$z]['ip_addr']) );
-				$z++;			//next index
 			}
+			$z++;			//next index
         }
 
         // wait for all the threads to finish
@@ -185,7 +185,7 @@ else {
 						unset($addresses[$index]);
 					}
                     //remove thread
-                    unset( $threads[$index]);
+                    unset($threads[$index]);
                 }
             }
             usleep(200000);

--- a/functions/scripts/discoveryCheck.php
+++ b/functions/scripts/discoveryCheck.php
@@ -132,28 +132,17 @@ if($Scan->icmp_type=="fping") {
 	            $z++;				//next index
 			}
 	    }
-	    // wait for all the threads to finish
-	    while( !empty( $threads ) ) {
-			foreach($threads as $index => $thread) {
-				$child_pipe = "/tmp/pipe_".$thread->getPid();
+		// wait for all the threads to finish
+		foreach($threads as $index => $thread) {
+			fclose($thread->sockets[0]);
 
-				if (file_exists($child_pipe)) {
-					$file_descriptor = fopen( $child_pipe, "r");
-					$child_response = "";
-					while (!feof($file_descriptor)) {
-						$child_response .= fread($file_descriptor, 8192);
-					}
-					//we have the child data in the parent, but serialized:
-					$child_response = unserialize( $child_response );
-					//store
-					$scan_subnets[$index]->discovered = $child_response;
-					//now, child is dead, and parent close the pipe
-					unlink( $child_pipe );
-					unset($threads[$index]);
-				}
+			$child_response = fgets($thread->sockets[1]);
+			if ($child_response !== false) {
+				$scan_subnets[$index]->discovered = json_decode($child_response);
 			}
-	        usleep(200000);
-	    }
+			fclose($thread->sockets[1]);
+			unset($threads[$index]);
+		}
 	}
 
 	//fping finds all subnet addresses, we must remove existing ones !

--- a/functions/scripts/discoveryCheck.php
+++ b/functions/scripts/discoveryCheck.php
@@ -35,6 +35,13 @@ $Scan		= new Scan ($Database);
 $DNS		= new DNS ($Database);
 $Result		= new Result();
 
+// Check if we are already running
+$fp = fopen(sys_get_temp_dir().'/phpipam-'.hash('sha256',__FILE__).'.lock', 'c');
+if ($fp === false || !flock($fp, LOCK_EX | LOCK_NB)) {
+	die("Another instance of this script is running.\n");
+}
+
+
 // set exit flag to true
 $Scan->ping_set_exit(true);
 // set debugging

--- a/functions/scripts/pingCheck.php
+++ b/functions/scripts/pingCheck.php
@@ -160,18 +160,19 @@ $z = 0;			//addresses array index
 //different scan for fping
 if($Scan->icmp_type=="fping") {
 	//run per MAX_THREADS
-	for ($m=0; $m<=sizeof($subnets); $m += $Scan->settings->scanMaxThreads) {
+	$size_subnets = sizeof($subnets);
+	for ($m=0; $m < $size_subnets; $m += $Scan->settings->scanMaxThreads) {
 	    // create threads
 	    $threads = array();
 	    //fork processes
-	    for ($i = 0; $i <= $Scan->settings->scanMaxThreads && $i <= sizeof($subnets); $i++) {
+	    for ($i = 0; $i < $Scan->settings->scanMaxThreads; $i++) {
 	    	//only if index exists!
 	    	if(isset($subnets[$z])) {
 				//start new thread
 	            $threads[$z] = new PingThread( 'fping_subnet' );
 	            $threads[$z]->start_fping( $subnets[$z]['cidr'] );
-	            $z++;				//next index
 			}
+			$z++;				//next index
 	    }
 		// wait for all the threads to finish
 		foreach($threads as $index => $thread) {
@@ -226,18 +227,19 @@ if($Scan->icmp_type=="fping") {
 //ping, pear
 else {
 	//run per MAX_THREADS
-	for ($m=0; $m<=sizeof($addresses); $m += $Scan->settings->scanMaxThreads) {
+	$size_addresses = sizeof($addresses);
+	for ($m=0; $m < $size_addresses; $m += $Scan->settings->scanMaxThreads) {
 	    // create threads
 	    $threads = array();
 	    //fork processes
-	    for ($i = 0; $i <= $Scan->settings->scanMaxThreads && $i <= sizeof($addresses); $i++) {
+	    for ($i = 0; $i < $Scan->settings->scanMaxThreads; $i++) {
 	    	//only if index exists!
 	    	if(isset($addresses[$z])) {
 				//start new thread
 	            $threads[$z] = new PingThread( 'ping_address' );
 	            $threads[$z]->start($Subnets->transform_to_dotted($addresses[$z]['ip_addr']));
-	            $z++;				//next index
 			}
+			$z++;				//next index
 	    }
 	    // wait for all the threads to finish
 	    while( !empty( $threads ) ) {

--- a/functions/scripts/pingCheck.php
+++ b/functions/scripts/pingCheck.php
@@ -43,6 +43,13 @@ $Scan		= new Scan ($Database);
 $DNS		= new DNS ($Database);
 $Result		= new Result();
 
+// Check if we are already running
+$fp = fopen(sys_get_temp_dir().'/phpipam-'.hash('sha256',__FILE__).'.lock', 'c');
+if ($fp === false || !flock($fp, LOCK_EX | LOCK_NB)) {
+	die("Another instance of this script is running.\n");
+}
+
+
 // set exit flag to true
 $Scan->ping_set_exit(true);
 // set debugging


### PR DESCRIPTION
I've tested under CentOS 6.9/Ubuntu/Fedora using php5.3-php7.1. Windows PHP is supported via STREAM_PF_INET instead of STREAM_PF_UNIX socket pairs but is untested.

- Restrict ping and discovery scans to one running instance each.
  [cron every 5mins but takes 10mins to scan == lots of running threads! ]

- Use stream_socket_pair() for Thread inter-process-communication instead of creating posix_mkfifo() files on /tmp which may be on tmpfs and be space limited and/or be unreliable.
The parent relies on the child creating the \tmp file. If this does not happen the parent process infinite loops waiting for the file to be created.

- nice(9) all child threads.

- IPC setup/teardown and handle errors in Thread __construct() __destruct().

- Handle edge-case errors where child thread dies or is OOM terminated.
IPC sockets are closed and detected by parent.

- Use JSON for IPC.

- Cleanup  pingCheck/discoveryCheck scripts. Fix off-by-one and other minor issues.

- Fix minor errors reported by scrutinizer. 