### PR TITLE
Bugfix edit-options.php (color-picker)

### DIFF
--- a/app/admin/circuits/edit-options.php
+++ b/app/admin/circuits/edit-options.php
@@ -55,7 +55,7 @@ $readonly = $_POST['action']=="delete" ? "disabled" : "";
 		<td><?php print  _('Map Color') ?></td>
 		<td>
 
-			<input type="color" name="color" id="color-picker" class="form-control input-sm" placeholder="<?php print _('Hex Color (ex. #000000)'); ?>" value="<?php if(isset($_POST['color'])) print $_POST['color']; ?>" <?php print $readonly; ?>>
+			<input type="color" name="color" id="pick-a-color" class="form-control input-sm" placeholder="<?php print _('Hex Color (ex. #000000)'); ?>" value="<?php if(isset($_POST['color'])) print $_POST['color']; ?>" <?php print $readonly; ?>>
 
 		</td>
 	</tr>


### PR DESCRIPTION
Bugfix issues #3004 #3147 where conflicting Bootstrap Color Picker events were firing. Reserved id=color-picker was firing in sequence after type=color (or vice versa) was firing causing the default value to be replicated over the picked color.  Renamed id for input value to prevent double match.

- #3004 Cannot set Circuit option color
- #3147 Unable to set Map Color in when adding new option in Circuit Options