### PR TITLE
Bugfix for issue 4094

### DIFF
--- a/api/controllers/Sections.php
+++ b/api/controllers/Sections.php
@@ -179,8 +179,8 @@ class Sections_controller extends Common_api_functions {
 		if(isset($this->_params->masterSection)) {
 			$masterSection = $this->Sections->fetch_section ("id", $this->_params->masterSection);
 			// checks
-			if(sizeof($masterSection)==0)				{ $this->Response->throw_exception(400, 'Invalid masterSection id '.$this->_params->masterSection); }
-			elseif($masterSection->masterSection!="0")	{ $this->Response->throw_exception(400, 'Only 1 level of nesting is permitted for sections');  }
+			if(count(get_object_vars($masterSection))==0)	{ $this->Response->throw_exception(400, 'Invalid masterSection id '.$this->_params->masterSection); }
+			elseif($masterSection->masterSection!="0")		{ $this->Response->throw_exception(400, 'Only 1 level of nesting is permitted for sections');  }
 		}
 
 		# execute update

--- a/api/controllers/Sections.php
+++ b/api/controllers/Sections.php
@@ -179,8 +179,8 @@ class Sections_controller extends Common_api_functions {
 		if(isset($this->_params->masterSection)) {
 			$masterSection = $this->Sections->fetch_section ("id", $this->_params->masterSection);
 			// checks
-			if(count(get_object_vars($masterSection))==0)	{ $this->Response->throw_exception(400, 'Invalid masterSection id '.$this->_params->masterSection); }
-			elseif($masterSection->masterSection!="0")		{ $this->Response->throw_exception(400, 'Only 1 level of nesting is permitted for sections');  }
+			if(!is_object($masterSection))				{ $this->Response->throw_exception(400, 'Invalid masterSection id '.$this->_params->masterSection); }
+			elseif($masterSection->masterSection!="0")	{ $this->Response->throw_exception(400, 'Only 1 level of nesting is permitted for sections');  }
 		}
 
 		# execute update


### PR DESCRIPTION
This is a proposed fix for the issue where `sizeof()` is incorrectly used to determine the properties of a `stdClass`.

The fix is to use `count(get_object_vars())` instead.