### PR TITLE
Bugfix: Fixed password validation

### DIFF
--- a/app/admin/users/edit-result.php
+++ b/app/admin/users/edit-result.php
@@ -48,7 +48,6 @@ if($_POST['action']!="delete") {
 	if((!is_blank(@$_POST['password1']) || (@$_POST['action']=="add") && $auth_method->type=="local")) {
 		//checks
 		if($_POST['password1']!=$_POST['password2'])						{ $Result->show("danger", _("Passwords do not match"), true); }
-		if(strlen($_POST['password1'])<8)									{ $Result->show("danger", _("Password must be at least 8 characters long!"), true); }
 
 		//enforce password policy
 		$policy = (pf_json_decode($User->settings->passwordPolicy, true));

--- a/functions/classes/class.Password_check.php
+++ b/functions/classes/class.Password_check.php
@@ -229,7 +229,7 @@ class Password_check extends Common_functions {
 	private function validate_maxSymbols () {
 		$cnt = $this->count_symbols ();
 		// check
-		if ($cnt < $this->requirements['maxSymbols']) {
+		if ($cnt > $this->requirements['maxSymbols']) {
 			$this->save_error (_("Too many symbols")." ("._("maximum")." {$this->requirements['maxSymbols']}).");
 		}
 	}

--- a/misc/CHANGELOG
+++ b/misc/CHANGELOG
@@ -14,6 +14,7 @@
     + Fixed Force mac address update during status update scan (#3791);
     + Fixed RADIUS authentication fails on 1.6.0 (#3986);
     + Fixed cannot add NAT issue (#3993);
+    + Fixed Password validation error, too many symbols (#4099);
 
     Enhancements, changes:
     ----------------------------

--- a/misc/CHANGELOG
+++ b/misc/CHANGELOG
@@ -14,7 +14,7 @@
     + Fixed Force mac address update during status update scan (#3791);
     + Fixed RADIUS authentication fails on 1.6.0 (#3986);
     + Fixed cannot add NAT issue (#3993);
-    + Fixed Password validation error, too many symbols (#4099);
+    + Fixed Password validation errors (#4099,#2423);
 
     Enhancements, changes:
     ----------------------------


### PR DESCRIPTION
Setting the "Maximum symbols" field in the Password Policy does not work because of a flipped less-than/greater-than sign.
+ Fixes #4099
+ Fixes #2423