### PR TITLE
Closes #1401

### DIFF
--- a/functions/classes/class.Addresses.php
+++ b/functions/classes/class.Addresses.php
@@ -464,7 +464,8 @@ class Addresses extends Common_functions {
 						"note"        =>@$address['note'],
 						"is_gateway"  =>@$address['is_gateway'],
 						"excludePing" =>@$address['excludePing'],
-						"PTRignore"   =>@$address['PTRignore']
+						"PTRignore"   =>@$address['PTRignore'],
+						"lastSeen"    =>@$address['lastSeen']
 						);
 		# permissions
 		if($User->get_module_permissions ("devices")<1) {


### PR DESCRIPTION
PATCH api requests to update lastSeen field of ip addresses did not work.
The reason for this is missing array element in class.Addresses.php inside the **modify_address_edit** method.