### PR TITLE
[security] Log failed accesses

### DIFF
--- a/config.dist.php
+++ b/config.dist.php
@@ -167,6 +167,14 @@ $proxy_pass     = 'PASSWORD';                             // Proxy Password
 $proxy_use_auth = false;                                  // Enable/Disable Proxy authentication
 
 /**
+ * Failed access
+ * message to log into webserver logs in case of failed access, for further processing by tools like Fail2Ban
+ * Apache users should use : user "%u" authentication failure for "phpIPAM"
+ * Nginx  users should use : user "%u" was not found in "phpIPAM"
+ ******************************/
+$failed_access_message = '';
+
+/**
  * General tweaks
  ******************************/
 $config['logo_width']             = 220;                    // logo width

--- a/functions/classes/class.User.php
+++ b/functions/classes/class.User.php
@@ -805,17 +805,30 @@ class User extends Common_functions {
     private function fetch_user_details ($username, $force = false) {
         # only if not already active
         if(!is_object($this->user) || $force) {
-            try { $user = $this->Database->findObject("users", "username", $username); }
-            catch (Exception $e)     { $this->Result->show("danger", _("Error: ").$e->getMessage(), true);}
+            try {
+                $user = $this->Database->findObject("users", "username", $username);
+            }
+            catch (Exception $e) {
+                $this->Result->show("danger", _("Error: ").$e->getMessage(), true);
+            }
 
             # if not result return false
             $usert = (array) $user;
 
             # admin?
-            if($user->role == "Administrator")    { $this->isadmin = true; }
+            if($user->role == "Administrator") {
+                $this->isadmin = true;
+            }
 
-            if(sizeof($usert)==0)    { $this->block_ip (); $this->Log->write ("User login", _('Invalid username'), 2, $username ); $this->Result->show("danger", _("Invalid username or password"), true);}
-            else                     { $this->user = $user; }
+            if(sizeof($usert)==0) {
+                $this->block_ip ();
+                $this->log_failed_access ($username);
+                $this->Log->write ("User login", _('Invalid username'), 2, $username );
+                $this->Result->show("danger", _("Invalid username or password"), true);
+            }
+            else {
+                $this->user = $user;
+            }
 
             // register permissions
             $this->register_user_module_permissions ();
@@ -907,6 +920,7 @@ class User extends Common_functions {
         else {
             # add blocked count
             $this->block_ip ();
+            $this->log_failed_access ($username);
 
             $this->Log->write( "User login", "Invalid username or password", 2, $username );
 
@@ -1034,6 +1048,7 @@ class User extends Common_functions {
             else {
                 # add blocked count
                 $this->block_ip();
+                $this->log_failed_access ($username);
                 $this->Log->write($method . " login", "User $username failed to authenticate against " . $method, 1, $username);
                 $this->Result->show("danger", _("Invalid username or password"), true);
 
@@ -1146,6 +1161,7 @@ class User extends Common_functions {
         else {
             # add blocked count
             $this->block_ip ();
+            $this->log_failed_access ($username);
             $this->Log->write( "Radius login", "Failed to authenticate user on radius server", 2, $username );
             $this->Result->show("danger", _("Invalid username or password"), true);
         }
@@ -1487,6 +1503,20 @@ class User extends Common_functions {
     private function block_remove_entry() {
         try { $this->Database->deleteRow("loginAttempts", "ip", $this->ip); }
         catch (Exception $e) { !$this->debugging ? : $this->Result->show("danger", $e->getMessage(), false); }
+    }
+
+    /**
+     * log failed accesses, matching the default fail2ban nginx/apache auth rules
+     *
+     * @access private
+     * @return void
+     */
+    private function log_failed_access($username) {
+        if (isset($_SERVER['SERVER_SOFTWARE']) && preg_match('/nginx/i', $_SERVER['SERVER_SOFTWARE'])) {
+            error_log('user "' . $username . '" was not found in "phpIPAM"', 4);
+        } else {
+            error_log('user "' . $username . '" authentication failure for "phpIPAM"', 4);
+        }
     }
 
 

--- a/functions/classes/class.User.php
+++ b/functions/classes/class.User.php
@@ -1506,7 +1506,7 @@ class User extends Common_functions {
     }
 
     /**
-     * log failed accesses, matching the default fail2ban nginx/apache auth rules
+     * log failed accesses, for further processing by tools like Fail2Ban
      *
      * @access private
      * @return void

--- a/functions/classes/class.User.php
+++ b/functions/classes/class.User.php
@@ -1512,10 +1512,8 @@ class User extends Common_functions {
      * @return void
      */
     private function log_failed_access($username) {
-        if (isset($_SERVER['SERVER_SOFTWARE']) && preg_match('/nginx/i', $_SERVER['SERVER_SOFTWARE'])) {
-            error_log('user "' . $username . '" was not found in "phpIPAM"', 4);
-        } else {
-            error_log('user "' . $username . '" authentication failure for "phpIPAM"', 4);
+        if (strlen(Config::ValueOf('failed_access_message'))) {
+            error_log(str_replace("%u", $username, Config::ValueOf('failed_access_message')), 4);
         }
     }
 


### PR DESCRIPTION
Hi,

This PR logs failed login attempts for further processing by tools such as fail2ban.
It then uses the default fail2ban nginx/apache auth rules/patterns, then sending the messages directly to the webserver log files.

It then closes #1811.

While here, some indent enhancements.

Thank you 👍