### PR TITLE
Fixed php warning

### DIFF
--- a/app/admin/requests/edit.php
+++ b/app/admin/requests/edit.php
@@ -42,7 +42,7 @@ if($Subnets->check_permission($User->user, $request['subnetId']) != 3)	{ $Result
 if(strlen($request['ip_addr'])>0) {
 	// check if it exists
 	if ( $Addresses->address_exists ($request['ip_addr'], $request['subnetId'])) {
-		$errmsg = _("Requested IP address").' '.($request[ip_addr]).' '._("already used. First available address automatically provided.");
+		$errmsg = _("Requested IP address").' '.($request['ip_addr']).' '._("already used. First available address automatically provided.");
 		$errmsg_class = "warning";
 		//fetch first free
 		$ip_address = $Addresses->transform_to_dotted($Addresses->get_first_available_address ($request['subnetId'], $Subnets));


### PR DESCRIPTION
Fixed php warning:
Warning: Use of undefined constant ip_addr - assumed 'ip_addr' (this will throw an Error in a future version of PHP)