### PR TITLE
Add support for authentication and user creation using external HTTP headers

### DIFF
--- a/app/login/index.php
+++ b/app/login/index.php
@@ -4,9 +4,11 @@ header('X-XSS-Protection:1; mode=block');
 include('functions/checks/check_php_build.php');		# check for support for PHP modules and database connection
 
 // http auth
-if( !empty($_SERVER['PHP_AUTH_USER']) ) {
-    // try to authenticate
-	$User->authenticate ($_SERVER['PHP_AUTH_USER'], '');
+if( !empty($_SERVER['PHP_AUTH_USER']) || (@isset($config['auth_headers_username_field']) && isset($_SERVER[$config['auth_headers_username_field']])) ) {
+
+	$username = ($_SERVER['PHP_AUTH_USER'] ?: $_SERVER[$config['auth_headers_username_field']]);
+	// try to authenticate
+	$User->authenticate ($username, '');
 	// Redirect user where he came from, if unknown go to dashboard.
 	if( !empty($_COOKIE['phpipamredirect']) )   { header("Location: ".escape_input($_COOKIE['phpipamredirect'])); }
 	else                                        { header("Location: ".create_link("dashboard")); }

--- a/config.dist.php
+++ b/config.dist.php
@@ -135,6 +135,12 @@ define('MAP_SAML_USER', true);    // Enable SAML username mapping
 if(!defined('SAML_USERNAME'))
 define('SAML_USERNAME', 'admin'); // Map SAML to explicit user
 
+/**
+ * External HTTP header authentication
+ ******************************/
+//$config['auth_headers_email_field'] = 'HTTP_X_EMAIL';
+//$config['auth_headers_username_field'] = 'HTTP_X_USERNAME';
+//$config['default_authentication_method'] = 'headers';
 
 /**
  * Permit private subpages - private apps under /app/tools/custom/<custom_app_name>/index.php

--- a/functions/upgrade_queries.php
+++ b/functions/upgrade_queries.php
@@ -860,6 +860,12 @@ $upgrade_queries["1.4.21"][] = "ALTER TABLE `widgets` CHANGE `wadminonly` `wadmi
 $upgrade_queries["1.4.21"][] = "ALTER TABLE `widgets` CHANGE `wactive` `wactive` ENUM('yes','no') NOT NULL DEFAULT 'no';";
 $upgrade_queries["1.4.21"][] = "INSERT INTO `widgets` (`wtitle`, `wdescription`, `wfile`, `wparams`, `whref`, `wsize`, `wadminonly`, `wactive`) VALUES ('User Instructions', 'Shows user instructions', 'instructions', NULL, 'yes', '6', 'no', 'yes');";
 
+// HTTP headers auth method
+$upgrade_queries["1.4.22"][] = "-- HTTP headers auth method";
+$upgrade_queries["1.4.22"][] = "ALTER TABLE `usersAuthMethod` CHANGE `type` `type` SET('local','AD','LDAP','NetIQ','Radius','http','headers')  CHARACTER SET utf8  NOT NULL  DEFAULT 'local';";
+$upgrade_queries["1.4.22"][] = "INSERT INTO `usersAuthMethod` (`type`, `params`, `protected`, `description`) VALUES ('headers', NULL, 'Yes', 'External HTTP header authentication');";
+
+
 // output if required
 if(!defined('VERSION') && php_sapi_name()=="cli") {
   // version check


### PR DESCRIPTION
An external proxy (such as a Single Sign On service) can authenticate
the user and then let the user to access the app only if it has been
authenticated. In this case the user information is passed in special
user defined HTTP headers which can be trusted.

This patch adds the option to use these headers to authenticate the
user and if not present, also to create the user with appropriate
default settings.

I tried my best to make this fit nicely into the phpipam codebase. I'm willing to tune my approach if necessary based on the feedback.