### PR TITLE
Bugfix: wrong field name of deviceTypes table when checking device type

### DIFF
--- a/api/controllers/Devices.php
+++ b/api/controllers/Devices.php
@@ -344,7 +344,7 @@ class Devices_controller extends Common_api_functions {
                 $this->Response->throw_exception(400, 'Invalid devicetype identifier');
             }
             // check
-            if ($this->Tools->fetch_object('deviceTypes', 'id', $this->_params->type) === false) {
+            if ($this->Tools->fetch_object('deviceTypes', 'tid', $this->_params->type) === false) {
                 $this->Response->throw_exception(400, 'Device type does not exist');
             }
         }


### PR DESCRIPTION
The API return an error when we try to create a device giving a type:
`Cannot add object: Expecting value: line 1 column 1 (char 0)`