### PR TITLE
Fix api https check for reverse proxies

### DIFF
--- a/api/index.php
+++ b/api/index.php
@@ -99,7 +99,7 @@ try {
 	// SSL checks
 	elseif($app->app_security=="ssl_token" || $app->app_security=="ssl_code") {
 		// verify SSL
-		if (!((!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off') || $_SERVER['SERVER_PORT'] == 443)) {
+		if (!(new Common_functions())->isHttps()) {
 															{ $Response->throw_exception(503, 'App requires SSL connection'); }
 		}
 		// save request parameters

--- a/functions/classes/class.Common.php
+++ b/functions/classes/class.Common.php
@@ -833,6 +833,24 @@ class Common_functions  {
     	// return
     	return $mac;
 	}
+	
+	/**
+	* Returns true if site is accessed with https
+	*
+	* @access public
+	* @return bool
+	*/
+	public function isHttps() {
+		$isSecure = false;
+		if (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] == 'on') {
+			$isSecure = true;
+		}
+		elseif (!empty($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] == 'https' || !empty($_SERVER['HTTP_X_FORWARDED_SSL']) && $_SERVER['HTTP_X_FORWARDED_SSL'] == 'on') {
+			$isSecure = true;
+		}
+		
+		return $isSecure;
+	}
 
 	/**
 	 * Create URL for base


### PR DESCRIPTION
With the previous method, HTTPS was not detected if phpipam was running behind an reverse proxy.

Now the check works correctly.