### PR TITLE
Bugfix: Search results are sometimes placed into wrong sections

### DIFF
--- a/app/tools/search/search_results/search-results_addresses.php
+++ b/app/tools/search/search_results/search-results_addresses.php
@@ -63,7 +63,7 @@ $result_addresses = $Tools->search_addresses($searchTerm, $searchTerm_edited['hi
 <?php
 
 $m = 0;		//for section change
-$n = 0;		//fpr ermission and result count
+$n = 0;		//for permission and result count
 
 /* if no result print nothing found */
 if(is_array($result_addresses)) {
@@ -93,7 +93,6 @@ if(is_array($result_addresses)) {
 				}
 				print '</tr>';
 			}
-			$m++;
 
 			//print table
 			print '<tr class="ipSearch" id="'. $line['id'] .'" subnetId="'. $line['subnetId'] .'" sectionId="'. $subnet['sectionId'] .'" link="'. $section['name'] .'|'. $subnet['id'] .'">'. "\n";
@@ -184,8 +183,9 @@ if(is_array($result_addresses)) {
 			print "	</div>";
 			print "</td>";
 
-		print '</tr>' . "\n";
-	}
+			print '</tr>' . "\n";
+		}
+		$m++;
 	}
 }
 ?>

--- a/misc/CHANGELOG
+++ b/misc/CHANGELOG
@@ -14,6 +14,7 @@
     + Fixed Force mac address update during status update scan (#3791);
     + Fixed RADIUS authentication fails on 1.6.0 (#3986);
     + Fixed cannot add NAT issue (#3993);
+    + Fixed Searches do not properly organize results (#3917);
 
     Enhancements, changes:
     ----------------------------


### PR DESCRIPTION
Sometimes when viewing search results where permissions or validation fails, results will be placed into weird sections. This is because the results are iterated using a `foreach` but results are checked against the previous result using a separate counter variable `$m`. Under certain circumstances the counter is not updated. Thus, results are rendered wrong.

Fixes #3917