### PR TITLE
Fixes pdns bug #1471 and #2374 by reverse compare the hostname with the domain.

### DIFF
--- a/app/admin/powerDNS/record-edit.php
+++ b/app/admin/powerDNS/record-edit.php
@@ -50,13 +50,16 @@ else {
 		// fetch all domains
 		$all_domains = $PowerDNS->fetch_all_domains ();
 		if ($all_domains!==false) {
+
+			// Reverse the hostname, this fixes #1471 and #2374
+			$r_hostname = implode(".", array_reverse(explode(".", $_POST['domain_id'])));
+
 			foreach($all_domains as $dk=>$domain_s) {
-				// loop through and find all matches
-				if (strpos($_POST['domain_id'],$domain_s->name) !== false) {
-					// check best match to avoid for example a.example.net.nz1 added to example.net.nz
-					if (substr($_POST['domain_id'], -strlen($domain_s->name)) === $domain_s->name) {
-						$matches[$dk] = $domain_s;
-					}
+				// Reverse the domain and compare it reversed, this fixes #1471 and #2374
+				$r_domain = implode(".", array_reverse(explode(".", $domain_s->name)));
+
+				if (substr($r_hostname, 0, strlen($r_domain)) == $r_domain) {
+					$matches[$dk] = $domain_s;
 				}
 			}
 			// match found ?


### PR DESCRIPTION
We have made the following script to test its functionality:

```php
<?php

$test_domains = array(
	"a.webmeisterei.com",
	"b.webmeisterei.com",
	"webmeisterei.com",
	"google.at",
	"webmeisterei.com1",
	"twebmeisterei.com",
	"z.webmeisterei.com",
);

$test_hostnames = array(
	"foo.webmeisterei.com" => "webmeisterei.com",
	"foo.b.webmeisterei.com" => "b.webmeisterei.com",
	"foo.webmeisterei.com1" => "webmeisterei.com1",
	"foo.a.webmeisterei.com" => "a.webmeisterei.com",
	"foo.twebmeisterei.com" => "twebmeisterei.com",
	"foo.z.webmeisterei.com" => "z.webmeisterei.com",

	"foo.test.webmeisterei.com" => "webmeisterei.com",
	"foo.google.at" => "google.at",
	"foo.test.google.at" => "google.at",
);

function find_domain($domains, $hostname) {
	// Reverse the hostname, so its easier to compare
	$r_hostname = implode(".", array_reverse(explode(".", $hostname)));

	// Reverse the domains to compare with the reversed hostname
	$r_domains = array_map(function($domain) {
		return implode(".", array_reverse(explode(".", $domain)));
	}, $domains);

	$matches = [];
	foreach($r_domains as $r_domain) {
		if (substr($r_hostname, 0, strlen($r_domain)) == $r_domain) {
			$matches[] = $r_domain;
		}
	}

	if (count($matches) < 0) {
		return "";
	}

	$max = 0;
	$result = "";
	foreach($matches as $m) {
		$length = strlen($m);
		if ($length > $max) { 
			$max = $length;
			$result = $m;
		}
	}

	return implode(".", array_reverse(explode(".", $result)));
}

foreach($test_hostnames as $test_hostname => $test_result) {
	$result = find_domain($test_domains, $test_hostname);

	if ($result == $test_result) {
		print($test_hostname . "\tOK\t" . $result . "\t" . $test_result . "\n");
	} else {
		print($test_hostname . "\tNOK\t\t" . $test_result . "\n");
	}
}

```

Signed-off-by: René Jochum <rene@jochums.at>