### PR TITLE
Enhancement: edit device front/back rack position labels

### DIFF
--- a/app/admin/devices/edit-rack-dropdown.php
+++ b/app/admin/devices/edit-rack-dropdown.php
@@ -77,14 +77,14 @@ if($_POST['rackid']>0 || @$device['rack']>0) {
 			    print "<optgroup label='"._("Front")."'>";
 			    foreach ($available as $a) {
 			    	$selected = $a==$device['rack_start'] ? "selected" : "";
-			        print "<option value='$a' $selected $disabled>$a</option>";
+			        print "<option value='$a' $selected $disabled>Front:$a</option>";
 			    }
 			    print "</optgroup>";
 
 			    print "<optgroup label='"._("Back")."'>";
 			    foreach ($available_back as $k=>$a) {
 			    	$selected = $k==$device['rack_start'] ? "selected" : "";
-			        print "<option value='$k' $selected>$a</option>";
+			        print "<option value='$k' $selected>Back:$a</option>";
 			    }
 			    print "</optgroup>";
 			}


### PR DESCRIPTION
In conjunction with changes made in edit-rack-devices.php adding a device to the rack, the start position had two option groups, a front, and a back group.  It was not intuitive that there were two option groups in the dropdown list. When a start position was selected it showed '5' and you did not know was it a front or a back 5.  Added 'Front:" and 'Back:' to the select option.