### PR TITLE
Fix inconsistant API success value returned

### DIFF
--- a/api/controllers/Responses.php
+++ b/api/controllers/Responses.php
@@ -111,7 +111,7 @@ class Responses {
 		$this->exception = true;
 
 		// set success
-		$this->result['success'] = 0;
+		$this->result['success'] = false;
 		// set exit code
 		$this->result['code'] 	 = $code;
 		// set message


### PR DESCRIPTION
To be compatible with PhpIpam API documentation and strict typed non PHP Client, I have changed API Success value returned when Response Exception is throwing. Now the Success value will be false instead of 0. In PHP 0 it is same that false but not in all languanges.