### PR TITLE
Make database grant host configureable

### DIFF
--- a/config.dist.php
+++ b/config.dist.php
@@ -9,6 +9,17 @@ $db['pass'] = 'phpipamadmin';
 $db['name'] = 'phpipam';
 $db['port'] = 3306;
 
+/**
+ * Database webhost settings
+ *
+ * Enable and change this setting if your MySQL database does not run on
+ * localhost and you want to use the automatic database installation method
+ * to create a database user for you (which by default is created @localhost)
+ *
+ * Set to the hostname or IP address of the webserver, or % to allow all
+ ******************************/
+#$db['webhost'] = 'localhost';
+
 
 /**
  *  SSL options for MySQL

--- a/functions/classes/class.Install.php
+++ b/functions/classes/class.Install.php
@@ -180,7 +180,7 @@ class Install extends Common_functions {
 	 */
 	private function create_grants () {
 	 	# set query
-	    $query = 'grant ALL on `'. $this->db['name'] .'`.* to '. $this->db['user'] .'@localhost identified by "'. $this->db['pass'] .'";';
+	    $query = 'grant ALL on `'. $this->db['name'] .'`.* to '. $this->db['user'] .'@' .(isset($this->db['webhost']) ? '\'' .$this->db['webhost'] .'\'' : 'localhost') .' identified by "'. $this->db['pass'] .'";';
 		# execute
 		try { $this->Database_root->runQuery($query); }
 		catch (Exception $e) {	$this->Result->show("danger", $e->getMessage(), true);}


### PR DESCRIPTION
When using the 'Automatic database installation' for a new install, when your MySQL server is not running on localhost and you use the option 'Set permissions to tables', a user is created with it's host set to 'localhost', which causes 2 queries to fail and the application not being able to reach it's database.

This PR adds a configuration option to set the grant host to something other than localhost when set (if not set, it will remain 'localhost').