### PR TITLE
change type from string to boolean for ssl_verify value

### DIFF
--- a/config.dist.php
+++ b/config.dist.php
@@ -38,7 +38,7 @@ $db['ssl']        = false;                             // true/false, enable or 
 // $db['ssl_ca']     = '/path/to/ca.crt';                 // path to a file containing SSL CA certs
 // $db['ssl_capath'] = '/path/to/ca_certs';               // path to a directory containing CA certs
 // $db['ssl_cipher'] = 'HIGH:!PSK:!SHA:!MD5:!RC4:!aNULL'; // one or more SSL Ciphers, see openssl ciphers -v '....'
-// $db['ssl_verify'] = 'true';                            // Verify Common Name (CN) of server certificate?
+// $db['ssl_verify'] = true;                            // Verify Common Name (CN) of server certificate?
 
 $db['tmptable_engine_type'] = "MEMORY";                // Temporary table type to construct complex queries (MEMORY, InnoDB)
 $db['use_cte'] = 1;                                    // Use recursive CTE queries [>=MariaDB 10.2.2, >=MySQL 8.0] (0=disabled, 1=autodetect, 2=force enable)


### PR DESCRIPTION
The `ssl_verify` option in config.php must be a boolean otherwise we are not able to connect PHPIpam to database. This small fix should make configuration clearer.