### PR TITLE
Allow white spaces in VLAN names

### DIFF
--- a/app/admin/import-export/import-vlan-check.php
+++ b/app/admin/import-export/import-vlan-check.php
@@ -68,7 +68,7 @@ foreach ($data as &$cdata) {
 
 	# check data format
 	if ($action != "error") {
-		if (!preg_match("/^[a-zA-Z0-9-_]+$/", $cdata['name'])) { $msg.="Invalid name format."; $action = "error"; }
+		if (!preg_match("/^[a-zA-Z0-9-_]+( [a-zA-Z0-9-_]+)*$/", $cdata['name'])) { $msg.="Invalid name format."; $action = "error"; }
 		if (!preg_match("/^[0-9]+$/", $cdata['number'])) { $msg.="Invalid number format."; $action = "error"; }
 		if (preg_match("/[;'\"]/", $cdata['description'])) { $msg.="Invalid characters in description."; $action = "error"; }
 		if (!preg_match("/^[a-zA-Z0-9-_. ]+$/", $cdom)) { $msg.="Invalid domain format."; $action = "error"; }


### PR DESCRIPTION
Manual insert of VLAN name allows white spaces. I guess it should be allowed in the import procedure as well.