### PR TITLE
Fix for VLAN problem in #2636

### DIFF
--- a/functions/classes/class.Tools.php
+++ b/functions/classes/class.Tools.php
@@ -200,10 +200,13 @@ class Tools extends Common_functions {
 		$result2 = $this->search_subnets_inside ($high, $low);
 		# search inside subnets even if IP does not exist - IPv6
 		$result3 = $this->search_subnets_inside_v6 ($high, $low, $search_req);
-		# merge arrays
-		$result = array_merge($result1, $result2, $result3);
-	    # result
-	    return array_filter($result);
+		# filter results based on id
+		$results = [];
+		foreach (array_merge($result1, $result2, $result3) as $result) {
+			$results[$result->id] = $result;
+		}
+		# result
+		return $results;
 	}
 
 	/**


### PR DESCRIPTION
In this fix i make a new array and using the id as key in the array. In that way a subnet can only be showed once. If there had been a model for subnets then that model could have implemented __tostring and that way we could have used array_unique.