### PR TITLE
Fix due to 'Change dns_name to hostname'

### DIFF
--- a/app/subnets/addresses/address-details-index.php
+++ b/app/subnets/addresses/address-details-index.php
@@ -45,7 +45,7 @@ if($subnet_permission == 0)				{ $Result->show("danger", _('You do not have perm
 
  # resolve dns name
 $DNS = new DNS ($Database);
-$resolve = $DNS->resolve_address($address['ip_addr'], $address['dns_name'], false, $subnet['nameserverId']);
+$resolve = $DNS->resolve_address($address['ip_addr'], $address['hostname'], false, $subnet['nameserverId']);
 
 # reformat empty fields
 $address = $Addresses->reformat_empty_array_fields($address, "<span class='text-muted'>/</span>");


### PR DESCRIPTION
Due to the name change of the dns_name field to hostname (which on my phpipam instance made dns_name a custom field, if I remember correctly and which I later removed), following code change is needed to display the info from the hostname field.
( there are still more instances where dns_name as word is still present in the current code - haven't checked these other instances yet for impact so for now just fixing this case which did have impact )