### PR TITLE
SAML JIT Provisioning

### DIFF
--- a/app/admin/authentication-methods/edit-SAML2.php
+++ b/app/admin/authentication-methods/edit-SAML2.php
@@ -84,6 +84,15 @@ $(document).ready(function() {
 
 	<!-- Advanced Settings -->
 	<tr>
+		<td><?php print _('Enable JIT'); ?></td>
+		<td>
+			<input type="checkbox" class="input-switch" value="1" name="jit" <?php if(@$method_settings->params->jit == 1) print 'checked'; ?>  <?php print $is_disabled; ?> >
+		</td>
+		<td class="info2">
+			<?php print _('Provision new users automatically'); ?><br>
+		</td>
+	</tr>
+	<tr>
 		<td><?php print _('Use advanced settings'); ?></td>
 		<td>
 			<input type="checkbox" class="input-switch" value="1" name="advanced" <?php if(@$method_settings->params->advanced == 1) print 'checked'; ?>  <?php print $is_disabled; ?> >

--- a/app/admin/authentication-methods/edit-result.php
+++ b/app/admin/authentication-methods/edit-result.php
@@ -44,14 +44,28 @@ $values = array(
 				"type"        =>$_POST['type'],
 				"description" =>@$_POST['description'],
 				);
+
+# Validate input
+if (isset($_POST['type']) && $_POST['type']=="SAML2") {
+	# The JIT & SAML mapped user options are mutually exclusive.
+	if (filter_var($_POST['jit'], FILTER_VALIDATE_BOOLEAN) && !empty($_POST['MappedUser'])) {
+		$Result->show("danger",  _("The JIT and mapped user options are mutually exclusive"), true);
+	}
+
+	# Validate Prettify links is enabled for strict mode.
+	if (filter_var($_POST['strict'], FILTER_VALIDATE_BOOLEAN) && !filter_var($User->settings->prettyLinks, FILTER_VALIDATE_BOOLEAN)) {
+		$Result->show("danger",  _("Strict mode requires global setting \"Prettify links\"=yes"), true);
+	}
+
+	# Verify that the private certificate and key are provided if Signing Authn Requests is set
+	if($action!="delete" && filter_var(['spsignauthn'], FILTER_VALIDATE_BOOLEAN) && (empty($_POST['spx509cert']) || empty($_POST['spx509key']))) {
+		$Result->show("danger",  _("SP (Client) certificate and key are required to sign Authn requests"), true);
+	}
+}
+
 # remove processed params
 unset($_POST['id'], $_POST['type'], $_POST['description'], $_POST['action']);
 $values["params"]=json_encode($_POST);
-
-#Verify that the private certificate and key are provided if Signing Authn Requests is set
-if($action!="delete" && @$_POST['spsignauthn']=="1" && (empty($_POST['spx509cert']) || empty($_POST['spx509key']))) {
-	$Result->show("danger",  _("SP (Client) certificate and key are required to sign Authn requests"), true);
-}
 
 $secure_keys=[
 	'adminUsername',

--- a/app/saml2/index.php
+++ b/app/saml2/index.php
@@ -129,13 +129,14 @@ else{
             "disabled"       =>"No"
             );
         // update existing user
-        if($User->user != null) {
-            $values["id"] = $User->user->id;
+        $existing = $Database->getObjectQuery("SELECT * FROM `users` where `username` = '$username' limit 1;", $values);
+        if( $existing != null) {
+            $values["id"] = $existing->id;
             # null empty values
             $values = $User->reformat_empty_array_fields ($values, null);
     
             # execute
-            try { $Database->updateObject($table, $values, $key); }
+            try { $Database->updateObject($table, $values); }
             catch (Exception $e) {
                 $User->Log->write( $table." "._("object")." ".$values[$key]." "._("edit"), _("Failed to edit object")." ".$key=$values[$key]." "._("in")." $table.<hr>".$e->getMessage()."<hr>".$User->array_to_log($User->reformat_empty_array_fields ($values_log, "NULL")), 2);
             }

--- a/misc/CHANGELOG
+++ b/misc/CHANGELOG
@@ -23,6 +23,7 @@
         + php-saml protocol debugging;
         + Support for signed assertions;
         + SAML usernames can be extracted from assertion attributes (#2948);
+        + JIT auto-provisioning of accounts (#3389);
     + Selectable mask for number of subnets/hosts in subnet masks;
     + Switch from Google Maps to OpenStreeMap and Nominatim;
 


### PR DESCRIPTION
Hey all,

Gonna start this by saying I am absolutely not a PHP dev.  That out of the way, our use case for phpIPAM involves creating accounts for a constantly-changing set of users,   SAML allows us to avoid managing authentication, but without SCIM or JIT, we still need to provision several dozen or even hundred accounts manually, which is not desirable.

I've taken a crack at basic JIT for SAML here- it works for our use case, but is far from comprehensive or perfect.  I am not familiar enough with the phpIPAM codebase to know if there is a more idiomatic way of dealing with this, but without having an Admin in scope it looks like direct database modification is the only method.

The core idea for JIT is that users are automatically created or updated based on information passed from the IdP.

Finally, I couldn't find any place to update documentation for features like this, but I'd happily do so if anyone could show me where.  In particular, this implementation requires 3 additional attributes from the SAML IdP: `display_name`, `role`, and `email`.

Feedback would be greatly appreciated.