### PR TITLE
Remove user hint upon login.

### DIFF
--- a/functions/classes/class.User.php
+++ b/functions/classes/class.User.php
@@ -1061,7 +1061,7 @@ class User extends Common_functions {
                 # add blocked count
                 $this->block_ip();
                 $this->Log->write($method . " login", "User $username failed to authenticate against " . $method, 1, $username);
-                $this->Result->show("danger", _("Invalid username or password for " . $username ), true);
+                $this->Result->show("danger", _("Invalid username or password"), true);
 
             }
         } catch (adLDAPException $e) {


### PR DESCRIPTION
Hi,
when authenticating via ldap, if the login is incorrect the form returns a username and an ldap dn.
It could possibly lead to ldap users enumeration, and it can also give information about ldap structure by displaying the dn. 
Simply reverting to a default message solves this issue.