### PR TITLE
Bugfix: Use UTF-16LE encoding for XLS sheet names, and UTF-8 as input encoding

### DIFF
--- a/app/admin/import-export/export-ipaddr.php
+++ b/app/admin/import-export/export-ipaddr.php
@@ -287,6 +287,7 @@ $curRow++;
 if( (isset($_GET['exportSections'])) && ($_GET['exportSections'] == "on") ) {
 	// Create a worksheet
 	$worksheet_sections =& $workbook->addWorksheet('Sections');
+	$worksheet_sections->setInputEncoding("utf-8");
 
 	$curRow = 0;
 	$curColumn = 0;

--- a/app/admin/import-export/export-subnets.php
+++ b/app/admin/import-export/export-subnets.php
@@ -252,6 +252,7 @@ $curRow++;
 if( (isset($_GET['exportSections'])) && ($_GET['exportSections'] == "on") ) {
 	// Create a worksheet
 	$worksheet_sections =& $workbook->addWorksheet('Sections');
+	$worksheet_sections->setInputEncoding("utf-8");
 
 	$curRow = 0;
 	$curColumn = 0;

--- a/app/admin/import-export/export-vlan.php
+++ b/app/admin/import-export/export-vlan.php
@@ -157,6 +157,7 @@ if(
 ) {
 	// Create a worksheet
 	$worksheet_domains =& $workbook->addWorksheet('Domains');
+	$worksheet_domains->setInputEncoding("utf-8");
 
 	$curRow = 0;
 	$curColumn = 0;

--- a/app/admin/import-export/import-template.php
+++ b/app/admin/import-export/import-template.php
@@ -22,6 +22,7 @@ $lineCount = 0;
 
 // Create a worksheet
 $worksheet = $workbook->addWorksheet("template");
+$worksheet->setInputEncoding("utf-8");
 
 
 if ($type == 'subnets'){

--- a/functions/PEAR/Spreadsheet/Excel/Writer/Workbook.php
+++ b/functions/PEAR/Spreadsheet/Excel/Writer/Workbook.php
@@ -326,6 +326,10 @@ class Spreadsheet_Excel_Writer_Workbook extends Spreadsheet_Excel_Writer_BIFFwri
             if (strlen($name) > 31) {
                 return $this->raiseError("Sheetname $name must be <= 31 chars");
             }
+        } else {
+            if (function_exists('iconv')) {
+                $name = iconv('UTF-8', 'UTF-16LE', $name);
+            }
         }
 
         // Check that the worksheet name doesn't already exist: a fatal Excel error.
@@ -932,11 +936,15 @@ class Spreadsheet_Excel_Writer_Workbook extends Spreadsheet_Excel_Writer_BIFFwri
         }
 
         $grbit     = 0x0000;                    // Visibility and sheet type
-        $cch       = strlen($sheetname);        // Length of sheet name
+        if ($this->_BIFF_version == 0x0600) {
+            $cch = mb_strlen($sheetname, 'UTF-16LE'); // Length of sheet name
+        } else {
+            $cch = strlen($sheetname); // Length of sheet name
+        }
 
         $header    = pack("vv",  $record, $length);
         if ($this->_BIFF_version == 0x0600) {
-            $data      = pack("Vvv", $offset, $grbit, $cch);
+            $data      = pack("VvCC", $offset, $grbit, $cch, 0x1);
         } else {
             $data      = pack("VvC", $offset, $grbit, $cch);
         }


### PR DESCRIPTION
This is a backport of the [original work](https://github.com/pear/Spreadsheet_Excel_Writer/commit/7803f3018431e1f4030f4930af83f3a281068627) by cfhay on Spreadsheet_Excel_Writer.

XLS expects all text to be UTF-16-encoded, which isn't the case right now as UTF-8-encoded strings are passed to [addWorksheet in generate-xls.php](https://github.com/phpipam/phpipam/blob/master/app/admin/import-export/generate-xls.php#L85).

I stumbled upon this bug as I had section names containing characters like "åäö", so a section named "Nät" comes out as "NÃ¤t" in the XLS-file sheet name when exported.

This PR fixes this bug by backporting the fix by cfhay from the "upstream" Spreadsheet_Excel_Writer package.