### PR TITLE
API - USER  calls + fix #2291 - part1 

### DIFF
--- a/api/controllers/User.php
+++ b/api/controllers/User.php
@@ -175,7 +175,7 @@ class User_controller extends Common_api_functions {
 	 */
 	public function GET () {
 		// token_expires
-		if ($this->_params->id=="token_expires" || $this->_params->id=="expires" || !isset($this->_params->id) || $this->_params->id=="all" || $this->_params->id=="admins") {
+		if ($this->_params->id=="token_expires" || $this->_params->id=="token" || !isset($this->_params->id) || $this->_params->id=="all" || $this->_params->id=="admins") {
 			// block IP
 			$this->validate_block ();
 			// validate token


### PR DESCRIPTION
According to documentation the valid API calls are;
/api/my_app/user/
/api/my_app/user/token/
/api/my_app/user/token_expires/	
/api/my_app/user/all/
/api/my_app/user/admins/

so I think    $this->_params->id=="expires"   should be  $this->_params->id=="token"