### PR TITLE
Fix cookie setting

### DIFF
--- a/js/magic.js
+++ b/js/magic.js
@@ -215,7 +215,7 @@ function createCookie(name,value,days) {
 	    var expires = "";
     }
 
-    document.cookie = name+"="+value+expires+"; path=/";
+    document.cookie = name+"="+encodeURI(value)+expires+"; path=/";
 }
 function readCookie(name) {
     var nameEQ = name + "=";

--- a/js/magic.js
+++ b/js/magic.js
@@ -212,7 +212,7 @@ function createCookie(name,value,days) {
         expires = "; expires="+date.toGMTString();
     }
     else {
-	    var expires = "";
+        var expires = "";
     }
 
     document.cookie = name+"="+encodeURI(value)+expires+"; path=/";

--- a/js/magic.js
+++ b/js/magic.js
@@ -206,7 +206,7 @@ function createCookie(name,value,days) {
     var date;
     var expires;
 
-    if (typeof days === 'undefined') {
+    if (typeof days !== 'undefined') {
         date = new Date();
         date.setTime(date.getTime()+(days*24*60*60*1000));
         expires = "; expires="+date.toGMTString();


### PR DESCRIPTION
Expiry date was never set correctly as the logic only set it, calculated based on the `days` variable, when `days` was `undefined`.

Cookie value should be URI encoded as `"` characters are illegal in cookies and thus don't work in purist browsers such as Opera

Small whitespace fix