### PR TITLE
Fix Incorrect DATETIME value error

### DIFF
--- a/functions/scripts/remove_offline_addresses.php
+++ b/functions/scripts/remove_offline_addresses.php
@@ -44,7 +44,7 @@ $query = "select
 			and `su`.`pingSubnet` = 1
 			and (`ip`.`excludePing` IS NULL or `ip`.`excludePing`!=1 )
 			and
-			(`ip`.`lastSeen` < '$beforetime' and `ip`.`lastSeen` != '0000-00-00 00:00:00' and `ip`.`lastSeen` is not NULL);";
+			(`ip`.`lastSeen` < '$beforetime' and `ip`.`lastSeen` != '1970-01-01 00:00:01' and `ip`.`lastSeen` is not NULL);";
 
 # fetch
 try { $offline_addresses = $Database->getObjectsQuery($query); }


### PR DESCRIPTION
By default, the lastSeen field of the ip address is set to '1970-01-01 00:00:01'.
In mysql 8.0, the script does not work correctly referring to the incorrect DATETIME value '0000-00-00 00:00:00'.
Specifying the date '0000-00-00 00:00:00' does not make sense.