### PR TITLE
[powerDNS] use configured default TTL instead of fixed value - fixes #2605

### DIFF
--- a/app/admin/powerDNS/record-edit.php
+++ b/app/admin/powerDNS/record-edit.php
@@ -98,7 +98,7 @@ $domain!==false ? : $Result->show("danger", _("Invalid ID"), true, true);
 // default
 if (!isset($record)) {
 	$record = new StdClass ();
-	$record->ttl = 3600;
+	$record->ttl = @$pdns->ttl;
 	$record->name = $domain->name;
 }
 


### PR DESCRIPTION
In powerDNS Administation, use configured default TTL instead of fixed value when adding a new record

This fixes #2605