### PR TITLE
Update class.Rackspace.php

### DIFF
--- a/functions/classes/class.Rackspace.php
+++ b/functions/classes/class.Rackspace.php
@@ -359,6 +359,7 @@ class phpipam_rack extends Tools {
                                     "name"=>$d->hostname,
                                     "startLocation"=>$d->rack_start-$rack->size,
                                     "size"=>$d->rack_size,
+				    "active"=>true,
                                     "rackName"=>$rack->name
                                     );
                         // if startlocation is not set
@@ -377,6 +378,7 @@ class phpipam_rack extends Tools {
                                     "name"=>$d->hostname,
                                     "startLocation"=>$d->rack_start,
                                     "size"=>$d->rack_size,
+				    "active"=>true,
                                     "rackName"=>$rack->name
                                     );
                         // if startlocation is not set


### PR DESCRIPTION
i'm assuming `active` was intented for all non-custom-equipment.
this causes all devices to be a different color in rack images