### PR TITLE
Adding field length checks and limits for IP addresses

### DIFF
--- a/api/controllers/Addresses.php
+++ b/api/controllers/Addresses.php
@@ -609,6 +609,9 @@ class Addresses_controller extends Common_api_functions  {
 	 * @return void
 	 */
 	public function validate_create_parameters () {
+		// validate input lengths
+		$this->validate_parameter_lengths();
+
 		// validate subnet
 		$this->validate_subnet ();
 
@@ -663,6 +666,9 @@ class Addresses_controller extends Common_api_functions  {
 																							{ $this->Response->throw_exception(400, "No data provided"); }
 		}
 
+		// validate input lengths
+		$this->validate_parameter_lengths();
+
     	//validate and normalize MAC address
     	if(strlen($this->_params->mac)>0) {
         	if($this->validate_mac ($this->_params->mac)===false)                           { $this->Response->throw_exception(400, "Invalid MAC address"); }
@@ -680,5 +686,17 @@ class Addresses_controller extends Common_api_functions  {
 		if(isset($this->_params->state)) {
 		if($this->Tools->fetch_object("ipTags", "id", $this->_params->state)===false)		{ $this->Response->throw_exception(400, "Tag does not exist"); } }
 		else { $this->_params->state = 2; }
+	}
+
+	/**
+	 * Validation of POST and PATCH field lengths
+	 *
+	 * @access private
+	 * @return void
+	 */
+	private function validate_parameter_lengths () {
+		if (isset($this->_params->hostname) && mb_strlen($this->_params->hostname) > 255)	{ $this->Response->throw_exception(400, "Hostname too long"); }
+		if (isset($this->_params->description) && mb_strlen($this->_params->description) > 64)	{ $this->Response->throw_exception(400, "Description too long"); }
+		if (isset($this->_params->owner) && mb_strlen($this->_params->owner) > 32)	{ $this->Response->throw_exception(400, "Owner too long"); }
 	}
 }

--- a/app/subnets/addresses/address-modify-submit.php
+++ b/app/subnets/addresses/address-modify-submit.php
@@ -86,6 +86,11 @@ isset($address['subnet']) ?:		$Result->show("danger", _("Missing required fields
 isset($address['subnetId']) ?:		$Result->show("danger", _("Missing required fields"). " subnetId", true);
 isset($address['id']) ?:			$Result->show("danger", _("Missing required fields"). " id", true);
 
+# field lengths
+isset($address['hostname']) && mb_strlen($address['hostname']) > 255 &&	$Result->show("danger", _("Input too long for field"). " hostname", true);
+isset($address['description']) && mb_strlen($address['description']) > 64 &&	$Result->show("danger", _("Input too long for field"). " description", true);
+isset($address['owner']) && mb_strlen($address['owner']) > 32 &&	$Result->show("danger", _("Input too long for field"). " owner", true);
+
 # ptr
 if(!isset($address['PTRignore']))	$address['PTRignore']=0;
 

--- a/app/subnets/addresses/address-modify.php
+++ b/app/subnets/addresses/address-modify.php
@@ -232,7 +232,7 @@ function validate_mac (ip, mac, sectionId, vlanId, id) {
 		print '	<td>'._('Hostname').$required.'</td>'. "\n";
 		print '	<td>'. "\n";
 		print '	<div class="input-group">';
-		print ' <input type="text" name="hostname" class="ip_addr form-control input-sm" placeholder="'._('Hostname').'" value="'. $address['hostname']. '" '.$delete.'>'. "\n";
+		print ' <input type="text" name="hostname" class="ip_addr form-control input-sm" placeholder="'._('Hostname').'" value="'. $address['hostname']. '" '.$delete.' maxlength=255>'. "\n";
 		print '	 <span class="input-group-addon">'."\n";
 		print "		<i class='fa fa-gray fa-repeat' id='refreshHostname' data-subnetId='$subnetId' rel='tooltip' data-placement='right' title='"._('Click to check for hostname')."'></i></span>";
 		print "	</span>";
@@ -253,7 +253,7 @@ function validate_mac (ip, mac, sectionId, vlanId, id) {
 		<td>
 			<input type="text" name="description" class="ip_addr form-control input-sm" value="<?php if(isset($address['description'])) {print $address['description'];} ?>" size="30"
 			<?php if ( $act == "delete" ) { print " readonly";} ?>
-			placeholder="<?php print _('Description'); ?>">
+			placeholder="<?php print _('Description'); ?>" maxlength=64>
 		</td>
 	</tr>
 
@@ -473,7 +473,7 @@ function validate_mac (ip, mac, sectionId, vlanId, id) {
 		print '<tr>'. "\n";
 		print '	<td>'._('Owner').$required.'</td>'. "\n";
 		print '	<td>'. "\n";
-		print ' <input type="text" name="owner" class="ip_addr form-control input-sm" id="owner" placeholder="'._('IP address owner').'" value="'. $address['owner']. '" size="30" '.$delete.'>'. "\n";
+		print ' <input type="text" name="owner" class="ip_addr form-control input-sm" id="owner" placeholder="'._('IP address owner').'" value="'. $address['owner']. '" size="30" '.$delete.' maxlength=32>'. "\n";
 		print '	</td>'. "\n";
 		print '</tr>'. "\n";
 	}


### PR DESCRIPTION
When adding or changing IP addresses, there is no check on the max input length for the hostname, description and owner fields. In the database these are set at resp. 255, 64 and 32 characters.

With MySQL 5.6 this is silently truncated to the max length (which can cause the user not to notice his data was not fully saved). With MySQL 5.7 an error is thrown (both in the API and the GUI):

SQLSTATE[22001]: String data, right truncated: 1406 Data too long for column 'description' at row 1

This PR adds both backend checks for the max length of these fields for both the API and GUI, and sets a maxlength in the frontend.