### PR TITLE
Use PHP_BINARY instead of PHP_BINDIR to detect the php executable

### DIFF
--- a/functions/classes/class.Scan.php
+++ b/functions/classes/class.Scan.php
@@ -201,7 +201,7 @@ class Scan extends Common_functions {
 	 * @return void
 	 */
 	private function set_php_exec () {
-		$this->php_exec = $this->os_type=="Windows" ? PHP_BINARY : PHP_BINDIR."/php";
+		$this->php_exec = PHP_BINARY;
 	}
 
 	/**


### PR DESCRIPTION
Fixes #1732

(cherry picked from commit 56a68bec9aba1da08743e022c0e4ef721748b950)