### PR TITLE
Explicitly create a new StdClass where needed

### DIFF
--- a/app/admin/authentication-methods/edit-AD.php
+++ b/app/admin/authentication-methods/edit-AD.php
@@ -20,6 +20,7 @@ if($_POST['action']!="add") {
 }
 else {
 	$method_settings = new StdClass ();
+	$method_settings->params = new StdClass ();
 	# set default values
    @$method_settings->params->domain_controllers = "dc1.domain.local;dc2.domain.local";
 	$method_settings->params->base_dn = "CN=Users,CN=Company,DC=domain,DC=local";

--- a/app/admin/authentication-methods/edit-LDAP.php
+++ b/app/admin/authentication-methods/edit-LDAP.php
@@ -20,6 +20,7 @@ if($_POST['action']!="add") {
 }
 else {
 	$method_settings = new StdClass ();
+	$method_settings->params = new StdClass ();
 	# set default values
    @$method_settings->params->domain_controllers = "ldap1.domain.local;ldap2.domain.local";
 	$method_settings->params->base_dn = "CN=Users,CN=Company,DC=domain,DC=local";

--- a/app/admin/authentication-methods/edit-NetIQ.php
+++ b/app/admin/authentication-methods/edit-NetIQ.php
@@ -20,6 +20,7 @@ if($_POST['action']!="add") {
 }
 else {
 	$method_settings = new StdClass ();
+	$method_settings->params = new StdClass ();
 	# set default values
    @$method_settings->params->domain_controllers = "dc1.domain.local;dc2.domain.local";
 	$method_settings->params->base_dn = "ou=user,o=domain.local";

--- a/app/admin/authentication-methods/edit-Radius.php
+++ b/app/admin/authentication-methods/edit-Radius.php
@@ -20,6 +20,7 @@ if($_POST['action']!="add") {
 }
 else {
 	$method_settings = new StdClass ();
+	$method_settings->params = new StdClass ();
 	# set default values
    @$method_settings->params->hostname = "localhost";
 	$method_settings->params->port = 1812;


### PR DESCRIPTION
As of PHP 8.0, this is no longer done automatically and throws an error

This should fix #3709 