### PR TITLE
Set requestedAuthnContext to false for SAML

### DIFF
--- a/app/saml2/idp.php
+++ b/app/saml2/idp.php
@@ -43,6 +43,9 @@ else{
             'certFingerprintAlgorithm' => $params->idpcertalgorithm,
             'x509cert' => $params->idpx509cert,
         ),
+       'security' => array (
+            'requestedAuthnContext' => false,
+        ),
     );
 }
 try {

--- a/app/saml2/index.php
+++ b/app/saml2/index.php
@@ -43,6 +43,9 @@ else{
             'certFingerprintAlgorithm' => $params->idpcertalgorithm,
             'x509cert' => $params->idpx509cert,
 	),
+       'security' => array (
+            'requestedAuthnContext' => false,
+        ),
     );
 	$auth = new OneLogin_Saml2_Auth($settings);
 }


### PR DESCRIPTION
In php-saml, when the variable requestedAuthnContext is unset, the SAML request will send a PasswordProtectedTransport request which tells the identity provider (IDP) to force password authentication. By setting requestedAuthnContext to false, the SAML request will omit the line and the IDP can use any method to validate the authentication request.

By default, the php-saml toolkit sets requestedAuthnContext to false. This PR is to continue to do so for phpipam.

Thanks,
Alex