### PR TITLE
Option to emove only autodiscovered offline addresses

### DIFF
--- a/config.dist.php
+++ b/config.dist.php
@@ -56,6 +56,7 @@ $config['discovery_check_method']      = false;      // false/ping/pear/fping, r
 # remove_offline_addresses.php script parameters
 $config['removed_addresses_send_mail'] = true;       // true/false, send or not mail on pomoving inactive addresses
 $config['removed_addresses_timelimit'] = 86400 * 7;  // int, after how many seconds of inactivity address will be deleted (7 days)
+$config['removed_addresses_autodiscovered'] = false; // Only remove addresses with -- autodiscovered -- description
 # resolveIPaddresses.php script parameters
 $config['resolve_emptyonly']           = true;       // if true it will only update the ones without DNS entry!
 $config['resolve_verbose']             = true;       // verbose response - prints results, cron will email it to you!

--- a/functions/scripts/remove_offline_addresses.php
+++ b/functions/scripts/remove_offline_addresses.php
@@ -34,17 +34,24 @@ $beforetime = date ("Y-m-d H:i:s", (time()-$config['removed_addresses_timelimit'
 
 // set query to fetch addresses and belongign subnets
 $query = "select
-			`ip`.`id`,`ip`.`ip_addr`,`ip`.`lastSeen`,`ip`.`subnetId`,`ip`.`description`,`ip`.`hostname`,`ip`.`lastSeen`,
-			`su`.`subnet`,`su`.`mask`,`su`.`sectionId`,`su`.`description`,
-			'delete' as `action`
-		 from
-		 	`ipaddresses` as `ip`, `subnets` as `su`
-		 where
-			`ip`.`subnetId` = `su`.`id`
-			and `su`.`pingSubnet` = 1
-			and (`ip`.`excludePing` IS NULL or `ip`.`excludePing`!=1 )
-			and
-			(`ip`.`lastSeen` < '$beforetime' and `ip`.`lastSeen` != '1970-01-01 00:00:01' and `ip`.`lastSeen` is not NULL);";
+                        `ip`.`id`,`ip`.`ip_addr`,`ip`.`lastSeen`,`ip`.`subnetId`,`ip`.`description`,`ip`.`hostname`,`ip`.`lastSeen`,
+                        `su`.`subnet`,`su`.`mask`,`su`.`sectionId`,`su`.`description`,
+                        'delete' as `action`
+                 from
+                        `ipaddresses` as `ip`, `subnets` as `su`
+                 where
+                        `ip`.`subnetId` = `su`.`id`
+                        and `su`.`pingSubnet` = 1
+                        and (`ip`.`excludePing` IS NULL or `ip`.`excludePing`!=1)
+                        and (`ip`.`lastSeen` < '$beforetime' and `ip`.`lastSeen` != '1970-01-01 00:00:01' and `ip`.`lastSeen` is not NULL) ";
+
+// Only remove autodiscovered IPs ? (based on description)
+if (isset($config['removed_addresses_autodiscovered']) && $config['removed_addresses_autodiscovered']) {
+        $query.= " and `ip`.`description` = '" .  _('-- autodiscovered --') . "'";
+}
+
+// End the query gracefully
+$query.= ";";
 
 # fetch
 try { $offline_addresses = $Database->getObjectsQuery($query); }


### PR DESCRIPTION
Added an option to clean only autodiscovered and offline addresses

This is based on description 

This is useful when you want to clean "accidentally" autodiscovered IPs that are now reported offline without affecting other offline entries.

Not sure though if it's the best way to do it. AFAIK checking the description is the only way to identify the entry as autodiscovered (when the description never got changed to something else).