### PR TITLE
Ldap auth with dn found at user_base_dn using filter by uid_attr

### DIFF
--- a/functions/adLDAP/src/classes/adLDAPUsers.php
+++ b/functions/adLDAP/src/classes/adLDAPUsers.php
@@ -647,6 +647,22 @@ class adLDAPUsers {
         }
         return ($usersArray);
     }
+
+    /**
+     * Return a list of all entries at baseDn with filter applying
+     *
+     * @param string $baseDn
+     * @param string $filters
+     * @return array
+     */
+    public function search($baseDn, $filters) {
+        if (!$this->adldap->getLdapBind()) { return false; }
+
+        $sr = ldap_search($this->adldap->getLdapConnection(), $baseDn, $filters);
+        $entries = ldap_get_entries($this->adldap->getLdapConnection(), $sr);
+
+        return $entries;
+    }
     
     /**
     * Move a user account to a different OU


### PR DESCRIPTION
Problem:
At current version of phpipam username (at phpipam) should be part of LDAP DN  (`uid=username` or `cn=username`). 

There is a problem because if we configure ldap DN like this: `cn = Darya kamynina, ou = People, dc = mobbtech, dc = com` we should in PHPIPAM use `username` = `ldap cn`, but we want to use `username`=`ldap uid`

In this PR  at the first we are looking for ldap entry in `user_base_dn` and filter by `uid_attr`, extract DN then and use it for authenticate.