### PR TITLE
Add custom_ prefix to Prefix controller custom fields

### DIFF
--- a/api/controllers/Prefix.php
+++ b/api/controllers/Prefix.php
@@ -63,7 +63,7 @@ class Prefix_controller extends Common_api_functions {
      * @var string
      * @access private
      */
-    private $custom_field_name = "customer_type";
+    private $custom_field_name = "custom_customer_type";
 
     /**
      * This selector will be used to order found subnets
@@ -100,7 +100,7 @@ class Prefix_controller extends Common_api_functions {
      * @var string
      * @access private
      */
-    private $custom_field_name_addr = "customer_address_type";
+    private $custom_field_name_addr = "custom_customer_address_type";
 
     /**
      * External identifier to link subnets and addresses with


### PR DESCRIPTION
The prefix controller always fails with the `Invalid custom field customer_type` message because when custom fields are created, they are prefixed with `custom_`.

