### PR TITLE
Update print-address-table.php (Gateway)

### DIFF
--- a/app/subnets/addresses/print-address-table.php
+++ b/app/subnets/addresses/print-address-table.php
@@ -369,7 +369,7 @@ else {
 			    $gw = $addresses[$n]->is_gateway==1 ? "gateway" : "";
 
 			    print "	<td class='ipaddress $gw'><span class='status status-$hStatus' $hTooltip></span><a href='".create_link("subnets",$subnet['sectionId'],$_GET['subnetId'],"address-details",$addresses[$n]->id)."'>".$Subnets->transform_to_dotted( $addresses[$n]->ip_addr)."</a>";
-			    if($addresses[$n]->is_gateway==1)						{ print " <i class='fa fa-info-circle fa-gateway' rel='tooltip' title='"._('Address is marked as gateway')."'></i>"; }
+			    if($addresses[$n]->is_gateway==1)						{ print " <i class='fa fa-arrows' rel='tooltip' title='"._('Address is marked as gateway')."'></i>"; }
 			    print $Addresses->address_type_format_tag($addresses[$n]->state);
 
                 # set subnet nat


### PR DESCRIPTION
On IP addresses that are marked as a gateway: change fa-info-circle and fa-gateway (which doesn't exist) to fa-arrows to be a specific icon for a gateway instead of a circle requiring you to hover over the tooltip to understand its significance.