### PR TITLE
BUGFIX : bad DNS reverse zone for /23 subnet (#666)

### DIFF
--- a/functions/classes/class.PowerDNS.php
+++ b/functions/classes/class.PowerDNS.php
@@ -1445,7 +1445,7 @@ class PowerDNS extends Common_functions {
      */
     public function get_ptr_zone_name_v4 ($ip, $mask) {
         // check mask to see how many IP bits to remove
-        $bits = $mask<23 ? 2 : 1;
+        $bits = $mask<24 ? 2 : 1;
 
         // to array
         $zone = explode(".", $ip);


### PR DESCRIPTION
This is a bug fix for correcting bad DNS reverse zone for /23 subnet ( XX.XX.in-addr.arpa instead of XX.XX.XX.in-addr.arpa).
Bug already describe in #666.

Thanks.
