### PR TITLE
Fix a bunch of implicit const to string assumptions

### DIFF
--- a/app/login/login_check.php
+++ b/app/login/login_check.php
@@ -36,7 +36,7 @@ if( !empty($_POST['ipamusername']) && !empty($_POST['ipampassword']) )  {
 	}
 	# count set, captcha required
 	elseif(!isset($_POST['captcha'])) {
-		$Log->write( "Login IP blocked", "Login from IP address $_SERVER[REMOTE_ADDR] was blocked because of 5 minute block after 5 failed attempts", 1);
+		$Log->write( "Login IP blocked", "Login from IP address ".$_SERVER['REMOTE_ADDR']." was blocked because of 5 minute block after 5 failed attempts", 1);
 		$Result->show("danger", _('You have been blocked for 5 minutes due to authentication failures'), true);
 	}
 	# captcha check

--- a/functions/classes/class.Common.php
+++ b/functions/classes/class.Common.php
@@ -817,27 +817,27 @@ class Common_functions  {
 	public function createURL () {
 		// SSL on standard port
 		if(($_SERVER['HTTPS'] == 'on') || ($_SERVER['SERVER_PORT'] == 443)) {
-			$url = "https://$_SERVER[HTTP_HOST]";
+			$url = "https://".$_SERVER['HTTP_HOST'];
 		}
 		// reverse proxy doing SSL offloading
-        elseif(isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] == 'https') {
-            if (isset($_SERVER[HTTP_X_FORWARDED_HOST])) {
-                $url = "https://$_SERVER[HTTP_X_FORWARDED_HOST]";
-            }
-            else {
-                $url = "https://$_SERVER[HTTP_HOST]";
-            }
-        }
+		elseif(isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] == 'https') {
+			if (isset($_SERVER['HTTP_X_FORWARDED_HOST'])) {
+				$url = "https://".$_SERVER['HTTP_X_FORWARDED_HOST'];
+			}
+			else {
+				$url = "https://".$_SERVER['HTTP_HOST'];
+			}
+		}
 		elseif(isset($_SERVER['HTTP_X_SECURE_REQUEST'])  && $_SERVER['HTTP_X_SECURE_REQUEST'] == 'true') {
-			$url = "https://$_SERVER[SERVER_NAME]";
+			$url = "https://".$_SERVER['SERVER_NAME'];
 		}
 		// custom port
 		elseif($_SERVER['SERVER_PORT']!="80" && (isset($_SERVER['HTTP_X_FORWARDED_PORT']) && $_SERVER['HTTP_X_FORWARDED_PORT']!="80")) {
-			$url = "http://$_SERVER[SERVER_NAME]:$_SERVER[SERVER_PORT]";
+			$url = "http://".$_SERVER['SERVER_NAME'].":".$_SERVER['SERVER_PORT'];
 		}
 		// normal http
 		else {
-			$url = "http://$_SERVER[HTTP_HOST]";
+			$url = "http://".$_SERVER['HTTP_HOST'];
 		}
 
 		//result

--- a/functions/classes/class.Log.php
+++ b/functions/classes/class.Log.php
@@ -475,7 +475,7 @@ class Logging extends Common_functions {
 
 		# open syslog and write log
 		openlog('phpipam', LOG_NDELAY | LOG_PID, $this->syslog_facility);
-		syslog($this->syslog_priority, "$_SERVER[REMOTE_ADDR] | ".$username.$this->log_command." | ".$this->log_details);
+		syslog($this->syslog_priority, $_SERVER['REMOTE_ADDR']." | ".$username.$this->log_command." | ".$this->log_details);
 
 		# close
 		closelog();


### PR DESCRIPTION
Implicit conversion of constants to strings doesn't work in PHP 7.0 and higher. I noticed this was broken because it wasn't working at all behind a proxy server.