### PR TITLE
Bugfixes for logical circuits add/delete

### DIFF
--- a/app/admin/circuits/edit-logical-circuit-submit.php
+++ b/app/admin/circuits/edit-logical-circuit-submit.php
@@ -45,6 +45,7 @@ if($circuit['logical_cid'] == "") 	{ $Result->show("danger", _('Logical Circuit 
 $_POST['circuit_list'] = str_replace("undefined.", "", $_POST['circuit_list']);
 $id_list = $_POST['circuit_list']!=="" ? explode("." , rtrim($_POST['circuit_list'],".")) : [];
 if(sizeof($id_list ) != sizeof(array_unique($id_list))){  $Result->show("danger", _('Remove duplicates of circuit').'!', true); }
+if(($circuit['action'] == "add" && sizeof($id_list ) == 0)){  $Result->show("danger", _('No circuits selected').'!', true); }
 
 # fetch custom fields
 $custom = $Tools->fetch_custom_fields('circuitsLogical');
@@ -83,8 +84,6 @@ if(isset($update)) {
 # update circuit
 if(!$Admin->object_modify("circuitsLogical", $circuit['action'], "id", $values)) {}
 else {
-	$Result->show("success", _("Circuit $circuit[action] success!"));
-
 	// If this is a new circuit, save id of insert and process
 	if($circuit['id'] == "") {
 		if ($Admin->lastId==null) {
@@ -126,6 +125,11 @@ else {
 		$Result->show("success", _("Logical Circuit $circuit[action] successful").'!', false);
 	}
 	else {
-		$Result->show("warning", _("No Logical Circuits selected").'!', false);
+		if($circuit['action'] == "delete"){
+        		$Result->show("success", _("Logical Circuit $circuit[action] successful").'!', false);
+		}
+		else{
+        		$Result->show("warning", _("No circuits selected").'!', false);
+		}
 	}
 }

--- a/app/admin/circuits/edit-logical-circuit.php
+++ b/app/admin/circuits/edit-logical-circuit.php
@@ -242,7 +242,7 @@ function update_hidden_input(){
 				// readonly
 				$disabled = $readonly == "readonly" ? true : false;
 	    		// create input > result is array (required, input(html), timepicker_index)
-	    		$custom_input = $Tools->create_custom_field_input ($field, $circuit, $_POST['action'], $timepicker_index, $disabled);
+	    		$custom_input = $Tools->create_custom_field_input ($field, $logical_circuit, $_POST['action'], $timepicker_index, $disabled);
 	    		// add datepicker index
 	    		$timepicker_index = $timepicker_index + $custom_input['timepicker_index'];
 	            // print

--- a/app/tools/circuits/logical-circuits/logical-circuit-details-general.php
+++ b/app/tools/circuits/logical-circuits/logical-circuit-details-general.php
@@ -20,7 +20,12 @@ print "<table class='ipaddress_subnet table-condensed table-auto'>";
 	print "	<td>$logical_circuit->purpose</td>";
 	print "</tr>";
 
-  /* Maybe put in a calculated cost value here */
+	print '<tr>';
+	print "	<th>". _('Comment').'</th>';
+	print "	<td>$logical_circuit->comments</td>";
+	print "</tr>";
+      
+      /* Maybe put in a calculated cost value here */
 
 
 	if(sizeof($custom_fields) > 0) {

--- a/app/tools/circuits/logical-circuits/logical-circuits.php
+++ b/app/tools/circuits/logical-circuits/logical-circuits.php
@@ -48,6 +48,7 @@ print "	<th>"._('Circuit ID')."</th>";
 print "	<th>"._('Purpose').'</th>';
 print "	<th>"._('Circuit Count').'</th>';
 print "	<th>"._('Members').'</th>';
+print "	<th>"._('Comment').'</th>';
 if(sizeof(@$custom_fields) > 0) {
 	foreach($custom_fields as $field) {
 		if(!in_array($field['name'], $hidden_circuit_fields)) {
@@ -86,6 +87,7 @@ else {
 		else {
 			print "<span class='text-muted'>No members</span>";
 		}
+		print "	<td>".$circuit->comments."</td>";
 		print "	</td>";
 		//custom
 		if(sizeof(@$custom_fields) > 0) {

--- a/app/tools/circuits/physical-circuits/circuit-details-general.php
+++ b/app/tools/circuits/physical-circuits/circuit-details-general.php
@@ -42,6 +42,11 @@ print "	<th>". _('Capacity').'</th>';
 print "	<td>$circuit->capacity</td>";
 print "</tr>";
 
+print '<tr>';
+print "	<th>". _('Comment').'</th>';
+print "	<td>$circuit->comments</td>";
+print "</tr>";
+
 if ($User->settings->enableCustomers=="1") {
 	$customer = $Tools->fetch_object ("customers", "id", $circuit->customer_id);
 	if($customer===false) {


### PR DESCRIPTION
This fixes the following issues with logical circuits:

- Clicking "Add" with no physical circuits selected no longer creates a logical circuit
  - This was making a SQL error pop up when correcting the issue and clicking "Add" again
- Populates custom fields (#2325)
- Circuit deletion was showing a warning (No circuit selected) and didn't reload when deletion was working fine
  - Mappings are always removed, but a id list of 0 is OK when deleting the LC
  - Modification of the LC object will still get caught here if there are 0 circuits

- Removed extra success message
  