### PR TITLE
[API] Fix filtered results to always return data as array.

### DIFF
--- a/api/controllers/Common.php
+++ b/api/controllers/Common.php
@@ -300,10 +300,6 @@ class Common_api_functions {
 		# reindex filtered result
 		$result = array_values($result2);
 
-		// Single result - return as object
-		if (sizeof($result) == 1)
-			return $result[0];
-
 		return $result;
 	}
 


### PR DESCRIPTION
Current API filter_by functionality rewrites returned data as a single object if the filter search only found one item. This creates some unpredictability in the format of returned results. For example, if I have only a single device named "test.device.name" and that device resides in location ID 2, these two requests will return the same information, just formatted differently:

* `https://<server>/api/<app>/devices/search/test.device.name/?filter_by=location&filter_value=2`
* `https://<server>/api/<app>/devices/search/test.device.name/`

Or as a separate example, the format of any filtered response is inherently unpredictable if I do not know beforehand whether there will be exactly one match versus multiple matches.