### PR TITLE
fix: redirect problem in login form

### DIFF
--- a/functions/classes/class.User.php
+++ b/functions/classes/class.User.php
@@ -495,7 +495,7 @@ class User extends Common_functions {
     private function set_redirect_cookie () {
         # save current redirect vaule
         if($_SERVER['SCRIPT_URL']!="/login/" && $_SERVER['SCRIPT_URL']!="logout" && $_SERVER['SCRIPT_URL']!="?page=login" && $_SERVER['SCRIPT_URL']!="?page=logout" && $_SERVER['SCRIPT_URL']!="index.php?page=login" && $_SERVER['SCRIPT_URL']!="index.php?page=logout" && $_SERVER['SCRIPT_URL']!="/" && $_SERVER['SCRIPT_URL']!="%2f");
-        setcookie("phpipamredirect", preg_replace('/^\/+/', '/', $_SERVER['REQUEST_URI']), time()+10, "/", null, null, true);
+        setcookie("phpipamredirect", preg_replace('/^\/+/', BASE, $_SERVER['REQUEST_URI']), time()+10, "/", null, null, true);
     }
 
     /**


### PR DESCRIPTION
Hi

I'm using phpipam behind a reverse proxy.
I have changed a BASE directory from `"/"` to `"/phpipam/"`.

my conf:
`define('BASE', "/phpipam/");`

But I was redirected to default page(apache index.html) when I was logged in.
So I fixed it.

Probably the same problem has been reported. #1866 