### PR TITLE
Bugfix: Multiple ripe-import issues

### DIFF
--- a/app/admin/ripe-import/ripe-telnet.php
+++ b/app/admin/ripe-import/ripe-telnet.php
@@ -41,8 +41,12 @@ if(sizeof(@$subnet) == 0) {
 	$Result->show("danger alert-absolute", _('No subnets found').'!', true);
 }
 else {
+	if (sizeof(@$subnet) > 1000) {
+		$Result->show("danger alert-absolute", _('Limiting results to 1000 subnets').'!', false);
+	}
+
 	//form
-	print '<form name="asImport" id="asImport">';
+	print '<form name="asImport" id="asImport" style="clear:both;">';
 	//table
 	print '<table class="asImport table table-striped table-condensed table-top table-auto">';
 	//headers
@@ -64,6 +68,9 @@ else {
 	//print found subnets
 	$m = 0;
 	foreach ($subnet as $route) {
+		# break if we reach 1000 routes
+		if ($m > 999) break;
+
 		# only not empty
 		if(strlen($route)>2) {
 			print '<tr>'. "\n";
@@ -103,7 +110,7 @@ else {
 			print '<td>'. "\n";
 			print '<select name="vrf-'. $m .'" class="form-control input-sm input-w-auto">'. "\n";
 			print '<option value="0">No VRF</option>';
-			if(sizeof(@$vrfs)>0) {
+			if($vrfs && sizeof($vrfs)>0) {
 				foreach($vrfs as $vrf) {
 					# set description
 					$vrf_description = !is_blank($vrf->description) ? " (".$vrf->description.")" : "";

--- a/functions/classes/class.Subnets.php
+++ b/functions/classes/class.Subnets.php
@@ -3703,15 +3703,15 @@ class Subnets extends Common_functions {
 			fputs ($ripe_connection, '-i origin as'. $as ."\r\n");
 			//save result to var out
 			$out = "";
-		    while (!feof($ripe_connection)) { $out .= fgets($ripe_connection); }
+			while (!feof($ripe_connection)) { $out .= fgets($ripe_connection); }
 
-		    //parse it
-		    $out = pf_explode("\n", $out);
+			//parse it
+			$out = pf_explode("\n", $out);
 
-		    //we only need route
-		    foreach($out as $line) {
-				if (!is_blank(strstr($line,"route"))) {
-    				if(!isset($subnet)) $subnet = array();
+			//we only want lines starting with route or route6
+			$subnet = array();
+			foreach($out as $line) {
+				if (substr($line,0,6)=="route:" || substr($line,0,7)=="route6:") {
 					//replace route6 with route
 					$line = str_replace("route6:", "route:", $line);
 					//only take IP address
@@ -3720,9 +3720,9 @@ class Subnets extends Common_functions {
 					//set result
 					$subnet[] = $line;
 				}
-		    }
-		    //return
-		    return isset($subnet) ? $subnet : array();
+			}
+			//return
+			return $subnet;
 		}
 	}
 

--- a/misc/CHANGELOG
+++ b/misc/CHANGELOG
@@ -14,6 +14,8 @@
     + Fixed Force mac address update during status update scan (#3791);
     + Fixed RADIUS authentication fails on 1.6.0 (#3986);
     + Fixed cannot add NAT issue (#3993);
+    + Fixed Ripe import results in jQuery error (#4007);
+    + Fixed Ripe import crashes if too many subnets are found (#4180);
 
     Enhancements, changes:
     ----------------------------


### PR DESCRIPTION
In certain circumstances, RIPE import fails due to various reasons:
 + No VRFs exist
 + RIPE provides a line containing the word `route` which is not a route, such as this example: `mnt-routes:     MNT-RELAIX`
 + RIPE provides more routes than PHP can allocate memory for

This PR fixes the above scenarios, and applies some whitespace indentation fixes.
 + Fixes #4007
 + Fixes #4180
