### PR TITLE
Display "Locations list" and "Locations map" links for read only users

### DIFF
--- a/app/tools/locations/all-locations-list.php
+++ b/app/tools/locations/all-locations-list.php
@@ -1,6 +1,15 @@
 <h4><?php print _('List of all locations'); ?></h4>
 <hr>
 
+<ul class='nav nav-tabs' style='margin-top:0px;margin-bottom:20px;'>
+    <li role='presentation' <?php if(!isset($_GET['subnetId'])||is_numeric($_GET['subnetId'])) print " class='active'"; ?>>
+        <a href='<?php print create_link($_GET['page'], "locations"); ?>'><?php print _("Locations list"); ?></a>
+    </li>
+    <li role='presentation' <?php if(@$_GET['subnetId']=="map") print " class='active'"; ?>>
+        <a href='<?php print create_link($_GET['page'], "locations", "map"); ?>'><?php print _("Locations map"); ?></a>
+    </li>
+</ul>
+
 <?php
 if($User->get_module_permissions ("locations")>=User::ACCESS_RW) {
 include('menu.php');

--- a/app/tools/locations/all-locations-map.php
+++ b/app/tools/locations/all-locations-map.php
@@ -3,6 +3,15 @@
 <hr>
 <?php } ?>
 
+<ul class='nav nav-tabs' style='margin-top:0px;margin-bottom:20px;'>
+    <li role='presentation' <?php if(!isset($_GET['subnetId'])||is_numeric($_GET['subnetId'])) print " class='active'"; ?>>
+        <a href='<?php print create_link($_GET['page'], "locations"); ?>'><?php print _("Locations list"); ?></a>
+    </li>
+    <li role='presentation' <?php if(@$_GET['subnetId']=="map") print " class='active'"; ?>>
+        <a href='<?php print create_link($_GET['page'], "locations", "map"); ?>'><?php print _("Locations map"); ?></a>
+    </li>
+</ul>
+
 <?php if(isset($admin) && ($admin && $User->settings->enableLocations=="1")) { ?>
 <?php
 if($User->get_module_permissions ("locations")>=User::ACCESS_RW) {

--- a/app/tools/locations/menu.php
+++ b/app/tools/locations/menu.php
@@ -1,12 +1,2 @@
-<ul class='nav nav-tabs' style='margin-top:0px;margin-bottom:20px;'>
-    <li role='presentation' <?php if(!isset($_GET['subnetId'])||is_numeric($_GET['subnetId'])) print " class='active'"; ?>>
-        <a href='<?php print create_link($_GET['page'], "locations"); ?>'><?php print _("Locations list"); ?></a>
-    </li>
-    <li role='presentation' <?php if(@$_GET['subnetId']=="map") print " class='active'"; ?>>
-        <a href='<?php print create_link($_GET['page'], "locations", "map"); ?>'><?php print _("Locations map"); ?></a>
-    </li>
-</ul>
-
-
 <!-- Add link -->
 <a href="" class='btn btn-sm btn-success open_popup' data-script='app/admin/locations/edit.php' data-action='add' data-id='' data-action='add' style='margin-bottom:10px;'><i class='fa fa-plus'></i> <?php print _('Add location'); ?></a>


### PR DESCRIPTION
Hi, for users with `Read` permission in the module `Locations`, the [Locations map]() link is not visible because it is inserted (from `app/tools/menu.php`) only for users with `Write` permission, with this check in `app/tools/all-locations-list.php`:
```
<?php
if($User->get_module_permissions ("locations")>=User::ACCESS_RW) {
include('menu.php');
...
```
So in this PR I extracted those links from `app/tools/menu.php` and added them to the `app/tools/all-locations-list.php` and `app/tools/all-locations-map.php` files.

Hope it makes sense :)