### PR TITLE
Revised baseurl logic, starting with exceptions

### DIFF
--- a/functions/classes/class.Common.php
+++ b/functions/classes/class.Common.php
@@ -979,31 +979,22 @@ class Common_functions  {
 	 * @return mixed
 	 */
 	public function createURL () {
-		// SSL on standard port
-		if(($_SERVER['HTTPS'] == 'on') || ($_SERVER['SERVER_PORT'] == 443)) {
-			$url = "https://".$_SERVER['HTTP_HOST'];
-		}
-		// reverse proxy doing SSL offloading
-		elseif(isset($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] == 'https') {
-			if (isset($_SERVER['HTTP_X_FORWARDED_HOST'])) {
-				$url = "https://".$_SERVER['HTTP_X_FORWARDED_HOST'];
-			}
-			else {
-				$url = "https://".$_SERVER['HTTP_HOST'];
-			}
-		}
-		elseif(isset($_SERVER['HTTP_X_SECURE_REQUEST'])  && $_SERVER['HTTP_X_SECURE_REQUEST'] == 'true') {
-			$url = "https://".$_SERVER['SERVER_NAME'];
+		// reverse proxy
+		if (isset($_SERVER['HTTP_X_FORWARDED_HOST'])) {
+			$url = "https://".$_SERVER['HTTP_X_FORWARDED_HOST'];
 		}
 		// custom port
 		elseif($_SERVER['SERVER_PORT']!="80" && (isset($_SERVER['HTTP_X_FORWARDED_PORT']) && $_SERVER['HTTP_X_FORWARDED_PORT']!="80")) {
 			$url = "http://".$_SERVER['SERVER_NAME'].":".$_SERVER['SERVER_PORT'];
 		}
+		// SSL on standard port
+		elseif(($_SERVER['HTTPS'] == 'on') || ($_SERVER['SERVER_PORT'] == 443)) {
+			$url = "https://".$_SERVER['HTTP_HOST'];
+		}
 		// normal http
 		else {
 			$url = "http://".$_SERVER['HTTP_HOST'];
 		}
-
 		//result
 		return $url;
 	}


### PR DESCRIPTION
Before this change, the elseif branches would never pass if HTTPS was enabled, for example. This created an invalid baseurl behind a reverse proxy.