### PR TITLE
Fix appended " U" in Rack description

### DIFF
--- a/app/tools/racks/print-single-rack.php
+++ b/app/tools/racks/print-single-rack.php
@@ -71,7 +71,7 @@ else {
 
         <tr>
             <th><?php print _("Description"); ?></th>
-            <td><?php print $rack->description; ?> U</td>
+            <td><?php print $rack->description; ?></td>
         </tr>
 
         <!-- Location -->


### PR DESCRIPTION
The rack details page unintentionally appends a suffix of " U" to the description field when displaying, just like the size field does but by intent. This simply removes that unintended suffix.