### PR TITLE
Fix: Rack image generation bug

### DIFF
--- a/functions/classes/class.Rackspace.php
+++ b/functions/classes/class.Rackspace.php
@@ -985,7 +985,7 @@ class RackContent extends Model {
      * @return int
      */
     public function getSize() {
-        return $this->size;
+        return max(1, $this->size);
     }
 
     /**


### PR DESCRIPTION
Fixes a bug I noticed where if the size of a device is set to zero, it causes the generation of the rack image to fail. 