### PR TITLE
made edit form skip latlong lookups if the API key is undefined

### DIFF
--- a/app/admin/locations/edit-result.php
+++ b/app/admin/locations/edit-result.php
@@ -50,7 +50,7 @@ if($_POST['action']=="add" || $_POST['action']=="edit") {
         }
 
         // fetch latlng
-        if(strlen($_POST['lat'])==0 && strlen($_POST['long'])==0 && strlen($_POST['address'])>0) {
+        if(strlen($gmaps_api_key)!=0 && strlen($_POST['lat'])==0 && strlen($_POST['long'])==0 && strlen($_POST['address'])>0) {
             $latlng = $Tools->get_latlng_from_address ($_POST['address']);
             if($latlng['lat']!=NULL && $latlng['lng']!=NULL) {
                 $_POST['lat'] = $latlng['lat'];


### PR DESCRIPTION
It seems the lat/long lookup when editing locations has stopped working without a valid Google Maps API key. This causes the edit form to successfully update as expected, but it doesn't close the form because it failed to talk to the Maps API. 

This change skips that check if the key is undefined or defined as an empty string in config.php
`$gmaps_api_key = ""`