### PR TITLE
Fixes for Subnets_controller extending

### DIFF
--- a/api/controllers/Common.php
+++ b/api/controllers/Common.php
@@ -688,7 +688,7 @@ class Common_api_functions {
 	 */
 	protected function remove_folders ($result) {
 		// must be subnets
-		if($this->_params->controller!="subnets") {
+		if(!($this instanceof Subnets_controller)) {
 			return $result;
 		}
 		else {
@@ -716,7 +716,7 @@ class Common_api_functions {
 	 */
 	protected function remove_subnets ($result) {
 		// must be subnets
-		if($this->_params->controller!="folders") {
+		if(!($this instanceof Folders_controller)) {
 			return $result;
 		}
 		else {

--- a/api/controllers/Subnets.php
+++ b/api/controllers/Subnets.php
@@ -790,21 +790,21 @@ class Subnets_controller extends Common_api_functions {
 	/**
 	 * Returns id of subnet gateay
 	 *
-	 * @access private
+	 * @access protected
 	 * @return int|bool
 	 */
-	private function read_subnet_gateway ($id=NULL) {
+	protected function read_subnet_gateway ($id=NULL) {
 		return $id === NULL ? $this->Subnets->find_gateway ($this->_params->id) : $this->Subnets->find_gateway ($id);
 	}
 
 	/**
 	 * Returns nameserver details
 	 *
-	 * @access private
+	 * @access protected
 	 * @param mixed $nsid
 	 * @return array|false
 	 */
-	private function read_subnet_nameserver ($nsid) {
+	protected function read_subnet_nameserver ($nsid) {
     	return $this->Tools->fetch_object ("nameservers", "id", $nsid);
 	}
 


### PR DESCRIPTION
In order to allow custom controler to extend base controler, base method must be in protected mode and not in private.

Custom controler has custom name so actions must not detect controler by name but by parent class:
http://php.net/manual/en/language.operators.type.php