### PR TITLE
SAML2 auth can get username from attribute

### DIFF
--- a/app/saml2/index.php
+++ b/app/saml2/index.php
@@ -83,7 +83,17 @@ else{
 	}
 
 	// try to authenticate in phpipam
-	$User->authenticate ( $auth->getNameId(), '', true);
+        if((defined('SAML_USERNAME_FROM_ATTR')) && (SAML_USERNAME_FROM_ATTR !== false))
+	{
+	    // the username comes from an attribute in the assertion
+	    $attributes = $auth->getAttributes();
+	    $User->authenticate ( $attributes[SAML_USERNAME_FROM_ATTR][0], '', true);
+	}
+	else
+	{
+	    // just use the nameID as username
+	    $User->authenticate ( $auth->getNameId(), '', true);
+	}
 
 	// Redirect user where he came from, if unknown go to dashboard.
 	if( !empty($_COOKIE['phpipamredirect']) )   { header("Location: ".escape_input($_COOKIE['phpipamredirect'])); }

--- a/config.dist.php
+++ b/config.dist.php
@@ -140,6 +140,9 @@ define('MAP_SAML_USER', true);    // Enable SAML username mapping
 if(!defined('SAML_USERNAME'))
 define('SAML_USERNAME', 'admin'); // Map SAML to explicit user
 
+if(!defined('SAML_USERNAME_FROM_ATTR')) // Fetch username from an attr
+define('SAML_USERNAME_FROM_ATTR', false);  // just use the nameID
+//define('SAML_USERNAME_FROM_ATTR', 'urn:oid:0.9.2342.19200300.100.1.1'); // pick another single-valued attr; this is uid
 
 /**
  * Permit private subpages - private apps under /app/tools/custom/<custom_app_name>/index.php


### PR DESCRIPTION
After a successful SAML2 auth, allow for building user using as username an attribute coming from the assertion.

It might be the `uid`, or the `mail` or whatever as long it's single-valued.

It comes handy because some SAML2 IdP like Shibboleth use an opaque ID as nameID and it is hard to map existing LDAP users after switching auth to SAML2.