### PR TITLE
Allow a 'none'-value for the ICMP Scan type

### DIFF
--- a/app/admin/settings/index.php
+++ b/app/admin/settings/index.php
@@ -545,7 +545,7 @@ $(document).ready(function() {
 	<td>
 		<select name="scanPingType" class="form-control input-sm input-w-auto">
 		<?php
-		$types = array("ping"=>"ping", "pear"=>"pear ping", "fping"=>"fping");
+		$types = array("ping"=>"ping", "pear"=>"pear ping", "fping"=>"fping", "none"=>"none");
 		//default
 		foreach($types as $k=>$d) {
 			if($k==$settings['scanPingType']) 	{ print "<option value='$k' selected='selected'>$d</option>"; }

--- a/functions/classes/class.Scan.php
+++ b/functions/classes/class.Scan.php
@@ -125,7 +125,7 @@ class Scan extends Common_functions {
 		# Log object
 		$this->Log = new Logging ($this->Database, $this->settings);
 
-		if ($errmsg = php_feature_missing(null, ['exec']))
+		if ($this->icmp_type != "none" && $errmsg = php_feature_missing(null, ['exec']))
 			$this->Result->show("danger", $errmsg, true);
 	}
 
@@ -136,7 +136,7 @@ class Scan extends Common_functions {
 	 * @return array
 	 */
 	public function ping_fetch_types () {
-		return array("ping", "pear", "fping");
+		return array("none","ping", "pear", "fping");
 	}
 
 	/**
@@ -243,6 +243,11 @@ class Scan extends Common_functions {
 	 * @return void
 	 */
 	public function ping_address ($address, $count=1, $timeout = 1) {
+		
+		# when no ping is set, return directly
+		if($this->icmp_type == "none")
+			return;
+		
 		#set parameters
 		$this->icmp_timeout = $timeout;
 		$this->icmp_count = $count;

--- a/functions/upgrade_queries/upgrade_queries_1.5.php
+++ b/functions/upgrade_queries/upgrade_queries_1.5.php
@@ -73,5 +73,9 @@ $upgrade_queries["1.5.31"][] = 'ALTER TABLE `users` CHANGE `module_permissions` 
 $upgrade_queries["1.5.31"][] = "-- Clone users l2dom permissions from existing vlan permission level. MySQL5.7+";
 $upgrade_queries["1.5.31"][] = "UPDATE users SET module_permissions = JSON_SET(module_permissions,'$.l2dom', JSON_EXTRACT(module_permissions,'$.vlan')); -- IGNORE_ON_FAILURE"; // MySQL 5.7+
 
+// None-type on scantype
+// 
+$upgrade_queries["1.5.31"][] = "ALTER TABLE `settings` CHANGE `scanPingType` `scanPingType` SET('ping','pear','fping','none') CHARACTER SET utf8 COLLATE utf8_general_ci NOT NULL DEFAULT 'ping';";
+
 $upgrade_queries["1.5.31"][] = "-- Database version bump";
 $upgrade_queries["1.5.31"][] = "UPDATE `settings` set `dbversion` = '31';";


### PR DESCRIPTION
In our deployment of IPAM, we use a public web server just for storing our database of ip-addresses. As it does have the php exec-command disabled, we weren't able to add, update or delete any ip addresses as it was still checking for the exec-command by just initializing the class `class.Scan.php`. With this proposed change, it is possible to set the ICMP scan type to None, which disables this check completely.

I would like to see any feedback to this, if I should implement it in another way to get it merged in the master branch just let me know.