### PR TITLE
Enhancement: intuitive option rack start position label

### DIFF
--- a/app/admin/racks/edit-rack-devices.php
+++ b/app/admin/racks/edit-rack-devices.php
@@ -149,13 +149,13 @@ $(document).ready(function(){
                     if($rack->hasBack!="0") {
                         print "<optgroup label='"._("Front")."'>";
                         foreach ($available as $a) {
-                            print "<option value='$a'>$a</option>";
+                            print "<option value='$a'>Front:$a</option>";
                         }
                         print "</optgroup>";
 
                         print "<optgroup label='"._("Back")."'>";
                         foreach ($available_back as $k=>$a) {
-                            print "<option value='$k'>$a</option>";
+                            print "<option value='$k'>Back:$a</option>";
                         }
                         print "</optgroup>";
                     }


### PR DESCRIPTION
In edit-rack-devices.php adding a device to the rack, the start position had two option groups, a front, and a back group.  It was not intuitive that there were two option groups in the dropdown list. When a start position was selected it showed '5' and you did not know was it a front or a back 5.  Added 'Front:" and 'Back:' to the select option.