### PR TITLE
Check for null value on user creation

### DIFF
--- a/app/admin/users/edit-result.php
+++ b/app/admin/users/edit-result.php
@@ -59,6 +59,11 @@ if((strlen(@$_POST['password1'])>0 || (@$_POST['action']=="add") && $auth_method
 if(strlen(@$_POST['real_name'])==0)										{ $Result->show("danger", _("Real name field is mandatory!"), true); }
 # email format must be valid
 if (!$Result->validate_email(@$_POST['email'])) 						{ $Result->show("danger", _("Invalid email address!"), true); }
+# populate default value for perm_customers (NULL not allowed by DB)
+if ($_POST['perm_customers'] === NULL) { $_POST['perm_customers'] = 0; }
+
+
+
 
 # username must not already exist (if action is add)
 if ($_POST['action']=="add") {


### PR DESCRIPTION
This is a fix for #2162. The DB schema does not allow for null values, and has a default value of 1.

When you disable the customer module it ends up passing a null value into the set object array. I put in a check to set it to 0 here since, if the module is disabled, there shouldn't be access to it.