### PR TITLE
Bugfix: Catch json_decode error

### DIFF
--- a/functions/classes/class.Admin.php
+++ b/functions/classes/class.Admin.php
@@ -447,6 +447,11 @@ class Admin extends Common_functions {
 			foreach($users as $u) {
 				if($u->role != "Administrator") {
 					$g = pf_json_decode($u->groups, true);
+					# if json failed to decode, then this user is eligible to be added
+					if (!$g) {
+						$out[] = $u->id;
+						continue;
+					}
 					if(!@in_array($group_id, $g)) { $out[] = $u->id; }
 				}
 			}

--- a/misc/CHANGELOG
+++ b/misc/CHANGELOG
@@ -14,6 +14,7 @@
     + Fixed Force mac address update during status update scan (#3791);
     + Fixed RADIUS authentication fails on 1.6.0 (#3986);
     + Fixed cannot add NAT issue (#3993);
+    + Fixed Bug when adding a user to a group (#4137);
 
     Enhancements, changes:
     ----------------------------


### PR DESCRIPTION
When attempting to add users to a group, if there exist non-admin users who are members of no group, an HTTP 500 error commonly arises. This is caused because the `groups` field on the user in the `users` table is frequently `null`, which produces a `False` output from the `json_decode` function. When this happens, the `in_array` function produces an error since `False` is not an array.
+ Fixes #4137