### PR TITLE
fix login bug

### DIFF
--- a/functions/classes/class.User.php
+++ b/functions/classes/class.User.php
@@ -768,7 +768,7 @@ class User extends Common_functions {
             $username = SAML_USERNAME;
         }
         # first we need to check if username exists
-        $this->fetch_user_details ($username);
+        $this->fetch_user_details ($username, true);
         # set method type if set, otherwise presume local auth
         $this->authmethodid = strlen(@$this->user->authMethod)>0 ? $this->user->authMethod : 1;
 


### PR DESCRIPTION
I fix a bug : if you open two login pages in chrome, and you entry into system with right username and password on one page,then you can entry into system with wrong username and password on another page. 