### PR TITLE
fetch circuit comment from DB

### DIFF
--- a/functions/classes/class.Tools.php
+++ b/functions/classes/class.Tools.php
@@ -2916,7 +2916,7 @@ class Tools extends Common_functions {
 	public function fetch_all_circuits ($custom_circuit_fields = array ()) {
 		// set query
 		$query[] = "select";
-		$query[] = "c.id,c.cid,c.type,c.device1,c.location1,c.device2,c.location2,c.customer_id,p.name,p.description,p.contact,c.capacity,p.id as pid,c.status";
+		$query[] = "c.id,c.cid,c.type,c.device1,c.location1,c.device2,c.location2,c.comment,c.customer_id,p.name,p.description,p.contact,c.capacity,p.id as pid,c.status";
 		// custom fields
 		if(is_array($custom_circuit_fields)) {
 			if(sizeof($custom_circuit_fields)>0) {


### PR DESCRIPTION
The circuit comment was never fetched from the database, so on the /tools/circuits/ page the comment column was always empty.