### PR TITLE
Hide section subnet tree menus

### DIFF
--- a/app/admin/sections/edit-result.php
+++ b/app/admin/sections/edit-result.php
@@ -101,6 +101,7 @@ else {
 					"description"      => @$_POST['description'],
 					"strictMode"       => @$_POST['strictMode'],
 					"subnetOrdering"   => @$_POST['subnetOrdering'],
+					"showSubnet"       => @$_POST['showSubnet'],
 					"showVLAN"         => @$_POST['showVLAN'],
 					"showVRF"          => @$_POST['showVRF'],
 					"showSupernetOnly" => @$_POST['showSupernetOnly'],

--- a/app/admin/sections/edit.php
+++ b/app/admin/sections/edit.php
@@ -99,9 +99,21 @@ $section  = (array) $Sections->fetch_section (null, @$_POST['sectionid']);
 			</td>
 		</tr>
 
+		<!-- Show Subnets -->
+		<tr>
+			<td><?php print _('Show subnet menu'); ?></td>
+			<td colspan="2">
+				<select name="showSubnet" class="input-small form-control input-sm input-w-auto  pull-left" <?php if($_POST['action']=="delete") print 'disabled="disabled"'; ?>>
+					<option value="1"><?php print _('Yes'); ?></option>
+					<option value="0" <?php if(@$section['showSubnet'] == "0") print "selected='selected'"; ?>><?php print _('No'); ?></option>
+				</select>
+				<span class="help-inline info2"><?php print _('Show list of section subnets in subnet list'); ?></span>
+			</td>
+		</tr>
+
 		<!-- Show VLANs -->
 		<tr>
-			<td><?php print _('Show VLANs'); ?></td>
+			<td><?php print _('Show VLAN menu'); ?></td>
 			<td colspan="2">
 				<select name="showVLAN" class="input-small form-control input-sm input-w-auto  pull-left" <?php if($_POST['action']=="delete") print 'disabled="disabled"'; ?>>
 					<option value="1"><?php print _('Yes'); ?></option>
@@ -113,7 +125,7 @@ $section  = (array) $Sections->fetch_section (null, @$_POST['sectionid']);
 
 		<!-- Show VRFs -->
 		<tr>
-			<td><?php print _('Show VRFs'); ?></td>
+			<td><?php print _('Show VRF menu'); ?></td>
 			<td colspan="2">
 				<select name="showVRF" class="input-small form-control input-sm input-w-auto  pull-left" <?php if($_POST['action']=="delete") print 'disabled="disabled"'; ?>>
 					<option value="1"><?php print _('Yes'); ?></option>

--- a/app/admin/sections/index.php
+++ b/app/admin/sections/index.php
@@ -50,8 +50,9 @@ if ($sections !== false) {
     <th><?php print _('Description'); ?></th>
     <th><?php print _('Parent'); ?></th>
     <th><?php print _('Strict mode'); ?></th>
-    <th><?php print _('Show VLANs'); ?></th>
-    <th><?php print _('Show VRFs'); ?></th>
+    <th><?php print _('Show subnet menu'); ?></th>
+    <th><?php print _('Show VLAN menu'); ?></th>
+    <th><?php print _('Show VRF menu'); ?></th>
     <th><?php print _('Show only supernets'); ?></th>
     <th><?php print _('Group Permissions'); ?></th>
     <th></th>
@@ -81,6 +82,10 @@ if(isset($sections_sorted)) {
 	    //strictMode
 	    $mode = $section['strictMode']==0 ? "<span class='badge badge1 badge5 alert-danger'>"._("No") : "<span class='badge badge1 badge5 alert-success'>"._("Yes");
 	    print '	<td>'. $mode .'</span></td>'. "\n";
+	    //Show Subnets
+	    print " <td>";
+	    print @$section['showSubnet']==1 ? "<span class='badge badge1 badge5 alert-success'>"._("Yes") : "<span class='badge badge1 badge5 alert-danger'>"._("No");
+	    print "	</span></td>";
 	    //Show VLANs
 	    print " <td>";
 	    print @$section['showVLAN']==1 ? "<span class='badge badge1 badge5 alert-success'>"._("Yes") : "<span class='badge badge1 badge5 alert-danger'>"._("No");

--- a/app/subnets/subnets-menu.php
+++ b/app/subnets/subnets-menu.php
@@ -77,14 +77,16 @@ else {
 	    print "</div>";
     }
 
-	# header
-    print "<h4>"._('Available subnets')." <span class='pull-right' style='margin-right:5px;cursor:pointer;'><i class='fa fa-gray fa-sm $iconClass' rel='tooltip' data-placement='bottom' title='"._('Expand/compress all folders')."' id='expandfolders' data-action='$action'></i></span></h4>";
-    print "<hr>";
-
-    $section_subnets = (array) $Subnets->fetch_section_subnets($_GET['section'], false, false, []);
 	/* print subnets menu ---------- */
-    print $Subnets->print_subnets_menu($User->user, $section_subnets);
+    if ($section['showSubnet'] == 1) {
+        # header
+        print "<h4>"._('Available subnets')." <span class='pull-right' style='margin-right:5px;cursor:pointer;'><i class='fa fa-gray fa-sm $iconClass' rel='tooltip' data-placement='bottom' title='"._('Expand/compress all folders')."' id='expandfolders' data-action='$action'></i></span></h4>";
+        print "<hr>";
 
+        if (!is_array($section_subnets))
+            $section_subnets = (array) $Subnets->fetch_section_subnets($_GET['section'], false, false, []);
+        print $Subnets->print_subnets_menu($User->user, $section_subnets);
+    }
 	/* print VLAN menu ---------- */
 	if($section['showVLAN'] == 1 && $User->get_module_permissions ("vlan")>=User::ACCESS_R) {
 		$vlans = $Sections->fetch_section_vlans($_GET['section']);
@@ -95,6 +97,8 @@ else {
 				# title
 				print "<hr><h4>"._('Associated VLANs')."</h4><hr>";
 				# create and print menu
+				if (!is_array($section_subnets))
+					$section_subnets = (array) $Subnets->fetch_section_subnets($_GET['section'], false, false, []);
 				print $Subnets->print_vlan_menu($User->user, $vlans, $section_subnets, $_GET['section']);
 			print "</div>";
 		}
@@ -111,6 +115,8 @@ else {
 				# title
 				print "<hr><h4>"._('Associated VRFs')."</h4><hr>";
 				# create and print menu
+				if (!is_array($section_subnets))
+					$section_subnets = (array) $Subnets->fetch_section_subnets($_GET['section'], false, false, []);
 				print $Subnets->print_vrf_menu($User->user, $vrfs, $section_subnets, $_GET['section']);
 			print "</div>";
 		}

--- a/db/SCHEMA.sql
+++ b/db/SCHEMA.sql
@@ -134,6 +134,7 @@ CREATE TABLE `sections` (
   `subnetOrdering` VARCHAR(16)  NULL  DEFAULT NULL,
   `order` INT(3)  NULL  DEFAULT NULL,
   `editDate` TIMESTAMP  NULL  ON UPDATE CURRENT_TIMESTAMP,
+  'showSubnet' BOOL NOT NULL DEFAULT '1',
   `showVLAN` BOOL  NOT NULL  DEFAULT '0',
   `showVRF` BOOL  NOT NULL  DEFAULT '0',
   `showSupernetOnly` BOOL  NOT NULL  DEFAULT '0',
@@ -996,4 +997,4 @@ CREATE TABLE `routing_subnets` (
 # ------------------------------------------------------------
 
 UPDATE `settings` SET `version` = "1.5";
-UPDATE `settings` SET `dbversion` = 28;
+UPDATE `settings` SET `dbversion` = 29;

--- a/functions/upgrade_queries/upgrade_queries_1.5.php
+++ b/functions/upgrade_queries/upgrade_queries_1.5.php
@@ -48,7 +48,7 @@ $upgrade_queries["1.5.28"][] = "ALTER TABLE `subnets` ADD `isPool` BOOL NOT NULL
 $upgrade_queries["1.5.28"][] = "-- Database version bump";
 $upgrade_queries["1.5.28"][] = "UPDATE `settings` set `dbversion` = '28';";
 
-// Subnet isPool
+// Hide section subnet tree menus
 //
 $upgrade_queries["1.5.29"][] = "ALTER TABLE `sections` ADD `showSubnet` BOOL NOT NULL DEFAULT '1';";
 

--- a/functions/upgrade_queries/upgrade_queries_1.5.php
+++ b/functions/upgrade_queries/upgrade_queries_1.5.php
@@ -47,3 +47,10 @@ $upgrade_queries["1.5.28"][] = "ALTER TABLE `subnets` ADD `isPool` BOOL NOT NULL
 
 $upgrade_queries["1.5.28"][] = "-- Database version bump";
 $upgrade_queries["1.5.28"][] = "UPDATE `settings` set `dbversion` = '28';";
+
+// Subnet isPool
+//
+$upgrade_queries["1.5.29"][] = "ALTER TABLE `sections` ADD `showSubnet` BOOL NOT NULL DEFAULT '1';";
+
+$upgrade_queries["1.5.29"][] = "-- Database version bump";
+$upgrade_queries["1.5.29"][] = "UPDATE `settings` set `dbversion` = '29';";


### PR DESCRIPTION
Add option to hide section subnet tree menus (same as VRF/VLAN menu option)

Creating the menu server side and rendering the menu in the browser on every page load can be slow with 10,000+ subnets.