### PR TITLE
Add support for SAML2 groups passed as array instead of comma-separated string

### DIFF
--- a/app/saml2/index.php
+++ b/app/saml2/index.php
@@ -180,8 +180,13 @@ else{
         $values["email"] = $auth->getAttribute("email")[0];
         $values["role"] = filter_var($auth->getAttribute("is_admin")[0], FILTER_VALIDATE_BOOLEAN) ? "Administrator" : "User";
 
-        // Parse groups
-        $saml_groups = array_map('trim', explode(',', $auth->getAttribute("groups")[0])) ? : [];
+        // parse groups
+        $saml_groups = array();
+        foreach ($auth->getAttribute("groups") as $group_attr) {
+            foreach (array_map('trim', explode(',', $group_attr)) as $g) {
+                if ($g) $saml_groups[] = $g;
+            }
+        }
 
         $ug = [];
         foreach ($Tools->fetch_all_objects("userGroups", "g_id") as $g) {


### PR DESCRIPTION
User group membership are commonly passed as an array in SAML2 assertions, instead of using a single comma-separated string which is the only supported format at the moment.

This pull requests updates the SAML validation to support both.