### PR TITLE
UPDATE class.Radius.php to php8

### DIFF
--- a/functions/classes/class.Radius.php
+++ b/functions/classes/class.Radius.php
@@ -44,15 +44,16 @@
  *
  *
  * @author: SysCo/al
+ * @updated: https://github.com/flaviojunior1995
  * @since CreationDate: 2008-01-04
  * @copyright (c) 2008 by SysCo systemes de communication sa
- * @version $LastChangedRevision: 1.2.2 $
- * @version $LastChangedDate: 2009-01-05 $
- * @version $LastChangedBy: SysCo/al $
+ * @version $LastChangedRevision: 1.2.3 $
+ * @version $LastChangedDate: 2023-20-12 $
+ * @version $LastChangedBy: https://github.com/flaviojunior1995 $
  * @link $HeadURL: radius.class.php $
  * @link http://developer.sysco.ch/php/
  * @link developer@sysco.ch
- * Language: PHP 4.0.7 or higher
+ * Language: PHP 7.2 or higher
  *
  *
  * Usage
@@ -151,6 +152,7 @@
  *
  * Change Log
  *
+ *   2023-12-20 1.2.3 https://github.com/flaviojunior1995 Updated to work with php8 and fix deprecated errors
  *   2009-01-05 1.2.2 SysCo/al Added Robert Svensson feedback, Mideye RADIUS server is supported
  *   2008-11-11 1.2.1 SysCo/al Added Carlo Ferrari resolution in examples (add NAS IP Address for a VASCO Middleware server)
  *   2008-07-07 1.2   SysCo/al Added Pim Koeman (Parantion) contribution
@@ -174,10 +176,11 @@
  * Pure PHP radius class
  *
  * Creation 2008-01-04
- * Update 2009-01-05
+ * Update 2023-12-20
  * @package radius
- * @version v.1.2.2
+ * @version v.1.2.3
  * @author SysCo/al
+ * @updated https://github.com/flaviojunior1995
  *
  *********************************************************************/
 class Radius
@@ -217,9 +220,10 @@ class Radius
      * short description: Radius class constructor
      *
      * Creation 2008-01-04
-     * Update 2009-01-05
-     * @version v.1.2.2
+     * Update 2023-12-20
+     * @version v.1.2.3
      * @author SysCo/al
+     * @updated https://github.com/flaviojunior1995
      * @param string ip address of the radius server
      * @param string shared secret with the radius server
      * @param string radius domain name suffix (default is empty)
@@ -576,7 +580,7 @@ class Radius
     function SetAttribute($type, $value)
     {
         $attribute_index = -1;
-        $attribute_count = !is_null($this->_attributes_to_send) ? count($this->_attributes_to_send) : 0;
+        $attribute_count = count((array)$this->_attributes_to_send);
         for ($attributes_loop = 0; $attributes_loop < $attribute_count; $attributes_loop++)
         {
             if ($type == ord(substr($this->_attributes_to_send[$attributes_loop], 0, 1)))
@@ -603,7 +607,7 @@ class Radius
                     $temp_attribute = chr($type).chr(6).chr($ip_array[0]).chr($ip_array[1]).chr($ip_array[2]).chr($ip_array[3]);
                     break;
                 case 'I': // Integer, 32 bit unsigned value, most significant octet first.
-                    $temp_attribute = chr($type).chr(6).chr(($value / (256 * 256 * 256)) % 256).chr(($value / (256 * 256)) % 256).chr(($value / (256)) % 256).chr($value % 256);
+		    $temp_attribute = chr($type).chr(6).chr($value / 256 * 256 * 256 % 256).chr($value / 256 * 256 % 256). chr($value * 256 / 256 % 256 ) .chr($value % 256);
                     break;
                 case 'D': // Time, 32 bit unsigned value, most significant octet first -- seconds since 00:00:00 UTC, January 1, 1970. (not used in this RFC)
                     $temp_attribute = NULL;
@@ -716,8 +720,7 @@ class Radius
         }
 
         $attributes_content = '';
-        $attribute_count1 = !is_null($this->_attributes_to_send) ? count($this->_attributes_to_send) : 0;
-
+        $attribute_count1 = count((array)$this->_attributes_to_send);
         for ($attributes_loop = 0; $attributes_loop < $attribute_count1; $attributes_loop++)
         {
             $attributes_content .= $this->_attributes_to_send[$attributes_loop];


### PR DESCRIPTION
-Fix RADIUS authentication fail on phpipam 1.6.0
-Fix deprecated Implicit conversion
-Compatibility with php7

![1_5_2](https://github.com/phpipam/phpipam/assets/53404989/40b3d73a-2590-491c-852a-ee2872710602)

![1_6_0](https://github.com/phpipam/phpipam/assets/53404989/1e45be7e-1110-442f-bc43-221a32ca74ef)

![calc_bug](https://github.com/phpipam/phpipam/assets/53404989/4030c168-fd57-430c-8ca0-9364c38c9a34)

![fix_calc_bug](https://github.com/phpipam/phpipam/assets/53404989/77dbc0af-9dcd-4acb-9df2-f82b2e04dd57)

```
root@debian:/var/www/html/functions/classes# php8.2 -e TEST2.php
Authentication accepted.<br />Vendor-Specific: Vendor-Id: 14988, Vendor-type: 3,  Attribute-specific: full<br />
Vendor-Specific: Vendor-Id: 2011, Vendor-type: 29,  Attribute-specific: <br />
Vendor-Specific: Vendor-Id: 8886, Vendor-type: 3,  Attribute-specific: <br />
Vendor-Specific: Vendor-Id: 9, Vendor-type: 1,  Attribute-specific: shell:priv-lvl=15<br />
Vendor-Specific: Vendor-Id: 9, Vendor-type: 1,  Attribute-specific: shell:roles="sysadmin"<br />
Reply-Message: phpipam:group="Administrators"<br />
```