### PR TITLE
ensure devices with height 0 don't crash Rack image generation

### DIFF
--- a/app/admin/devices/edit-result.php
+++ b/app/admin/devices/edit-result.php
@@ -61,7 +61,7 @@ if (!is_blank(@$device['rack']) && $User->get_module_permissions ("racks")>=User
         # validate position and size
         if (!is_numeric($device['rack']))                               { $Result->show("danger", _('Invalid rack identifier').'!', true); }
         if (!is_numeric($device['rack_start']))                         { $Result->show("danger", _('Invalid rack start position').'!', true); }
-        if (!is_numeric($device['rack_size']))                          { $Result->show("danger", _('Invalid rack size').'!', true); }
+        if (intval($device['rack_size']) === 0)                         { $Result->show("danger", _('Invalid rack size').'!', true); }
 		# validate rack
 		$rack = $Racks->fetch_rack_details($device['rack']);
 		if (!is_numeric($device['rack']) || ($rack > 0 && !is_object($rack))) {

--- a/functions/classes/class.Rackspace.php
+++ b/functions/classes/class.Rackspace.php
@@ -617,7 +617,7 @@ class RackDrawer extends Common_functions {
     private function drawContents() {
         foreach ($this->rack->getContent() as $content)
         {
-            $pixelSize = $this->unitYSize * $content->getSize();
+            $pixelSize = $this->unitYSize * max($content->getSize(), 1);
 
             $img = imagecreate($this->rackInsideXSize - 2, $pixelSize);
             $this->drawContent($content, $img, $content->getName());


### PR DESCRIPTION
it is possible to create devices with height=0 which will crash the rack image generation:
```
PHP Fatal error:  Uncaught ValueError: imagecreate(): Argument #2 ($height) must be greater than 0 in phpipam/functions/classes/class.Rackspace.php:626
```
