### PR TITLE
Add support for SAML group assertions passed as LDAP DN

### DIFF
--- a/app/saml2/index.php
+++ b/app/saml2/index.php
@@ -184,7 +184,11 @@ else{
         $saml_groups = array();
         foreach ($auth->getAttribute("groups") as $group_attr) {
             foreach (array_map('trim', explode(',', $group_attr)) as $g) {
-                if ($g) $saml_groups[] = $g;
+                if (preg_match('/^(cn|ou)=([^,]+),/i'), $g, $m) { // ldap dn
+                    $saml_groups[] = $m[1]
+                } elseif ($g) {
+                    $saml_groups[] = $g;
+                }
             }
         }
 

--- a/app/saml2/index.php
+++ b/app/saml2/index.php
@@ -180,8 +180,13 @@ else{
         $values["email"] = $auth->getAttribute("email")[0];
         $values["role"] = filter_var($auth->getAttribute("is_admin")[0], FILTER_VALIDATE_BOOLEAN) ? "Administrator" : "User";
 
-        // Parse groups
-        $saml_groups = array_map('trim', explode(',', $auth->getAttribute("groups")[0])) ? : [];
+        // parse groups
+        $saml_groups = array();
+        foreach ($auth->getAttribute("groups") as $group_attr) {
+            foreach (array_map('trim', explode(',', $group_attr)) as $g) {
+                if ($g) $saml_groups[] = $g;
+            }
+        }
 
         $ug = [];
         foreach ($Tools->fetch_all_objects("userGroups", "g_id") as $g) {


### PR DESCRIPTION
Group membership in SAML assertions are also commonly based on LDAP group membership. This pull request extends #3656 to also add support to extract group name passed as LDAP rfc2307bis format. E.g. `groupname` from `cn=groupname,ou=groups,dc=example,dc=com`