### PR TITLE
Bugfix: Fix MAC address display issue by converting MAC from Kea to hexadecimal

### DIFF
--- a/api/controllers/Prefix.php
+++ b/api/controllers/Prefix.php
@@ -158,6 +158,7 @@ class Prefix_controller extends Common_api_functions {
                                         "pingSubnet",
                                         "discoverSubnet",
                                         "DNSrecursive",
+                                        "DNSforward",
                                         "DNSrecords",
                                         "nameserverId",
                                         "scanAgent",

--- a/app/admin/subnets/edit.php
+++ b/app/admin/subnets/edit.php
@@ -76,10 +76,13 @@ else {
     	$subnet_old_details['pingSubnet'] 	    = @$subnet_old_temp['pingSubnet'];        // inherit pingSubnet
     	$subnet_old_details['discoverSubnet']   = @$subnet_old_temp['discoverSubnet'];    // inherit discovery
     	$subnet_old_details['nameserverId']     = @$subnet_old_temp['nameserverId'];      // inherit nameserver
-    	if($User->settings->enableLocations=="1")
-    	$subnet_old_details['location']         = @$subnet_old_temp['location'];          // inherit location
-        if($User->settings->enableCustomers=="1")
-        $subnet_old_details['customer_id']         = @$subnet_old_temp['customer_id'];          // inherit location
+    	if($User->settings->enableLocations)
+	    	$subnet_old_details['location']         = @$subnet_old_temp['location'];          // inherit location
+      if($User->settings->enableCustomers)
+	      $subnet_old_details['customer_id']         = @$subnet_old_temp['customer_id'];          // inherit location
+			if($User->settings->enablePowerDNS)
+				$subnet_old_details['DNSrecursive'] = @$subnet_old_temp['DNSrecursive'];
+				$subnet_old_details['DNSforward'] = @$subnet_old_temp['DNSforward'];
 	}
 	# set master if it came from free space!
 	if(isset($_POST['freespaceMSID'])) {
@@ -126,6 +129,7 @@ var switch_options = {
 $(".input-switch").bootstrapSwitch(switch_options);
 $(".input-switch-agents-ping").bootstrapSwitch(switch_options);
 $(".input-switch-agents-scan").bootstrapSwitch(switch_options);
+$(".input-switch-dns-recursive").bootstrapSwitch(switch_options);
 
 // change - agent selector
 $('.input-switch-agents-ping, .input-switch-agents-scan').on('switchChange.bootstrapSwitch', function (e, data) {
@@ -137,7 +141,16 @@ $('.input-switch-agents-ping, .input-switch-agents-scan').on('switchChange.boots
 	if 		(ping==true || scan==true)		{ $("tr#scanAgentDropdown").removeClass("hidden"); }
 	else if (ping==false && scan==false)	{ $("tr#scanAgentDropdown").addClass("hidden"); }
 });
-<?php if ($User->settings->enableThreshold=="1") { ?>
+// change - allow dns forward
+$('.input-switch-dns-recursive').on('switchChange.bootstrapSwitch', function (e, data) {
+	// get state
+	var DNSrecursive = ($(".input-switch-dns-recursive").bootstrapSwitch('state'));
+
+	// change
+	if (DNSrecursive) { $("tr#dnsForwardSwitch").removeClass("hidden"); }
+	else { $("tr#dnsForwardSwitch").addClass("hidden"); }
+});
+<?php if ($User->settings->enableThreshold) { ?>
 $('.slider').slider().on('slide', function(ev){
     $('.slider-text span').html(ev.value);
 });
@@ -472,12 +485,12 @@ $("input[name='subnet']").change(function() {
 		}
 		print "</select>";
 		print "</td>";
-		print '	<td class="info2">'._('Select which scanagent to use').'</td>' . "\n";
+		print '	<td class="info2">'._('Select which scan agent to use').'</td>' . "\n";
 		print "</tr>";
 	}
 
 	//check host status
-	$checked = @$subnet_old_details['pingSubnet']==1 ? "checked": "";
+	$checked = @$subnet_old_details['pingSubnet'] ? "checked": "";
 	print '<tr>' . "\n";
     print '	<td>'._('Check hosts status').'</td>' . "\n";
     print '	<td>' . "\n";
@@ -487,7 +500,7 @@ $("input[name='subnet']").change(function() {
     print '</tr>';
 
 	//Discover new hosts
-	$checked = @$subnet_old_details['discoverSubnet']==1 ? "checked": "";
+	$checked = @$subnet_old_details['discoverSubnet'] ? "checked": "";
 	print '<tr>' . "\n";
     print '	<td>'._('Discover new hosts').'</td>' . "\n";
     print '	<td>' . "\n";
@@ -497,7 +510,7 @@ $("input[name='subnet']").change(function() {
     print '</tr>';
 
     //resolve hostname
-    $checked = @$subnet_old_details['resolveDNS']==1 ? "checked": "";
+    $checked = @$subnet_old_details['resolveDNS'] ? "checked": "";
     print '<tr>' . "\n";
     print ' <td>'._('Resolve DNS names').'</td>' . "\n";
     print ' <td>' . "\n";
@@ -558,17 +571,28 @@ $("input[name='subnet']").change(function() {
 
 		//autocreate reverse records
 		if($User->settings->enablePowerDNS==1) {
-		$checked = @$subnet_old_details['DNSrecursive']==1 ? "checked": "";
+		$checked = @$subnet_old_details['DNSrecursive'] ? "checked": "";
 		print '<tr>' . "\n";
         print '	<td>'._('Autocreate reverse records').'</td>' . "\n";
         print '	<td>' . "\n";
-        print '		<input type="checkbox" name="DNSrecursive" class="input-switch" value="1" '.$checked.'>'. "\n";
+        print '		<input type="checkbox" name="DNSrecursive" class="input-switch-dns-recursive" value="1" '.$checked.'>'. "\n";
         print '	</td>' . "\n";
         print '	<td class="info2">'._('Auto create reverse (PTR) records for this subnet').'</td>' . "\n";
         print '</tr>';
 
+		// autocreate forward records
+		$hidden = @$subnet_old_details['DNSrecursive'] ? "" : "hidden";
+		$checked = @$subnet_old_details['DNSforward'] ? "checked": "";
+		print "<tr id='dnsForwardSwitch' class='$hidden'>" . "\n";
+        print '	<td>'._('Autocreate forward records').'</td>' . "\n";
+        print '	<td>' . "\n";
+        print '		<input type="checkbox" name="DNSforward" class="input-switch" value="1" '.$checked.'>'. "\n";
+        print '	</td>' . "\n";
+        print '	<td class="info2">'._('Auto create forward (A) records for this subnet').'</td>' . "\n";
+        print '</tr>';
+
 		// show records
-		$checked = @$subnet_old_details['DNSrecords']==1 ? "checked": "";
+		$checked = @$subnet_old_details['DNSrecords'] ? "checked": "";
 		print '<tr>' . "\n";
         print '	<td>'._('Show DNS records').'</td>' . "\n";
         print '	<td>' . "\n";

--- a/app/subnets/subnet-details/subnet-details.php
+++ b/app/subnets/subnet-details/subnet-details.php
@@ -475,13 +475,13 @@ else {
 		print "</tr>";
 
 		print "<tr>";
-		print "	<th>"._('Autocreate reverse records')."</th>";
-		if($subnet['DNSrecursive'] == 1) 			{ print "	<td><span class='badge badge1 badge5 alert-success'>"._('enabled')."</span> $btns $zone</td>"; }		# yes
+		print "	<th>"._('Autocreate ' . ($subnet['DNSforward'] ? 'DNS' : 'reverse') .' records')."</th>";
+		if($subnet['DNSrecursive']) 			{ print "	<td><span class='badge badge1 badge5 alert-success'>"._('enabled')."</span> $btns $zone</td>"; }		# yes
 		else 										{ print "	<td><span class='badge badge1 badge5'>"._('disabled')."</span></td>";}		# no
 		print "</tr>";
 		print "<tr>";
 		print "	<th>"._('Show DNS records')."</th>";
-		if($subnet['DNSrecords'] == 1) 				{ print "	<td><span class='badge badge1 badge5 alert-success'>"._('enabled')."</span></td>"; }		# yes
+		if($subnet['DNSrecords']) 				{ print "	<td><span class='badge badge1 badge5 alert-success'>"._('enabled')."</span></td>"; }		# yes
 		else 										{ print "	<td><span class='badge badge1 badge5'>"._('disabled')."</span></td>";}		# no
 		print "</tr>";
 	}

--- a/db/SCHEMA.sql
+++ b/db/SCHEMA.sql
@@ -275,6 +275,7 @@ CREATE TABLE `subnets` (
   `discoverSubnet` BINARY(1)  NULL  DEFAULT '0',
   `resolveDNS` TINYINT(1)  NULL  DEFAULT '0',
   `DNSrecursive` TINYINT(1)  NULL  DEFAULT '0',
+  `DNSforward` TINYINT(1)  NULL  DEFAULT '0',
   `DNSrecords` TINYINT(1)  NULL  DEFAULT '0',
   `nameserverId` INT(11) NULL DEFAULT '0',
   `scanAgent` INT(11)  DEFAULT NULL,
@@ -995,4 +996,4 @@ CREATE TABLE `routing_subnets` (
 # ------------------------------------------------------------
 
 UPDATE `settings` SET `version` = "1.5";
-UPDATE `settings` SET `dbversion` = 26;
+UPDATE `settings` SET `dbversion` = 27;

--- a/functions/classes/class.DHCP.kea.php
+++ b/functions/classes/class.DHCP.kea.php
@@ -563,7 +563,7 @@ class DHCP_kea extends Common_functions {
         $this->init_database_conection ($reservations_database['user'], $reservations_database['password'], $reservations_database['host'], 3306, $reservations_database['name']);
         // set query
         if($type=="IPv4") {
-            $query = "select 'MySQL' as 'location', `dhcp4_subnet_id`, `ipv4_address` as `ip-address`, `dhcp_identifier` as `hw-address`, `hostname` from `hosts`;";
+            $query = "select 'MySQL' as 'location', `dhcp4_subnet_id`, `ipv4_address` as `ip-address`, HEX(`dhcp_identifier`) as `hw-address`, `hostname` from `hosts`;";
         }
         else {
             $query = "select * from `hosts`;";

--- a/functions/classes/class.Log.php
+++ b/functions/classes/class.Log.php
@@ -190,6 +190,7 @@ class Logging extends Common_functions {
 						"discoverSubnet"        => "Discover new hosts for this subnet",
 						"allowRequests"         => "Allow IP requests for subnet",
 						"DNSrecursive"          => "Create recursive PowerDNS records",
+						"DNSforward"            => "Create forward PowerDNS records",
 						"DNSrecords"            => "Show PowerDNS records",
 						"nameserverId"          => "Nameserver",
 						"scanAgent"             => "Scan agent index",
@@ -1074,6 +1075,7 @@ class Logging extends Common_functions {
 					$this->object_new['pingSubnet'],
 					$this->object_new['discoverSubnet'],
 					$this->object_new['DNSrecursive'],
+					$this->object_new['DNSforward'],
 					$this->object_new['DNSrecords'],
 					$this->object_new['nameserverId'],
 					$this->object_new['scanAgent'],
@@ -1093,6 +1095,7 @@ class Logging extends Common_functions {
 					$this->object_old['pingSubnet'],
 					$this->object_old['discoverSubnet'],
 					$this->object_old['DNSrecursive'],
+					$this->object_old['DNSforward'],
 					$this->object_old['DNSrecords'],
 					$this->object_old['nameserverId'],
 					$this->object_old['scanAgent'],
@@ -1420,7 +1423,7 @@ class Logging extends Common_functions {
     	$keys = array();
 		// list of keys to be changed per object
 		$keys['section'] = array("strictMode", "showVLAN", "showVRF");
-		$keys['subnet']  = array("allowRequests", "showName", "pingSubnet", "discoverSubnet", "DNSrecursive", "DNSrecords", "isFull");
+		$keys['subnet']  = array("allowRequests", "showName", "pingSubnet", "discoverSubnet", "DNSrecursive", "DNSforward", "DNSrecords", "isFull");
 		$keys['ip_addr'] = array("is_gateway", "excludePing", "PTRignore");
 
 		// check

--- a/functions/upgrade_queries/upgrade_queries_1.5.php
+++ b/functions/upgrade_queries/upgrade_queries_1.5.php
@@ -8,4 +8,7 @@
 $upgrade_queries["1.5.26"][] = "ALTER TABLE `customers` CHANGE `postcode` `postcode` VARCHAR(32)  NULL  DEFAULT NULL;";
 $upgrade_queries["1.5.26"][] = "-- Database version bump";
 $upgrade_queries["1.5.26"][] = "UPDATE `settings` set `dbversion` = '26';";
+
 $upgrade_queries["1.5.27"][] = "ALTER TABLE `subnets` ADD `DNSforward` TINYINT(1)  NULL  DEFAULT '0';";
+$upgrade_queries["1.5.27"][] = "-- Database version bump";
+$upgrade_queries["1.5.27"][] = "UPDATE `settings` set `dbversion` = '27';";

--- a/functions/upgrade_queries/upgrade_queries_1.5.php
+++ b/functions/upgrade_queries/upgrade_queries_1.5.php
@@ -8,3 +8,4 @@
 $upgrade_queries["1.5.26"][] = "ALTER TABLE `customers` CHANGE `postcode` `postcode` VARCHAR(32)  NULL  DEFAULT NULL;";
 $upgrade_queries["1.5.26"][] = "-- Database version bump";
 $upgrade_queries["1.5.26"][] = "UPDATE `settings` set `dbversion` = '26';";
+$upgrade_queries["1.5.27"][] = "ALTER TABLE `subnets` ADD `DNSforward` TINYINT(1)  NULL  DEFAULT '0';";


### PR DESCRIPTION
Kea stores the mac addresses as binary values, which causes an issue when displaying them on the DHCP menu. By adding HEX() to the mySQL query the values are returned in the expected hexadecimal form and correctly formated for display