### PR TITLE
Fix SCHEMA.sql syntax error

### DIFF
--- a/db/SCHEMA.sql
+++ b/db/SCHEMA.sql
@@ -134,7 +134,7 @@ CREATE TABLE `sections` (
   `subnetOrdering` VARCHAR(16)  NULL  DEFAULT NULL,
   `order` INT(3)  NULL  DEFAULT NULL,
   `editDate` TIMESTAMP  NULL  ON UPDATE CURRENT_TIMESTAMP,
-  'showSubnet' BOOL NOT NULL DEFAULT '1',
+  `showSubnet` BOOL NOT NULL DEFAULT '1',
   `showVLAN` BOOL  NOT NULL  DEFAULT '0',
   `showVRF` BOOL  NOT NULL  DEFAULT '0',
   `showSupernetOnly` BOOL  NOT NULL  DEFAULT '0',


### PR DESCRIPTION
ERROR Message
```shell
# sudo mysql phpipam < db/SCHEMA.sql
ERROR 1064 (42000) at line 127: You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near ''showSubnet' BOOL NOT NULL DEFAULT '1',
  `showVLAN` BOOL  NOT NULL  DEFAULT '0'' at line 11
```