### PR TITLE
Fix exception when deleting a section containing no subnets in PHP 8.0+

### DIFF
--- a/app/admin/sections/edit-result.php
+++ b/app/admin/sections/edit-result.php
@@ -64,7 +64,7 @@ if ($_POST['action']=="delete" && !isset($_POST['deleteconfirm'])) {
 	# no subsections
 	else {
 		$subnets  = $Subnets->fetch_section_subnets ($_POST['id']);			//fetch all subnets in section
-		$num_subnets = sizeof($subnets);
+		$num_subnets = is_array($subnets) ? sizeof($subnets) : 0;
 		$ipcnt = $Addresses->count_addresses_in_multiple_subnets($subnets);
 	}
 

--- a/functions/classes/class.Sections.php
+++ b/functions/classes/class.Sections.php
@@ -169,7 +169,7 @@ class Sections extends Common_functions {
 		# truncate and delete all subnets in all sections, than delete sections
 		foreach($all_ids as $id) {
 			$section_subnets = $Subnets->fetch_section_subnets ($id);
-			if(sizeof($section_subnets)>0) {
+			if(is_array($section_subnets) && sizeof($section_subnets)>0) {
 				foreach($section_subnets as $ss) {
 					//delete subnet
 					$Subnets->modify_subnet("delete", array("id"=>$ss->id));


### PR DESCRIPTION
As of PHP 8.0, `sizeof()` will throw an exception on a bool:

POST /app/admin/sections/edit-result.php - Uncaught TypeError: sizeof(): Argument #1 ($value) must be of type Countable|array, bool given in /home/nathan/source/phpipam/phpipam-git/app/admin/sections/edit-result.php:67
Stack trace:
#0 {main}
  thrown in /home/nathan/source/phpipam/phpipam-git/app/admin/sections/edit-result.php on line 67
