### PR TITLE
BUGFIX: Radius authentication php8

### DIFF
--- a/functions/classes/class.Radius.php
+++ b/functions/classes/class.Radius.php
@@ -576,7 +576,7 @@ class Radius
     function SetAttribute($type, $value)
     {
         $attribute_index = -1;
-        $attribute_count = !is_null($this->_attributes_to_send) ? count($this->_attributes_to_send) : 0;
+        $attribute_count = count((array)$this->_attributes_to_send) : 0;
         for ($attributes_loop = 0; $attributes_loop < $attribute_count; $attributes_loop++)
         {
             if ($type == ord(substr($this->_attributes_to_send[$attributes_loop], 0, 1)))
@@ -716,7 +716,7 @@ class Radius
         }
 
         $attributes_content = '';
-        $attribute_count1 = !is_null($this->_attributes_to_send) ? count($this->_attributes_to_send) : 0;
+        $attribute_count1 = count((array)$this->_attributes_to_send) : 0;
 
         for ($attributes_loop = 0; $attributes_loop < $attribute_count1; $attributes_loop++)
         {


### PR DESCRIPTION
This change fix the bug of Radius authentication and works for php7 and php8. 
Bug: on php8 variable should be defined as a array if it's a array

Tested on phpipam 1.5 and 1.6

![1_5_2](https://github.com/phpipam/phpipam/assets/53404989/2e575af3-9933-4b50-a678-75fbc7e9dc5a)
![1_6_0](https://github.com/phpipam/phpipam/assets/53404989/b26754a5-8592-421a-9b50-ed1e2e4c4247)
