### PR TITLE
feat(login_page): opportunity to disable main login form

### DIFF
--- a/app/login/index.php
+++ b/app/login/index.php
@@ -129,7 +129,11 @@ if(@$config['requests_public']===false) {
 
 	<?php
 	# include proper subpage
-	if($_GET['page'] == "login") 				{ include_once('login_form.php'); }
+	if($_GET['page'] == "login") 				{
+		# disable main login form if you want use another authentification method by default (SAML, LDAP, etc.)
+		$include_main_login_form = !isset($config['disable_main_login_form']) || !$config['disable_main_login_form'];
+		if ($include_main_login_form) include_once('login_form.php');
+	}
 	else if ($_GET['page'] == "request_ip") 	{ include_once('request_ip_form.php'); }
 	else 										{ $_GET['subnetId'] = "404"; print "<div id='error'>"; include_once('app/error.php'); print "</div>"; }
 	?>

--- a/config.dist.php
+++ b/config.dist.php
@@ -64,6 +64,7 @@ $config['removed_addresses_timelimit'] = 86400 * 7;  // int, after how many seco
 # resolveIPaddresses.php script parameters
 $config['resolve_emptyonly']           = true;       // if true it will only update the ones without DNS entry!
 $config['resolve_verbose']             = true;       // verbose response - prints results, cron will email it to you!
+$config['disable_main_login_form']     = false;      // disable main login form if you want use another authentification method by default (SAML, LDAP, etc.)
 
 
 /**


### PR DESCRIPTION
### Problem:

* I want use SAML authentification method by default. And it is not possible to disable main login form. 

### Solution:

* Disable main login form with config variable `disable_main_login_form` if you want use another authentification method by default (SAML, LDAP, etc.)