### PR TITLE
Added LUA record types

### DIFF
--- a/functions/classes/class.PowerDNS.php
+++ b/functions/classes/class.PowerDNS.php
@@ -284,6 +284,7 @@ class PowerDNS extends Common_functions {
         $record_types[] = "SOA";
         $record_types[] = "SPF";
         $record_types[] = "SRV";
+        $record_types[] = "LUA";
 
         // save
         $this->record_types = (object) $record_types;


### PR DESCRIPTION
PowerDNS supports LUA record types starting with version 4.2 that allows for more dynamic records. See https://doc.powerdns.com/authoritative/lua-records/

LUA records can also be used for more trivial things. For example, I used them to create a wildcard IPv6 PTR record that returns the ip address attached to a subdomain name:

MariaDB [powerdns]> select * from records where id='122954';
+--------+-----------+--------------------------------------------+------+------------------------------------------------+------+------+-------------+----------+-----------+------+
| id     | domain_id | name                                       | type | content                                        | ttl  | prio | change_date | disabled | ordername | auth |
+--------+-----------+--------------------------------------------+------+------------------------------------------------+------+------+-------------+----------+-----------+------+
| 122954 |       455 | *.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.x.ip6.arpa | LUA  | PTR "createReverse6('%33%.sub.domain.com')" | 3600 | NULL |  2020013011 |        0 | NULL      |    1 |
+--------+-----------+--------------------------------------------+------+------------------------------------------------+------+------+-------------+----------+-----------+------+
1 row in set (0.00 sec)