### PR TITLE
Updated locale files to match fixes in code

### DIFF
--- a/functions/locale/cs_CZ.UTF-8/LC_MESSAGES/phpipam.po
+++ b/functions/locale/cs_CZ.UTF-8/LC_MESSAGES/phpipam.po
@@ -2382,7 +2382,7 @@ msgid "Cannot update request"
 msgstr "Nelze aktualizovat požadavek"
 
 #: site/admin/manageRequestResult.php:33
-msgid "Request has beed rejected"
+msgid "Request has been rejected"
 msgstr "Požadavek byl odmítnut"
 
 #: site/admin/manageRequestResult.php:54 site/admin/manageRequestResult.php:58
@@ -2430,7 +2430,7 @@ msgid "Errors occured when importing to database!"
 msgstr "Při importu databáze nastala chyba!"
 
 #: site/admin/CSVimportSubmit.php:95 site/admin/RIPE / ARINImportResult.php:72
-msgid "Import successfull"
+msgid "Import successful"
 msgstr "Import proběhl úspěšně"
 
 #: site/admin/CSVimportVerify.php:25
@@ -2868,7 +2868,7 @@ msgstr ""
 #: site/admin/customIPFieldsOrder.php:15
 #: site/admin/customVLANFieldsOrder.php:15
 #: site/admin/customUserFieldsOrder.php:15
-msgid "Fileds cannot be empty"
+msgid "Fields cannot be empty"
 msgstr "Pole nemohou být prázdná"
 
 #: site/admin/customSubnetFieldsOrder.php:19
@@ -3264,7 +3264,7 @@ msgid "Truncating network will remove all IP addresses, that belong to selected 
 msgstr ""
 
 #: site/admin/manageSubnetTruncateSave.php:23
-msgid "Subnet truncated succesfully"
+msgid "Subnet truncated successfully"
 msgstr ""
 
 #: site/admin/usersEditEmailNotif.php:23

--- a/functions/locale/de_DE.UTF-8/LC_MESSAGES/phpipam.po
+++ b/functions/locale/de_DE.UTF-8/LC_MESSAGES/phpipam.po
@@ -2997,7 +2997,7 @@ msgid "Set which field to display in table"
 msgstr "Festlegen welche Felder in der Tabelle angezeigt werden"
 
 #: app/admin/custom-fields/order.php:21
-msgid "Fileds cannot be empty"
+msgid "Fields cannot be empty"
 msgstr "Felder k&ouml;nnen nicht leer sein"
 
 #: app/admin/custom-fields/order.php:25
@@ -3832,7 +3832,7 @@ msgstr "Verfahren Zonen Generator"
 
 #: app/admin/firewall-zones/settings.php:146
 msgid ""
-"Generate zone names automaticaly with the setting &quot;decimal&quot; or "
+"Generate zone names automatically with the setting &quot;decimal&quot; or "
 "&quot;hex&quot;.<br>The maximum value for a zone in hex mode would be "
 "ffffffff (4294967295 zones).<br>To use your own unique zone names you can "
 "choose the option &quot;text&quot;."
@@ -3890,7 +3890,7 @@ msgstr "Autogenerierung Adressobjekte"
 
 #: app/admin/firewall-zones/settings.php:201
 msgid ""
-"Automaticaly generate firewall address objects as an additional information "
+"Automatically generate firewall address objects as an additional information "
 "of an IP address.<br>(Works only for subnets which are bound to a firewall "
 "zone.)"
 msgstr ""
@@ -6139,7 +6139,7 @@ msgid "Minimum numbers"
 msgstr "Minimalanzahl Zahlen"
 
 #: app/admin/password-policy/index.php:50
-msgid "Minumum number of numbers"
+msgid "Minimum number of numbers"
 msgstr "Mindestanzahl von zu benutzenden Zahlen"
 
 #: app/admin/password-policy/index.php:54
@@ -6147,7 +6147,7 @@ msgid "Minimum letters"
 msgstr "Minimalanzahl Buchstaben"
 
 #: app/admin/password-policy/index.php:58
-msgid "Minumum number of letters"
+msgid "Minimum number of letters"
 msgstr "Mindestanzahl von zu benutzenden Buchstaben"
 
 #: app/admin/password-policy/index.php:62
@@ -6155,7 +6155,7 @@ msgid "Minimum lowercase letter"
 msgstr "Minimalanzahl kleine Buchstaben"
 
 #: app/admin/password-policy/index.php:66
-msgid "Minumum number of lowercase letters"
+msgid "Minimum number of lowercase letters"
 msgstr "Mindestanzahl von klein geschriebenen Buchstaben"
 
 #: app/admin/password-policy/index.php:70
@@ -6163,7 +6163,7 @@ msgid "Minimum uppercase letter"
 msgstr "Minimalanzahl große Buchstaben"
 
 #: app/admin/password-policy/index.php:74
-msgid "Minumum number of uppercase letters"
+msgid "Minimum number of uppercase letters"
 msgstr "Mindestanzahl von groß geschriebenen Buchstaben"
 
 #: app/admin/password-policy/index.php:78
@@ -6171,7 +6171,7 @@ msgid "Minimum symbols"
 msgstr "Minimalanzahl Sondersymbole"
 
 #: app/admin/password-policy/index.php:82
-msgid "Minumum number of symbols"
+msgid "Minimum number of symbols"
 msgstr "Mindestanzahl von zu benutzenden Sondersymbolen"
 
 #: app/admin/password-policy/index.php:86
@@ -6627,7 +6627,7 @@ msgid "Failed to reject IP request"
 msgstr "IP-Antrag ablehnen fehlgeschlagen"
 
 #: app/admin/requests/edit-result.php:53
-msgid "Request has beed rejected"
+msgid "Request has been rejected"
 msgstr "Anfrage wurde zur&uuml;ckgewiesen"
 
 #: app/admin/requests/edit-result.php:64
@@ -7625,7 +7625,7 @@ msgid "Require unique subnets"
 msgstr "Einfordern von eindeutigen Subnetzen"
 
 #: app/admin/settings/index.php:518
-msgid "Require unique subnets accross all sections"
+msgid "Require unique subnets across all sections"
 msgstr "Fordere eindeutige Subnetze &uuml;ber alle Bereiche"
 
 #: app/admin/settings/index.php:524
@@ -8374,17 +8374,17 @@ msgid "fill"
 msgstr "F&uuml;llen"
 
 #: app/admin/subnets/split-save.php:41
-msgid "Subnet splitted successfully"
+msgid "Subnet split successfully"
 msgstr "Aufsplitten des Subnetzes erfolgreich"
 
 #: app/admin/subnets/split.php:35
-msgid "Only subnets that have no nested subnets can be splitted"
+msgid "Only subnets that have no nested subnets can be split"
 msgstr ""
 "Nur Subnetze die keine untergeordneten Subnetze haben k&ouml;nnen geteilt "
 "werden."
 
 #: app/admin/subnets/split.php:42
-msgid "Subnet too small to be splitted"
+msgid "Subnet too small to be split"
 msgstr "Subnetz zu klein zum Splitten"
 
 #: app/admin/subnets/split.php:84
@@ -8436,7 +8436,7 @@ msgid "Failed to truncate subnet"
 msgstr "Subnetz verkleinern fehlgeschlagen"
 
 #: app/admin/subnets/truncate-save.php:44
-msgid "Subnet truncated succesfully"
+msgid "Subnet truncated successfully"
 msgstr "Subnetz Verkleinerung erfolgreich!"
 
 #: app/admin/subnets/truncate.php:64
@@ -9068,7 +9068,7 @@ msgid "Vault secret"
 msgstr "Secret vom Tresor"
 
 #: app/admin/vaults/edit.php:95
-msgid "Vault secret. Please store secret as it cannot be retreived if lost!"
+msgid "Vault secret. Please store secret as it cannot be retrieved if lost!"
 msgstr ""
 "Secret des Tresors, bitte das Secret sicher verwahren, es kann nicht wieder "
 "hergestellt werden!"
@@ -9318,7 +9318,7 @@ msgstr "Keine Dom&auml;nen verf&uuml;gbar!"
 #: app/subnets/scan/subnet-scan-execute-scan-snmp-arp.php:14
 #: app/subnets/scan/subnet-scan-execute-snmp-mac.php:18
 #: app/subnets/scan/subnet-scan-result-snmp-route-all.php:23
-msgid "SNMP module disbled"
+msgid "SNMP module disabled"
 msgstr "Modul SNMP ist deaktiviert"
 
 #: app/admin/vlans/vlans-scan-execute.php:32
@@ -10428,7 +10428,7 @@ msgstr ""
 "Datenbankbenutzers in der Datei config.php."
 
 #: app/install/sql_error.php:31
-msgid "Database connection succesfull"
+msgid "Database connection successful"
 msgstr "Datenbankverbindung erfolgreich"
 
 #: app/install/welcome.php:9
@@ -11629,7 +11629,7 @@ msgid "You cannot write to this subnet"
 msgstr "Sie haben keine Schreibberechtigung f&uuml;r das Subnetz"
 
 #: app/subnets/import-subnet/import-file.php:142
-msgid "Import successfull"
+msgid "Import successful"
 msgstr "Import erfolgreich"
 
 #: app/subnets/import-subnet/import-template.php:42
@@ -15038,7 +15038,7 @@ msgstr " ist keine g&uuml;ltige Adresse f&uuml;r Subnetz "
 
 #: functions/classes/class.Addresses.php:1854
 #: functions/classes/class.Addresses.php:1857
-msgid "Object is Natted"
+msgid "Object is NATted"
 msgstr "Objekt ist NAT'ed"
 
 #: functions/classes/class.Admin.php:187
@@ -15387,7 +15387,7 @@ msgid "Go to administration and fix"
 msgstr "Zum Administrations Men&uuml; gehen und korrigieren"
 
 #: functions/classes/class.Install.php:549
-msgid "Succesfull queries"
+msgid "Succesful queries"
 msgstr "Erfolgreiche Abfragen"
 
 #: functions/classes/class.Install.php:551
@@ -16032,7 +16032,7 @@ msgid "MAC address already exists"
 msgstr "MAC-Adresse existiert bereits"
 
 #: functions/classes/class.Subnets.php:3104
-msgid "Failed to set subnet permissons for subnet"
+msgid "Failed to set subnet permissions for subnet"
 msgstr "&Auml;ndern der Berechtigung f&uuml;r das Subnetz fehlgeschlagen"
 
 #: functions/classes/class.Subnets.php:3117
@@ -16338,7 +16338,7 @@ msgid "User self update failed"
 msgstr "Aktualisierung durch Benutzer fehlgeschlagen"
 
 #: functions/classes/class.User.php:1336
-msgid "User self update suceeded"
+msgid "User self update succeeded"
 msgstr "Aktualisierung durch Benutzer erfolgreich"
 
 #: functions/classes/class.User.php:1672

--- a/functions/locale/en_GB.UTF-8/LC_MESSAGES/phpipam.po
+++ b/functions/locale/en_GB.UTF-8/LC_MESSAGES/phpipam.po
@@ -2335,7 +2335,7 @@ msgid "Cannot update request"
 msgstr ""
 
 #: site/admin/manageRequestResult.php:33
-msgid "Request has beed rejected"
+msgid "Request has been rejected"
 msgstr ""
 
 #: site/admin/manageRequestResult.php:54 site/admin/manageRequestResult.php:58
@@ -2383,7 +2383,7 @@ msgid "Errors occured when importing to database!"
 msgstr ""
 
 #: site/admin/CSVimportSubmit.php:95 site/admin/RIPE / ARINImportResult.php:72
-msgid "Import successfull"
+msgid "Import successful"
 msgstr ""
 
 #: site/admin/CSVimportVerify.php:25
@@ -2825,7 +2825,7 @@ msgstr ""
 #: site/admin/customIPFieldsOrder.php:15
 #: site/admin/customVLANFieldsOrder.php:15
 #: site/admin/customUserFieldsOrder.php:15
-msgid "Fileds cannot be empty"
+msgid "Fields cannot be empty"
 msgstr ""
 
 #: site/admin/customSubnetFieldsOrder.php:19
@@ -3226,7 +3226,7 @@ msgid "Truncating network will remove all IP addresses, that belong to selected 
 msgstr ""
 
 #: site/admin/manageSubnetTruncateSave.php:23
-msgid "Subnet truncated succesfully"
+msgid "Subnet truncated successfully"
 msgstr ""
 
 #: site/admin/usersEditEmailNotif.php:23
@@ -5679,10 +5679,10 @@ msgstr ""
 msgid "Manage permissions for folder"
 msgstr ""
 
-msgid "Only subnets that have no nested subnets can be splitted"
+msgid "Only subnets that have no nested subnets can be split"
 msgstr ""
 
-msgid "Subnet too small to be splitted"
+msgid "Subnet too small to be split"
 msgstr ""
 
 msgid "Name prefix"
@@ -6314,7 +6314,7 @@ msgstr ""
 msgid "No new subnets found"
 msgstr ""
 
-msgid "SNMP module disbled"
+msgid "SNMP module disabled"
 msgstr ""
 
 msgid "No devices for SNMP ARP query available"
@@ -7106,7 +7106,7 @@ msgstr ""
 msgid "Require unique subnets"
 msgstr ""
 
-msgid "Require unique subnets accross all sections"
+msgid "Require unique subnets across all sections"
 msgstr ""
 
 msgid "Set maximum number of concurrent ICMP checks (default 128)"
@@ -7172,13 +7172,13 @@ msgstr ""
 msgid "Set subnet alert threshold"
 msgstr ""
 
-msgid "Failed to set subnet permissons for subnet"
+msgid "Failed to set subnet permissions for subnet"
 msgstr ""
 
 msgid "No result"
 msgstr ""
 
-msgid "Subnet splitted successfully"
+msgid "Subnet split successfully"
 msgstr ""
 
 msgid "Copy custom field values"
@@ -8000,7 +8000,7 @@ msgstr ""
 msgid "Upgrade"
 msgstr ""
 
-msgid "Object is Natted"
+msgid "Object is NATted"
 msgstr ""
 
 msgid "Invalid generator ID"
@@ -8198,31 +8198,31 @@ msgstr ""
 msgid "Minimum numbers"
 msgstr ""
 
-msgid "Minumum number of numbers"
+msgid "Minimum number of numbers"
 msgstr ""
 
 msgid "Minimum letters"
 msgstr ""
 
-msgid "Minumum number of letters"
+msgid "Minimum number of letters"
 msgstr ""
 
 msgid "Minimum lowercase letter"
 msgstr ""
 
-msgid "Minumum number of lowercase letters"
+msgid "Minimum number of lowercase letters"
 msgstr ""
 
 msgid "Minimum uppercase letter"
 msgstr ""
 
-msgid "Minumum number of uppercase letters"
+msgid "Minimum number of uppercase letters"
 msgstr ""
 
 msgid "Minimum symbols"
 msgstr ""
 
-msgid "Minumum number of symbols"
+msgid "Minimum number of symbols"
 msgstr ""
 
 msgid "Maximum symbols"

--- a/functions/locale/en_US.UTF-8/LC_MESSAGES/phpipam.po
+++ b/functions/locale/en_US.UTF-8/LC_MESSAGES/phpipam.po
@@ -2369,7 +2369,7 @@ msgid "Cannot update request"
 msgstr ""
 
 #: site/admin/manageRequestResult.php:33
-msgid "Request has beed rejected"
+msgid "Request has been rejected"
 msgstr ""
 
 #: site/admin/manageRequestResult.php:54 site/admin/manageRequestResult.php:58
@@ -2417,7 +2417,7 @@ msgid "Errors occured when importing to database!"
 msgstr ""
 
 #: site/admin/CSVimportSubmit.php:95 site/admin/ripeImportResult.php:72
-msgid "Import successfull"
+msgid "Import successful"
 msgstr ""
 
 #: site/admin/CSVimportVerify.php:25
@@ -2853,7 +2853,7 @@ msgstr ""
 #: site/admin/customIPFieldsOrder.php:15
 #: site/admin/customVLANFieldsOrder.php:15
 #: site/admin/customUserFieldsOrder.php:15
-msgid "Fileds cannot be empty"
+msgid "Fields cannot be empty"
 msgstr ""
 
 #: site/admin/customSubnetFieldsOrder.php:19
@@ -3248,7 +3248,7 @@ msgid "Truncating network will remove all IP addresses, that belong to selected 
 msgstr ""
 
 #: site/admin/manageSubnetTruncateSave.php:23
-msgid "Subnet truncated succesfully"
+msgid "Subnet truncated successfully"
 msgstr ""
 
 #: site/admin/usersEditEmailNotif.php:23
@@ -5712,10 +5712,10 @@ msgstr ""
 msgid "Manage permissions for folder"
 msgstr ""
 
-msgid "Only subnets that have no nested subnets can be splitted"
+msgid "Only subnets that have no nested subnets can be split"
 msgstr ""
 
-msgid "Subnet too small to be splitted"
+msgid "Subnet too small to be split"
 msgstr ""
 
 msgid "Name prefix"
@@ -6294,7 +6294,7 @@ msgstr ""
 msgid "Zone generator method"
 msgstr ""
 
-msgid "Generate zone names automaticaly with the setting &quot;decimal&quot; or &quot;hex&quot;.<br>To use your own unique zone names you can choose the option &quot;text&quot."
+msgid "Generate zone names automatically with the setting &quot;decimal&quot; or &quot;hex&quot;.<br>To use your own unique zone names you can choose the option &quot;text&quot."
 msgstr ""
 
 msgid "Zone name padding"
@@ -6576,7 +6576,7 @@ msgstr ""
 msgid "No new subnets found"
 msgstr ""
 
-msgid "SNMP module disbled"
+msgid "SNMP module disabled"
 msgstr ""
 
 msgid "No devices for SNMP ARP query available"
@@ -7359,7 +7359,7 @@ msgstr ""
 msgid "Require unique subnets"
 msgstr ""
 
-msgid "Require unique subnets accross all sections"
+msgid "Require unique subnets across all sections"
 msgstr ""
 
 msgid "Set maximum number of concurrent ICMP checks (default 128)"
@@ -7425,13 +7425,13 @@ msgstr ""
 msgid "Set subnet alert threshold"
 msgstr ""
 
-msgid "Failed to set subnet permissons for subnet"
+msgid "Failed to set subnet permissions for subnet"
 msgstr ""
 
 msgid "No result"
 msgstr ""
 
-msgid "Subnet splitted successfully"
+msgid "Subnet split successfully"
 msgstr ""
 
 msgid "Copy custom field values"
@@ -8253,7 +8253,7 @@ msgstr ""
 msgid "Upgrade"
 msgstr ""
 
-msgid "Object is Natted"
+msgid "Object is NATted"
 msgstr ""
 
 msgid "Invalid generator ID"

--- a/functions/locale/es_ES.UTF-8/LC_MESSAGES/phpipam.po
+++ b/functions/locale/es_ES.UTF-8/LC_MESSAGES/phpipam.po
@@ -2391,7 +2391,7 @@ msgid "Cannot update request"
 msgstr "No se puede actualizar la solicitud"
 
 #: site/admin/manageRequestResult.php:33
-msgid "Request has beed rejected"
+msgid "Request has been rejected"
 msgstr "La solicitud ha sido rechazada"
 
 #: site/admin/manageRequestResult.php:54 site/admin/manageRequestResult.php:58
@@ -2439,7 +2439,7 @@ msgid "Errors occured when importing to database!"
 msgstr "Errores durante la importación a la BBDD"
 
 #: site/admin/CSVimportSubmit.php:95 site/admin/RIPE / ARINImportResult.php:72
-msgid "Import successfull"
+msgid "Import successful"
 msgstr "Importación correcta"
 
 #: site/admin/CSVimportVerify.php:25
@@ -2881,7 +2881,7 @@ msgstr "Si el grupo no tiene acceso a la sección no podrá acceder a la subred,
 #: site/admin/customIPFieldsOrder.php:15
 #: site/admin/customVLANFieldsOrder.php:15
 #: site/admin/customUserFieldsOrder.php:15
-msgid "Fileds cannot be empty"
+msgid "Fields cannot be empty"
 msgstr "Los campos no pueden estar vacíos"
 
 #: site/admin/customSubnetFieldsOrder.php:19
@@ -3285,7 +3285,7 @@ msgstr "¡Truncando la red se eliminarán todas las IPs que pertenezcan a la sub
 "seleccionada!"
 
 #: site/admin/manageSubnetTruncateSave.php:23
-msgid "Subnet truncated succesfully"
+msgid "Subnet truncated successfully"
 msgstr "Subred truncada correctamente"
 
 #: site/admin/usersEditEmailNotif.php:23

--- a/functions/locale/fr_FR.UTF-8/LC_MESSAGES/phpipam.po
+++ b/functions/locale/fr_FR.UTF-8/LC_MESSAGES/phpipam.po
@@ -2219,7 +2219,7 @@ msgid "Cannot update request"
 msgstr "Impossible de mettre à jour la requête"
 
 #: site/admin/manageRequestResult.php:33
-msgid "Request has beed rejected"
+msgid "Request has been rejected"
 msgstr "Requête refusée"
 
 #: site/admin/manageRequestResult.php:54 site/admin/manageRequestResult.php:58
@@ -2267,7 +2267,7 @@ msgid "Errors occured when importing to database!"
 msgstr "Erreurs pendant l’importation dans la base de données"
 
 #: site/admin/CSVimportSubmit.php:95 site/admin/ripeImportResult.php:72
-msgid "Import successfull"
+msgid "Import successful"
 msgstr "Importation réussie"
 
 #: site/admin/CSVimportVerify.php:25
@@ -2713,7 +2713,7 @@ msgstr ""
 
 #: site/admin/customSubnetFieldsOrder.php:15 site/admin/customIPFieldsOrder.php:15
 #: site/admin/customVLANFieldsOrder.php:15 site/admin/customUserFieldsOrder.php:15
-msgid "Fileds cannot be empty"
+msgid "Fields cannot be empty"
 msgstr "Champs ne pouvant être vides"
 
 #: site/admin/customSubnetFieldsOrder.php:19 site/admin/customIPFieldsOrder.php:19
@@ -3109,7 +3109,7 @@ msgid "Truncating network will remove all IP addresses, that belong to selected 
 msgstr "Tronquer un réseau va supprimer toutes ses adresse IP !"
 
 #: site/admin/manageSubnetTruncateSave.php:23
-msgid "Subnet truncated succesfully"
+msgid "Subnet truncated successfully"
 msgstr "Sous-réseau tronqué avec succès"
 
 #: site/admin/usersEditEmailNotif.php:23
@@ -5565,10 +5565,10 @@ msgstr "Echec de modification des permissions de sous-réseau"
 msgid "Manage permissions for folder"
 msgstr "Gérer les premissions pour le dossier"
 
-msgid "Only subnets that have no nested subnets can be splitted"
+msgid "Only subnets that have no nested subnets can be split"
 msgstr "Seuls les sous-réseaux sans sous-réseaux rattachés peuvent être splités"
 
-msgid "Subnet too small to be splitted"
+msgid "Subnet too small to be split"
 msgstr "Sous-réseau trop petit pour être splité"
 
 msgid "Name prefix"
@@ -6166,7 +6166,7 @@ msgid "Zone generator method"
 msgstr "Méthode de génération de zone"
 
 msgid ""
-"Generate zone names automaticaly with the setting &quot;decimal&quot; or &quot;hex&quot;.<br>To use your own "
+"Generate zone names automatically with the setting &quot;decimal&quot; or &quot;hex&quot;.<br>To use your own "
 "unique zone names you can choose the option &quot;text&quot."
 msgstr ""
 "Génére des noms de zone automatiquement avec le paramètre &quot;decimal&quot; or &quot;hex&quot;.<b> Pour "
@@ -6461,7 +6461,7 @@ msgstr "Aucun équipement disponible pour la table de routage SNMP"
 msgid "No new subnets found"
 msgstr "Aucun nouveau sous-réseau trouvé"
 
-msgid "SNMP module disbled"
+msgid "SNMP module disabled"
 msgstr "Module SNMP désactivé"
 
 msgid "No devices for SNMP ARP query available"
@@ -7246,7 +7246,7 @@ msgstr "Mettre à jour les labels d’adresses quand un changement d’état d�
 msgid "Require unique subnets"
 msgstr "Requiert sous-réseau unique"
 
-msgid "Require unique subnets accross all sections"
+msgid "Require unique subnets across all sections"
 msgstr "Requiert l’unicité des sous-réseaux dans l’ensemble des sections"
 
 msgid "Set maximum number of concurrent ICMP checks (default 128)"
@@ -7312,13 +7312,13 @@ msgstr "Marquer sous-réseau comme utilisé"
 msgid "Set subnet alert threshold"
 msgstr "choisir le seul d’alerte de sous-réseau"
 
-msgid "Failed to set subnet permissons for subnet"
+msgid "Failed to set subnet permissions for subnet"
 msgstr "Echec de paramétrage des droits pour le sous-réseau"
 
 msgid "No result"
 msgstr "Aucun résultat"
 
-msgid "Subnet splitted successfully"
+msgid "Subnet split successfully"
 msgstr "Sous-réseau divisé avec succés"
 
 msgid "Copy custom field values"
@@ -8147,7 +8147,7 @@ msgstr "Options mises à jour"
 msgid "Upgrade"
 msgstr "Mettre à jour"
 
-msgid "Object is Natted"
+msgid "Object is NATted"
 msgstr "Obet naté"
 
 msgid "Invalid generator ID"

--- a/functions/locale/it_IT.UTF-8/LC_MESSAGES/phpipam.po
+++ b/functions/locale/it_IT.UTF-8/LC_MESSAGES/phpipam.po
@@ -2153,7 +2153,7 @@ msgid "Cannot update request"
 msgstr "Impossibile aggiornare la richiesta"
 
 #: site/admin/manageRequestResult.php:33
-msgid "Request has beed rejected"
+msgid "Request has been rejected"
 msgstr "La richiesta &egrave; stata rifiutata"
 
 #: site/admin/manageRequestResult.php:54 site/admin/manageRequestResult.php:58
@@ -2201,7 +2201,7 @@ msgid "Errors occured when importing to database!"
 msgstr "Si sono verificati degli errore durante l&#39;importazione del database!"
 
 #: site/admin/CSVimportSubmit.php:95 site/admin/ripeImportResult.php:72
-msgid "Import successfull"
+msgid "Import successful"
 msgstr "Impostazione eseguita"
 
 #: site/admin/CSVimportVerify.php:25
@@ -2628,7 +2628,7 @@ msgid "If group does not have access to section it will not be able to access su
 msgstr "Se un gruppo non ha accesso alla sezione non potr&agrave; accedere alle subnet, anche se<br>i permessi sulle subnet sono impostati"
 
 #: site/admin/customSubnetFieldsOrder.php:15 site/admin/customIPFieldsOrder.php:15 site/admin/customVLANFieldsOrder.php:15 site/admin/customUserFieldsOrder.php:15
-msgid "Fileds cannot be empty"
+msgid "Fields cannot be empty"
 msgstr "I campi non possono essere vuoti"
 
 #: site/admin/customSubnetFieldsOrder.php:19 site/admin/customIPFieldsOrder.php:19 site/admin/customVLANFieldsOrder.php:19 site/admin/customUserFieldsOrder.php:19
@@ -3005,7 +3005,7 @@ msgid "Truncating network will remove all IP addresses, that belong to selected 
 msgstr "Troncare la rete canceller&agrave; tutti gli indirizzi IP che appartengono alla subnet selezionata!"
 
 #: site/admin/manageSubnetTruncateSave.php:23
-msgid "Subnet truncated succesfully"
+msgid "Subnet truncated successfully"
 msgstr "Subnet troncata con successo"
 
 #: site/admin/usersEditEmailNotif.php:23
@@ -5438,10 +5438,10 @@ msgstr "Errore impostazione permessi subnet"
 msgid "Manage permissions for folder"
 msgstr "Gestione permessi per cartella"
 
-msgid "Only subnets that have no nested subnets can be splitted"
+msgid "Only subnets that have no nested subnets can be split"
 msgstr "Solo le subnet che non hanno subnet annidate possono essere divise"
 
-msgid "Subnet too small to be splitted"
+msgid "Subnet too small to be split"
 msgstr "Subnet troppo piccola per essere divisa"
 
 msgid "Name prefix"
@@ -6021,7 +6021,7 @@ msgstr "Indicatore cliente zona"
 msgid "Zone generator method"
 msgstr "Metodo generazione zona"
 
-msgid "Generate zone names automaticaly with the setting &quot;decimal&quot; or &quot;hex&quot;.<br>To use your own unique zone names you can choose the option &quot;text&quot."
+msgid "Generate zone names automatically with the setting &quot;decimal&quot; or &quot;hex&quot;.<br>To use your own unique zone names you can choose the option &quot;text&quot."
 msgstr "Genera i nomi zona automaticamente con l&#39;impostazione &quot;decimal&quot; o &quot;hex&quot;. Per utilizzare nomi zona proprietari scegliere &quot;text&quot;."
 
 msgid "Zone name padding"
@@ -6304,7 +6304,7 @@ msgstr "Nessun dispositivo disponibile per interrogazione tabella instradamenti 
 msgid "No new subnets found"
 msgstr "Nessuna nuova subnet trovata"
 
-msgid "SNMP module disbled"
+msgid "SNMP module disabled"
 msgstr "Modulo SNMP disattivato"
 
 msgid "No devices for SNMP ARP query available"
@@ -7087,7 +7087,7 @@ msgstr "Aggiorna i tag dell&#39;indirizzo quando si verifica un cambio di stato"
 msgid "Require unique subnets"
 msgstr "Richiedi subnet univoche"
 
-msgid "Require unique subnets accross all sections"
+msgid "Require unique subnets across all sections"
 msgstr "Richiedi subnet univoche tra tutte le sezioni"
 
 msgid "Set maximum number of concurrent ICMP checks (default 128)"
@@ -7153,13 +7153,13 @@ msgstr "Segna come utilizzata"
 msgid "Set subnet alert threshold"
 msgstr "Imposta soglia allerta subnet"
 
-msgid "Failed to set subnet permissons for subnet"
+msgid "Failed to set subnet permissions for subnet"
 msgstr "Errore impostando i permessi per la subnet"
 
 msgid "No result"
 msgstr "Nessun risultato"
 
-msgid "Subnet splitted successfully"
+msgid "Subnet split successfully"
 msgstr "Subent divisa"
 
 msgid "Copy custom field values"
@@ -7981,7 +7981,7 @@ msgstr "Opzioni aggiornate"
 msgid "Upgrade"
 msgstr "Aggiorna"
 
-msgid "Object is Natted"
+msgid "Object is NATted"
 msgstr "L&#39;oggetto &egrave; in nat"
 
 msgid "Invalid generator ID"

--- a/functions/locale/ja_JP.UTF-8/LC_MESSAGES/phpipam.po
+++ b/functions/locale/ja_JP.UTF-8/LC_MESSAGES/phpipam.po
@@ -769,7 +769,7 @@ msgstr "ブロードキャストはIPアドレスとして追加できません!
 
 #: /var/www/phpipam/functions/classes/class.Addresses.php:2072
 #: /var/www/phpipam/functions/classes/class.Addresses.php:2075
-msgid "Object is Natted"
+msgid "Object is NATted"
 msgstr "オブジェクトはナットされています"
 
 #: /var/www/phpipam/functions/classes/class.Log.php:388
@@ -1173,7 +1173,7 @@ msgid "error"
 msgstr "エラー"
 
 #: /var/www/phpipam/functions/classes/class.Subnets.php:2944
-msgid "Failed to set subnet permissons for subnet"
+msgid "Failed to set subnet permissions for subnet"
 msgstr "サブネットのサブネット権限を設定できませんでした"
 
 #: /var/www/phpipam/functions/classes/class.Subnets.php:2957
@@ -4661,7 +4661,7 @@ msgid "No devices configured"
 msgstr "デバイスが設定されなかった"
 
 #: /var/www/phpipam/app/admin/custom-fields/order.php:21
-msgid "Fileds cannot be empty"
+msgid "Fields cannot be empty"
 msgstr "フィールドを空にすることはできません"
 
 #: /var/www/phpipam/app/admin/custom-fields/order.php:25
@@ -5308,7 +5308,7 @@ msgid "Zone generator method"
 msgstr "ゾーン作成メソッド"
 
 #: /var/www/phpipam/app/admin/firewall-zones/settings.php:146
-msgid "Generate zone names automaticaly with the setting &quot;decimal&quot; or "
+msgid "Generate zone names automatically with the setting &quot;decimal&quot; or "
 "&quot;hex&quot;.<br>The maximum value for a zone in hex mode would be "
 "ffffffff (4294967295 zones).<br>To use your own unique zone names you can "
 "choose the option &quot;text&quot."
@@ -5355,7 +5355,7 @@ msgid "Autogenerate address objects"
 msgstr "アドレスオブジェクト"
 
 #: /var/www/phpipam/app/admin/firewall-zones/settings.php:201
-msgid "Automaticaly generate firewall address objects as an additional information "
+msgid "Automatically generate firewall address objects as an additional information "
 "of an IP address.<br>(Works only for subnets which are bound to a firewall "
 "zone.)"
 msgstr "ファイアウォールのアドレスオブジェクトを、IPアドレスの追加情報として自動生成"
@@ -6287,7 +6287,7 @@ msgstr "デフォルトのドメインは削除できません"
 #: /var/www/phpipam/app/subnets/scan/subnet-scan-snmp-mac.php:21
 #: /var/www/phpipam/app/subnets/scan/subnet-scan-snmp-arp.php:17
 #: /var/www/phpipam/app/subnets/scan/subnet-scan-snmp-route-all-result.php:41
-msgid "SNMP module disbled"
+msgid "SNMP module disabled"
 msgstr "SNMPモジュールを無効にする"
 
 #: /var/www/phpipam/app/admin/vlans/vlans-scan.php:23
@@ -7370,7 +7370,7 @@ msgid "Require unique subnets"
 msgstr "固有のサブネットが必要です"
 
 #: /var/www/phpipam/app/admin/settings/index.php:485
-msgid "Require unique subnets accross all sections"
+msgid "Require unique subnets across all sections"
 msgstr "すべてのセクションで一意のサブネットが必要です"
 
 #: /var/www/phpipam/app/admin/settings/index.php:491
@@ -8135,7 +8135,7 @@ msgid "Failed to reject IP request"
 msgstr "IP要求を拒否できませんでした"
 
 #: /var/www/phpipam/app/admin/requests/edit-result.php:53
-msgid "Request has beed rejected"
+msgid "Request has been rejected"
 msgstr "リクエストが拒否されました"
 
 #: /var/www/phpipam/app/admin/requests/edit-result.php:83
@@ -8240,7 +8240,7 @@ msgstr "サブネットのインポートに失敗しました"
 
 #: /var/www/phpipam/app/admin/ripe-import/import-subnets.php:95
 #: /var/www/phpipam/app/subnets/import-subnet/import-file.php:142
-msgid "Import successfull"
+msgid "Import successful"
 msgstr "インポート成功"
 
 #: /var/www/phpipam/app/admin/version-check/index.php:12
@@ -8462,11 +8462,11 @@ msgid "fill"
 msgstr "入力"
 
 #: /var/www/phpipam/app/admin/subnets/split.php:35
-msgid "Only subnets that have no nested subnets can be splitted"
+msgid "Only subnets that have no nested subnets can be split"
 msgstr "ネストされたサブネットを持たないサブネットのみが分割できます"
 
 #: /var/www/phpipam/app/admin/subnets/split.php:42
-msgid "Subnet too small to be splitted"
+msgid "Subnet too small to be split"
 msgstr "サブネットが小さすぎて分割できません"
 
 #: /var/www/phpipam/app/admin/subnets/split.php:66
@@ -8730,7 +8730,7 @@ msgid "Available subnets in section"
 msgstr "セクションの利用できるサブネット"
 
 #: /var/www/phpipam/app/admin/subnets/split-save.php:41
-msgid "Subnet splitted successfully"
+msgid "Subnet split successfully"
 msgstr "サブネットが正常に分割されました"
 
 #: /var/www/phpipam/app/admin/subnets/truncate.php:64
@@ -8748,7 +8748,7 @@ msgid "Failed to truncate subnet"
 msgstr "サブネットを切り捨てることができませんでした"
 
 #: /var/www/phpipam/app/admin/subnets/truncate-save.php:44
-msgid "Subnet truncated succesfully"
+msgid "Subnet truncated successfully"
 msgstr "サブネットが正常に切り捨てられました"
 
 #: /var/www/phpipam/app/admin/subnets/edit-vlan-dropdown.php:45

--- a/functions/locale/nl_NL.UTF-8/LC_MESSAGES/phpipam.po
+++ b/functions/locale/nl_NL.UTF-8/LC_MESSAGES/phpipam.po
@@ -2452,7 +2452,7 @@ msgid "Cannot update request"
 msgstr "Kan aanvraag niet bijwerken"
 
 #: site/admin/manageRequestResult.php:33
-msgid "Request has beed rejected"
+msgid "Request has been rejected"
 msgstr "Aanvraag is afgewezen"
 
 #: site/admin/manageRequestResult.php:54 site/admin/manageRequestResult.php:58
@@ -2500,7 +2500,7 @@ msgid "Errors occured when importing to database!"
 msgstr "Er is een fout opgetreden bij het importeren naar de database"
 
 #: site/admin/CSVimportSubmit.php:95 site/admin/ripeImportResult.php:72
-msgid "Import successfull"
+msgid "Import successful"
 msgstr "Import geslaagd"
 
 #: site/admin/CSVimportVerify.php:25
@@ -2970,7 +2970,7 @@ msgstr ""
 #: site/admin/customIPFieldsOrder.php:15
 #: site/admin/customVLANFieldsOrder.php:15
 #: site/admin/customUserFieldsOrder.php:15
-msgid "Fileds cannot be empty"
+msgid "Fields cannot be empty"
 msgstr "Velden kunnen niet leeg zijn"
 
 #: site/admin/customSubnetFieldsOrder.php:19
@@ -3405,7 +3405,7 @@ msgstr ""
 "subnet zitten!"
 
 #: site/admin/manageSubnetTruncateSave.php:23
-msgid "Subnet truncated succesfully"
+msgid "Subnet truncated successfully"
 msgstr "Subnetverkleining geslaagd"
 
 #: site/admin/usersEditEmailNotif.php:23
@@ -6028,12 +6028,12 @@ msgstr "Fout bij het instellen van de rechten voor subnet"
 msgid "Manage permissions for folder"
 msgstr "Beheer rechten van de map"
 
-msgid "Only subnets that have no nested subnets can be splitted"
+msgid "Only subnets that have no nested subnets can be split"
 msgstr ""
 "Alleen subnetten die geen onderliggende subnetten hebben kunnen worden "
 "gesplitst"
 
-msgid "Subnet too small to be splitted"
+msgid "Subnet too small to be split"
 msgstr "Het subnet is te klein om gesplitst te worden"
 
 msgid "Name prefix"
@@ -6641,7 +6641,7 @@ msgid "Zone generator method"
 msgstr "Methode van zone-generatie"
 
 msgid ""
-"Generate zone names automaticaly with the setting &quot;decimal&quot; or "
+"Generate zone names automatically with the setting &quot;decimal&quot; or "
 "&quot;hex&quot;.<br>To use your own unique zone names you can choose the "
 "option &quot;text&quot."
 msgstr ""
@@ -6955,7 +6955,7 @@ msgstr "Geen apparaten voor de SNMP routetabel query beschikbaar"
 msgid "No new subnets found"
 msgstr "Geen nieuwe subnetten gevonden"
 
-msgid "SNMP module disbled"
+msgid "SNMP module disabled"
 msgstr "SNMP-module uitgeschakeld"
 
 msgid "No devices for SNMP ARP query available"

--- a/functions/locale/pt_BR.UTF-8/LC_MESSAGES/phpipam.po
+++ b/functions/locale/pt_BR.UTF-8/LC_MESSAGES/phpipam.po
@@ -2482,7 +2482,7 @@ msgid "Cannot update request"
 msgstr "N&atilde;o foi poss&iacute;vel atualiza&ccedil;&atilde;o solicitada"
 
 #: site/admin/manageRequestResult.php:33
-msgid "Request has beed rejected"
+msgid "Request has been rejected"
 msgstr "Sua solicita&ccedil;&atilde;o foi rejeitada"
 
 #: site/admin/manageRequestResult.php:54 site/admin/manageRequestResult.php:58
@@ -2533,7 +2533,7 @@ msgstr ""
 "Erros ocorreram no momento da importa&ccedil;&atilde;o do banco de dados"
 
 #: site/admin/CSVimportSubmit.php:95 site/admin/RIPE / ARINImportResult.php:72
-msgid "Import successfull"
+msgid "Import successful"
 msgstr "Importa&ccedil;&atilde;o feita com sucesso"
 
 #: site/admin/CSVimportVerify.php:25
@@ -3023,7 +3023,7 @@ msgstr ""
 #: site/admin/customIPFieldsOrder.php:15
 #: site/admin/customVLANFieldsOrder.php:15
 #: site/admin/customUserFieldsOrder.php:15
-msgid "Fileds cannot be empty"
+msgid "Fields cannot be empty"
 msgstr "Os campos n&atilde;o podem ficar vazios"
 
 #: site/admin/customSubnetFieldsOrder.php:19
@@ -3465,7 +3465,7 @@ msgstr ""
 "a sub-rede selecionada"
 
 #: site/admin/manageSubnetTruncateSave.php:23
-msgid "Subnet truncated succesfully"
+msgid "Subnet truncated successfully"
 msgstr "Sub-rede truncada com sucesso"
 
 #: site/admin/usersEditEmailNotif.php:23

--- a/functions/locale/ru_RU.UTF-8/LC_MESSAGES/phpipam.po
+++ b/functions/locale/ru_RU.UTF-8/LC_MESSAGES/phpipam.po
@@ -4511,7 +4511,7 @@ msgid "Cannot update request"
 msgstr "Не могу обновить запрос"
 
 #: app/admin/requests/edit-result.php:53
-msgid "Request has beed rejected"
+msgid "Request has been rejected"
 msgstr "Запрос был отклонен"
 
 msgid "already in use"
@@ -4570,7 +4570,7 @@ msgid "Errors occured when importing to database!"
 msgstr "Произошла ошибка при импортировании в базу!"
 
 #: app/subnets/import-subnet/import-file.php:142
-msgid "Import successfull"
+msgid "Import successful"
 msgstr "Импорт прошёл успешно"
 
 msgid "Cannot upload - Return Code:"
@@ -4992,7 +4992,7 @@ msgid "If group does not have access to section it will not be able to access su
 msgstr "Если группа не имеет доступа в секцию, она не будет иметь доступ к подсети, даже если <br>были установлены права подсети"
 
 #: app/admin/custom-fields/order.php:21
-msgid "Fileds cannot be empty"
+msgid "Fields cannot be empty"
 msgstr "Поля не могут быть пустыми"
 
 #: app/admin/custom-fields/order.php:25
@@ -5440,7 +5440,7 @@ msgid "Truncating network will remove all IP addresses, that belong to selected 
 msgstr "Обрезка сети удалит все IP адреса, которые принадлежат выбранной подсети!"
 
 #: app/admin/subnets/truncate-save.php:44
-msgid "Subnet truncated succesfully"
+msgid "Subnet truncated successfully"
 msgstr "Подсеть обрезана успешно"
 
 #: app/admin/users/edit-notify.php:32
@@ -5720,7 +5720,7 @@ msgid "Make sure user defined in config.php has access to database."
 msgstr "Убедитесь, что указанный в config.php пользователь, имеет доступ к базе."
 
 #: app/install/sql_error.php:31
-msgid "Database connection succesfull"
+msgid "Database connection successful"
 msgstr "Успешное соединение с базой данных"
 
 #: app/install/welcome.php:9
@@ -9144,7 +9144,7 @@ msgstr "Домены не найдены!"
 #: app/subnets/scan/subnet-scan-execute-scan-snmp-arp.php:14
 #: app/subnets/scan/subnet-scan-execute-snmp-mac.php:18
 #: app/subnets/scan/subnet-scan-result-snmp-route-all.php:23
-msgid "SNMP module disbled"
+msgid "SNMP module disabled"
 msgstr "SNMP модуль отключён"
 
 #: app/admin/vlans/move-vlan-result.php:54
@@ -9645,11 +9645,11 @@ msgid "Manage permissions for folder"
 msgstr "Управление настройками для папки"
 
 #: app/admin/subnets/split.php:35
-msgid "Only subnets that have no nested subnets can be splitted"
+msgid "Only subnets that have no nested subnets can be split"
 msgstr "Может быть разбита только подсеть, которая не имеет вложенных подсетей"
 
 #: app/admin/subnets/split.php:42
-msgid "Subnet too small to be splitted"
+msgid "Subnet too small to be split"
 msgstr "Подсеть слишком мала для разбивки"
 
 #: app/admin/subnets/split.php:116
@@ -10294,7 +10294,7 @@ msgid "User self update failed"
 msgstr "Ошибка самообновления пользователя"
 
 #: functions/classes/class.User.php:1336
-msgid "User self update suceeded"
+msgid "User self update succeeded"
 msgstr "Успешное самообновление пользователя"
 
 #: functions/classes/class.User.php:1672
@@ -11066,7 +11066,7 @@ msgid "Zone generator method"
 msgstr "Метод генератора зоны"
 
 #: app/admin/firewall-zones/settings.php:146
-msgid "Generate zone names automaticaly with the setting &quot;decimal&quot; or &quot;hex&quot;.<br>To use your own unique zone names you can choose the option &quot;text&quot."
+msgid "Generate zone names automatically with the setting &quot;decimal&quot; or &quot;hex&quot;.<br>To use your own unique zone names you can choose the option &quot;text&quot."
 msgstr "Генерировать имя зоны автоматически с установкой &quot;decimal&quot; или &quot;hex&quot;.<br>Для использования вашего уникального названия зоны, вы можете выбрать опцию &quot;text&quot."
 
 #: app/admin/firewall-zones/settings.php:151
@@ -12302,7 +12302,7 @@ msgstr "Установки Зоны"
 msgid "Choose a maximum length of the zone name.<br>The default: 3, maximum: 31 characters.<br>(keep in mind that your firewall may have a limit for the length of zone names or address objects )"
 msgstr "Выберите максимальную длину имени зоны.<br>По-умолчанию:3, максимум:31 символ. <br>(учтите, что ваш фаервол может иметь ограничение на длину имени зоны или объектов адреса)"
 
-msgid "Generate zone names automaticaly with the setting &quot;decimal&quot; or &quot;hex&quot;.<br>The maximum value for a zone in hex mode would be ffffffff (4294967295 zones).<br>To use your own unique zone names you can choose the option &quot;text&quot."
+msgid "Generate zone names automatically with the setting &quot;decimal&quot; or &quot;hex&quot;.<br>The maximum value for a zone in hex mode would be ffffffff (4294967295 zones).<br>To use your own unique zone names you can choose the option &quot;text&quot."
 msgstr "Сгенерировать имя зоны автоматически с установками &quot;decimal&quot; или &quot;hex&quot;.<br>Максимальное значение зоны в hex режиме может быть ffffffff (4294967295 зон).<br>Для использования вашего личного уникального имени зоны, вы можете выбрать опцию &quot;text&quot."
 
 #: app/admin/firewall-zones/settings.php:190
@@ -12314,11 +12314,11 @@ msgid "Autogenerate address objects"
 msgstr "Автогенерация объектов адреса"
 
 #: app/admin/firewall-zones/settings.php:201
-msgid "Automaticaly generate firewall address objects as an additional information of an IP address.<br>(Works only for subnets which are bound to a firewall zone.)"
+msgid "Automatically generate firewall address objects as an additional information of an IP address.<br>(Works only for subnets which are bound to a firewall zone.)"
 msgstr "Автоматическая генерация объектов адреса фаервола в качестве дополнительной информации об IP-адресе.<br>(Работает только для подсетей, которые связаны с зоной фаервола.)"
 
 #: app/admin/firewall-zones/settings.php:146
-msgid "Generate zone names automaticaly with the setting &quot;decimal&quot; or &quot;hex&quot;.<br>The maximum value for a zone in hex mode would be ffffffff (4294967295 zones).<br>To use your own unique zone names you can choose the option &quot;text&quot;."
+msgid "Generate zone names automatically with the setting &quot;decimal&quot; or &quot;hex&quot;.<br>The maximum value for a zone in hex mode would be ffffffff (4294967295 zones).<br>To use your own unique zone names you can choose the option &quot;text&quot;."
 msgstr "Автоматическая генерация названия зоны с установками &quot;decimal&quot; или &quot;hex&quot;.<br>Максимальное значение для зоны в режиме hex может быть ffffffff (4294967295 зон).<br>Для использования собственных уникальных названий, можете выбрать &quot;text&quot;."
 
 #: app/admin/firewall-zones/settings.php:222
@@ -12338,7 +12338,7 @@ msgid "Subnet name"
 msgstr "Имя подсети"
 
 #: app/admin/firewall-zones/settings.php:316
-msgid "Firewall address objects for subnets will contain this information instead of FQDN or hostname.<br>By choosing \"description\" spaces and other characters but hiven or underline will be replaced by the separator value."
+msgid "Firewall address objects for subnets will contain this information instead of FQDN or hostname.<br>By choosing \"description\" spaces and other characters but hyphen or underline will be replaced by the separator value."
 msgstr "Объекты адреса фаервола для подсетей будут содержать эту информацию вместо FQDN или имени хоста. <br>При выборе \"описание\" пробелы и другие символы, кроме hiven и подчеркивания, будет заменено на значение разделителя."
 
 #: app/admin/firewall-zones/subnet-to-zone-save.php:21
@@ -13397,7 +13397,7 @@ msgid "Require unique subnets"
 msgstr "Требуются уникальные подсети"
 
 #: app/admin/settings/index.php:518
-msgid "Require unique subnets accross all sections"
+msgid "Require unique subnets across all sections"
 msgstr "Требуются уникальные подсети во всех секциях"
 
 #: app/admin/users/print-all.php:181
@@ -13526,7 +13526,7 @@ msgid "Set subnet alert threshold"
 msgstr "Установить порог предупреждения подсети"
 
 #: functions/classes/class.Subnets.php:3104
-msgid "Failed to set subnet permissons for subnet"
+msgid "Failed to set subnet permissions for subnet"
 msgstr "Ошибка установки разрешений для подсети"
 
 #: app/admin/subnets/ripe-query.php:82
@@ -13534,7 +13534,7 @@ msgid "No result"
 msgstr "Результата нет"
 
 #: app/admin/subnets/split-save.php:41
-msgid "Subnet splitted successfully"
+msgid "Subnet split successfully"
 msgstr "Подсеть разбита успешно"
 
 #: app/admin/subnets/split.php:108
@@ -13926,7 +13926,7 @@ msgid "Vault secret"
 msgstr "Секрет хранилища"
 
 #: app/admin/vaults/edit.php:95
-msgid "Vault secret. Please store secret as it cannot be retreived if lost!"
+msgid "Vault secret. Please store secret as it cannot be retrieved if lost!"
 msgstr "Секрет хранилища. Пожалуйста запомните секрет, так как его не восстановить при потере!"
 
 #: app/admin/vaults/fetch_website_certificate.php:38
@@ -15769,7 +15769,7 @@ msgstr "База данных успешно обновлена!"
 
 #: functions/classes/class.Addresses.php:1854
 #: functions/classes/class.Addresses.php:1857
-msgid "Object is Natted"
+msgid "Object is NATted"
 msgstr "Объект включён в NAT"
 
 #: functions/classes/class.Admin.php:187
@@ -16026,7 +16026,7 @@ msgid "Go to administration and fix"
 msgstr "Перейдите в раздел администрирования и исправьте"
 
 #: functions/classes/class.Install.php:549
-msgid "Succesfull queries"
+msgid "Succesful queries"
 msgstr "Успешные запросы"
 
 #: functions/classes/class.Install.php:551
@@ -16552,7 +16552,7 @@ msgid "Minimum numbers"
 msgstr "Минимум цифр"
 
 #: app/admin/password-policy/index.php:50
-msgid "Minumum number of numbers"
+msgid "Minimum number of numbers"
 msgstr "Минимальное количество цифр"
 
 #: app/admin/password-policy/index.php:54
@@ -16560,7 +16560,7 @@ msgid "Minimum letters"
 msgstr "Минимум букв"
 
 #: app/admin/password-policy/index.php:58
-msgid "Minumum number of letters"
+msgid "Minimum number of letters"
 msgstr "Минимальное количество букв"
 
 #: app/admin/password-policy/index.php:58
@@ -16568,7 +16568,7 @@ msgid "Minimum lowercase letter"
 msgstr "Минимум строчных букв"
 
 #: app/admin/password-policy/index.php:66
-msgid "Minumum number of lowercase letters"
+msgid "Minimum number of lowercase letters"
 msgstr "Минимальное количество строчных букв"
 
 #: app/admin/password-policy/index.php:70
@@ -16576,7 +16576,7 @@ msgid "Minimum uppercase letter"
 msgstr "Минимум заглавных букв"
 
 #: app/admin/password-policy/index.php:74
-msgid "Minumum number of uppercase letters"
+msgid "Minimum number of uppercase letters"
 msgstr "Минимальное количество заглавных букв"
 
 #: app/admin/password-policy/index.php:74
@@ -16584,7 +16584,7 @@ msgid "Minimum symbols"
 msgstr "Минимум символов"
 
 #: app/admin/password-policy/index.php:82
-msgid "Minumum number of symbols"
+msgid "Minimum number of symbols"
 msgstr "Минимальное количество символов"
 
 #: app/admin/password-policy/index.php:86

--- a/functions/locale/sl_SI.UTF-8/LC_MESSAGES/phpipam.po
+++ b/functions/locale/sl_SI.UTF-8/LC_MESSAGES/phpipam.po
@@ -2335,7 +2335,7 @@ msgid "Cannot update request"
 msgstr "Ne morem posodobiti zahteve"
 
 #: site/admin/manageRequestResult.php:33
-msgid "Request has beed rejected"
+msgid "Request has been rejected"
 msgstr "Zahteva je bila zavrnjena"
 
 #: site/admin/manageRequestResult.php:54 site/admin/manageRequestResult.php:58
@@ -2383,7 +2383,7 @@ msgid "Errors occured when importing to database!"
 msgstr "Pri uvozu v podatkovno bazo je prišlo do napak"
 
 #: site/admin/CSVimportSubmit.php:95 site/admin/RIPE / ARINImportResult.php:72
-msgid "Import successfull"
+msgid "Import successful"
 msgstr "Uvoz uspešen"
 
 #: site/admin/CSVimportVerify.php:25
@@ -2825,7 +2825,7 @@ msgstr "Če skupina nima dostopa do razdelka, potem ne bo mogla dostopati do omr
 #: site/admin/customIPFieldsOrder.php:15
 #: site/admin/customVLANFieldsOrder.php:15
 #: site/admin/customUserFieldsOrder.php:15
-msgid "Fileds cannot be empty"
+msgid "Fields cannot be empty"
 msgstr "Polja ne morejo biti prazna"
 
 #: site/admin/customSubnetFieldsOrder.php:19
@@ -3226,7 +3226,7 @@ msgid "Truncating network will remove all IP addresses, that belong to selected 
 msgstr "Izpraznitev omrežja bo pobrisalo vse IP naslove, ki temu omrežju pripadajo!"
 
 #: site/admin/manageSubnetTruncateSave.php:23
-msgid "Subnet truncated succesfully"
+msgid "Subnet truncated successfully"
 msgstr "Omrežje izpraznjeno"
 
 #: site/admin/usersEditEmailNotif.php:23
@@ -5679,10 +5679,10 @@ msgstr "Napaka pri nastavitvi pravic za omrežje"
 msgid "Manage permissions for folder"
 msgstr "Upravljaj pravice za mapo"
 
-msgid "Only subnets that have no nested subnets can be splitted"
+msgid "Only subnets that have no nested subnets can be split"
 msgstr "Samo omrežja, ki nimajo nestenih omrežij se lahko razdelijo"
 
-msgid "Subnet too small to be splitted"
+msgid "Subnet too small to be split"
 msgstr "Omrežje je premajno za delitev"
 
 msgid "Name prefix"
@@ -6314,7 +6314,7 @@ msgstr "Ni naprav za snmp poizvedbe"
 msgid "No new subnets found"
 msgstr "Ni novih omrežij"
 
-msgid "SNMP module disbled"
+msgid "SNMP module disabled"
 msgstr "SNMP modul onemogočen"
 
 msgid "No devices for SNMP ARP query available"
@@ -7106,7 +7106,7 @@ msgstr "Posodobitev oznak IP naslovov ko se spremeni sprememba stanja"
 msgid "Require unique subnets"
 msgstr "Zahtevaj unikatna omrežja"
 
-msgid "Require unique subnets accross all sections"
+msgid "Require unique subnets across all sections"
 msgstr "Zahtevaj unikatna omrežja tudi med razdelki"
 
 msgid "Set maximum number of concurrent ICMP checks (default 128)"
@@ -7172,13 +7172,13 @@ msgstr "Označi omrežje kot zasedeno"
 msgid "Set subnet alert threshold"
 msgstr "Nastavi prag za obvestila o zasedenosti"
 
-msgid "Failed to set subnet permissons for subnet"
+msgid "Failed to set subnet permissions for subnet"
 msgstr "Napaka pri nastavitvi pravic za omrežje"
 
 msgid "No result"
 msgstr "Ni rezultatov"
 
-msgid "Subnet splitted successfully"
+msgid "Subnet split successfully"
 msgstr "Omrežje razdeljeno"
 
 msgid "Copy custom field values"
@@ -8000,7 +8000,7 @@ msgstr "Možnosti posodobljene"
 msgid "Upgrade"
 msgstr "Nadgradnja"
 
-msgid "Object is Natted"
+msgid "Object is NATted"
 msgstr "Objekt je natiran"
 
 msgid "Invalid generator ID"
@@ -8198,31 +8198,31 @@ msgstr "Maksimalna dolžina znakov v geslu"
 msgid "Minimum numbers"
 msgstr "Min število števil"
 
-msgid "Minumum number of numbers"
+msgid "Minimum number of numbers"
 msgstr "Minimalno število števil"
 
 msgid "Minimum letters"
 msgstr "Min število črk"
 
-msgid "Minumum number of letters"
+msgid "Minimum number of letters"
 msgstr "Minimalno število črk v geslu"
 
 msgid "Minimum lowercase letter"
 msgstr "Min malih črk"
 
-msgid "Minumum number of lowercase letters"
+msgid "Minimum number of lowercase letters"
 msgstr "Minimalno število malih črk v geslu"
 
 msgid "Minimum uppercase letter"
 msgstr "Min velikih črk"
 
-msgid "Minumum number of uppercase letters"
+msgid "Minimum number of uppercase letters"
 msgstr "Minimalno število velikih črk v geslu"
 
 msgid "Minimum symbols"
 msgstr "Min simbolov"
 
-msgid "Minumum number of symbols"
+msgid "Minimum number of symbols"
 msgstr "Minimalno število simbolov v geslu"
 
 msgid "Maximum symbols"

--- a/functions/locale/zh_CN.UTF-8/LC_MESSAGES/phpipam.po
+++ b/functions/locale/zh_CN.UTF-8/LC_MESSAGES/phpipam.po
@@ -4520,7 +4520,7 @@ msgid "Cannot update request"
 msgstr "无法更新申请"
 
 #: app/admin/requests/edit-result.php:53
-msgid "Request has beed rejected"
+msgid "Request has been rejected"
 msgstr "申请已被拒绝"
 
 msgid "already in use"
@@ -4579,7 +4579,7 @@ msgid "Errors occured when importing to database!"
 msgstr "导入数据库时出现错误！!"
 
 #: app/subnets/import-subnet/import-file.php:142
-msgid "Import successfull"
+msgid "Import successful"
 msgstr "导入成功"
 
 msgid "Cannot upload - Return Code:"
@@ -5001,7 +5001,7 @@ msgid "If group does not have access to section it will not be able to access su
 msgstr "如果组无权访问该部分，则即使设置了<br>子网权限，也将无法访问子网"
 
 #: app/admin/custom-fields/order.php:21
-msgid "Fileds cannot be empty"
+msgid "Fields cannot be empty"
 msgstr "字段不能为空"
 
 #: app/admin/custom-fields/order.php:25
@@ -5502,7 +5502,7 @@ msgid "Truncating network will remove all IP addresses, that belong to selected 
 msgstr "截断网络将删除属于所选子网的所有 IP 地址！!"
 
 #: app/admin/subnets/truncate-save.php:44
-msgid "Subnet truncated succesfully"
+msgid "Subnet truncated successfully"
 msgstr "子网截断成功"
 
 #: app/admin/users/edit-notify.php:32
@@ -5782,7 +5782,7 @@ msgid "Make sure user defined in config.php has access to database."
 msgstr "确保 config.php 中定义的用户有权访问数据库."
 
 #: app/install/sql_error.php:31
-msgid "Database connection succesfull"
+msgid "Database connection successful"
 msgstr "数据库连接成功"
 
 #: app/install/welcome.php:9
@@ -9206,7 +9206,7 @@ msgstr "无可用域名！!"
 #: app/subnets/scan/subnet-scan-execute-scan-snmp-arp.php:14
 #: app/subnets/scan/subnet-scan-execute-snmp-mac.php:18
 #: app/subnets/scan/subnet-scan-result-snmp-route-all.php:23
-msgid "SNMP module disbled"
+msgid "SNMP module disabled"
 msgstr "SNMP 模块已禁用"
 
 #: app/admin/vlans/move-vlan-result.php:54
@@ -9707,11 +9707,11 @@ msgid "Manage permissions for folder"
 msgstr "管理文件夹的权限"
 
 #: app/admin/subnets/split.php:35
-msgid "Only subnets that have no nested subnets can be splitted"
+msgid "Only subnets that have no nested subnets can be split"
 msgstr "仅可以分割没有嵌套子网的子网"
 
 #: app/admin/subnets/split.php:42
-msgid "Subnet too small to be splitted"
+msgid "Subnet too small to be split"
 msgstr "子网太小，无法分割"
 
 #: app/admin/subnets/split.php:116
@@ -10356,7 +10356,7 @@ msgid "User self update failed"
 msgstr "用户自行更新失败"
 
 #: functions/classes/class.User.php:1336
-msgid "User self update suceeded"
+msgid "User self update succeeded"
 msgstr "用户自行更新成功"
 
 #: functions/classes/class.User.php:1672
@@ -11128,7 +11128,7 @@ msgid "Zone generator method"
 msgstr "区域生成器方法"
 
 #: app/admin/firewall-zones/settings.php:146
-msgid "Generate zone names automaticaly with the setting &quot;decimal&quot; or &quot;hex&quot;.<br>To use your own unique zone names you can choose the option &quot;text&quot."
+msgid "Generate zone names automatically with the setting &quot;decimal&quot; or &quot;hex&quot;.<br>To use your own unique zone names you can choose the option &quot;text&quot."
 msgstr "使用设置 &quot;十进制&quot;自动生成区域名称 或 &quot;十六进制&quot;。<br>要使用您自己的唯一区域名称，您可以选择 &quot;文本&quot选项."
 
 #: app/admin/firewall-zones/settings.php:151
@@ -12364,7 +12364,7 @@ msgstr "区域设置"
 msgid "Choose a maximum lenght of the zone name.<br>The default: 3, maximum: 31 characters.<br>(keep in mind that your firewall may have a limit for the length of zone names or address objects )"
 msgstr "选择区域名称的最大长度。<br>默认值：3，最大：31 个字符。<br>（请记住，您的防火墙可能对区域名称或地址对象的长度有限制）"
 
-msgid "Generate zone names automaticaly with the setting &quot;decimal&quot; or &quot;hex&quot;.<br>The maximum value for a zone in hex mode would be ffffffff (4294967295 zones).<br>To use your own unique zone names you can choose the option &quot;text&quot."
+msgid "Generate zone names automatically with the setting &quot;decimal&quot; or &quot;hex&quot;.<br>The maximum value for a zone in hex mode would be ffffffff (4294967295 zones).<br>To use your own unique zone names you can choose the option &quot;text&quot."
 msgstr "使用设置 &quot;十进制&quot; 自动生成区域名称或&quot;十六进制&quot;。<br>十六进制模式下区域的最大值为 ffffffff（4294967295 个区域）。<br>要使用您自己的唯一区域名称，您可以选择 &quot;文本&quot.选项."
 
 #: app/admin/firewall-zones/settings.php:190
@@ -12376,11 +12376,11 @@ msgid "Autogenerate address objects"
 msgstr "自动生成地址对象"
 
 #: app/admin/firewall-zones/settings.php:201
-msgid "Automaticaly generate firewall address objects as an additional information of an IP address.<br>(Works only for subnets which are bound to a firewall zone.)"
+msgid "Automatically generate firewall address objects as an additional information of an IP address.<br>(Works only for subnets which are bound to a firewall zone.)"
 msgstr "自动生成防火墙地址对象作为 IP 地址的附加信息。<br>（仅适用于绑定到防火墙区域的子网。）"
 
 #: app/admin/firewall-zones/settings.php:146
-msgid "Generate zone names automaticaly with the setting &quot;decimal&quot; or &quot;hex&quot;.<br>The maximum value for a zone in hex mode would be ffffffff (4294967295 zones).<br>To use your own unique zone names you can choose the option &quot;text&quot;."
+msgid "Generate zone names automatically with the setting &quot;decimal&quot; or &quot;hex&quot;.<br>The maximum value for a zone in hex mode would be ffffffff (4294967295 zones).<br>To use your own unique zone names you can choose the option &quot;text&quot;."
 msgstr "使用设置 &quot;十进制&quot; 自动生成区域名称 或&quot;十六进制&quot;。<br>十六进制模式下区域的最大值为 ffffffff（4294967295 个区域）。<br>要使用您自己的唯一区域名称，您可以选择 &quot;文本&quot.选项."
 
 #: app/admin/firewall-zones/settings.php:222
@@ -12400,7 +12400,7 @@ msgid "Subnet name"
 msgstr "子网名称"
 
 #: app/admin/firewall-zones/settings.php:316
-msgid "Firewall address objects for subnets will contain this information instead of FQDN or hostname.<br>By choosing \"description\" spaces and other characters but hiven or underline will be replaced by the separator value."
+msgid "Firewall address objects for subnets will contain this information instead of FQDN or hostname.<br>By choosing \"description\" spaces and other characters but hyphen or underline will be replaced by the separator value."
 msgstr "子网的防火墙地址对象将包含此信息，而不是 FQDN 或主机名。<br>通过选择“描述”空格和其他字符（但配置单元或下划线）将被分隔符值替换."
 
 #: app/admin/firewall-zones/subnet-to-zone-save.php:21
@@ -13445,7 +13445,7 @@ msgid "Require unique subnets"
 msgstr "需要唯一的子网"
 
 #: app/admin/settings/index.php:518
-msgid "Require unique subnets accross all sections"
+msgid "Require unique subnets across all sections"
 msgstr "所有部门都需要唯一的子网"
 
 #: app/admin/users/print-all.php:181
@@ -13574,7 +13574,7 @@ msgid "Set subnet alert threshold"
 msgstr "设置子网警报阈值"
 
 #: functions/classes/class.Subnets.php:3104
-msgid "Failed to set subnet permissons for subnet"
+msgid "Failed to set subnet permissions for subnet"
 msgstr "无法设置子网的子网权限"
 
 #: app/admin/subnets/ripe-query.php:82
@@ -13582,7 +13582,7 @@ msgid "No result"
 msgstr "无结果"
 
 #: app/admin/subnets/split-save.php:41
-msgid "Subnet splitted successfully"
+msgid "Subnet split successfully"
 msgstr "子网分割成功"
 
 #: app/admin/subnets/split.php:108
@@ -13974,7 +13974,7 @@ msgid "Vault secret"
 msgstr "保管库密码"
 
 #: app/admin/vaults/edit.php:95
-msgid "Vault secret. Please store secret as it cannot be retreived if lost!"
+msgid "Vault secret. Please store secret as it cannot be retrieved if lost!"
 msgstr "保管库密码。 请妥善保管，一旦丢失将无法找回！!"
 
 #: app/admin/vaults/fetch_website_certificate.php:38
@@ -15821,7 +15821,7 @@ msgstr "数据库升级成功！!"
 
 #: functions/classes/class.Addresses.php:1854
 #: functions/classes/class.Addresses.php:1857
-msgid "Object is Natted"
+msgid "Object is NATted"
 msgstr "对象已被解析"
 
 #: functions/classes/class.Admin.php:187
@@ -16078,7 +16078,7 @@ msgid "Go to administration and fix"
 msgstr "转到管理并修复"
 
 #: functions/classes/class.Install.php:549
-msgid "Succesfull queries"
+msgid "Succesful queries"
 msgstr "查询成功"
 
 #: functions/classes/class.Install.php:551
@@ -16620,7 +16620,7 @@ msgid "Minimum numbers"
 msgstr "最少数字"
 
 #: app/admin/password-policy/index.php:50
-msgid "Minumum number of numbers"
+msgid "Minimum number of numbers"
 msgstr "数字最少数量"
 
 #: app/admin/password-policy/index.php:54
@@ -16628,7 +16628,7 @@ msgid "Minimum letters"
 msgstr "最少字母"
 
 #: app/admin/password-policy/index.php:58
-msgid "Minumum number of letters"
+msgid "Minimum number of letters"
 msgstr "字母最少数量"
 
 #: app/admin/password-policy/index.php:58
@@ -16636,7 +16636,7 @@ msgid "Minimum lowercase letter"
 msgstr "最少小写字母"
 
 #: app/admin/password-policy/index.php:66
-msgid "Minumum number of lowercase letters"
+msgid "Minimum number of lowercase letters"
 msgstr "小写字母最少数量"
 
 #: app/admin/password-policy/index.php:70
@@ -16644,7 +16644,7 @@ msgid "Minimum uppercase letter"
 msgstr "最少大写字母"
 
 #: app/admin/password-policy/index.php:74
-msgid "Minumum number of uppercase letters"
+msgid "Minimum number of uppercase letters"
 msgstr "大写字母的最少数量"
 
 #: app/admin/password-policy/index.php:74
@@ -16652,7 +16652,7 @@ msgid "Minimum symbols"
 msgstr "最少符号"
 
 #: app/admin/password-policy/index.php:82
-msgid "Minumum number of symbols"
+msgid "Minimum number of symbols"
 msgstr "符号最少数量"
 
 #: app/admin/password-policy/index.php:86

--- a/functions/locale/zh_TW.UTF-8/LC_MESSAGES/phpipam.po
+++ b/functions/locale/zh_TW.UTF-8/LC_MESSAGES/phpipam.po
@@ -2404,7 +2404,7 @@ msgid "Cannot update request"
 msgstr "無法更新申請"
 
 #: site/admin/manageRequestResult.php:33
-msgid "Request has beed rejected"
+msgid "Request has been rejected"
 msgstr "申請被拒絕"
 
 #: site/admin/manageRequestResult.php:54 site/admin/manageRequestResult.php:58
@@ -2452,7 +2452,7 @@ msgid "Errors occured when importing to database!"
 msgstr "匯入資料庫時出錯。"
 
 #: site/admin/CSVimportSubmit.php:95 site/admin/ripeImportResult.php:72
-msgid "Import successfull"
+msgid "Import successful"
 msgstr "匯入成功"
 
 #: site/admin/CSVimportVerify.php:25
@@ -2906,7 +2906,7 @@ msgstr "如果群組沒有區段權限，即使設定為子網路設定了權限
 #: site/admin/customIPFieldsOrder.php:15
 #: site/admin/customVLANFieldsOrder.php:15
 #: site/admin/customUserFieldsOrder.php:15
-msgid "Fileds cannot be empty"
+msgid "Fields cannot be empty"
 msgstr "欄位不能是空值"
 
 #: site/admin/customSubnetFieldsOrder.php:19
@@ -3319,7 +3319,7 @@ msgid ""
 msgstr "分割子網路將會移除所選擇子網路的所有IP位址"
 
 #: site/admin/manageSubnetTruncateSave.php:23
-msgid "Subnet truncated succesfully"
+msgid "Subnet truncated successfully"
 msgstr "子網路分割成功"
 
 #: site/admin/usersEditEmailNotif.php:23
@@ -5802,10 +5802,10 @@ msgstr "未能設定子網路的存取權限"
 msgid "Manage permissions for folder"
 msgstr "管理資料夾權限"
 
-msgid "Only subnets that have no nested subnets can be splitted"
+msgid "Only subnets that have no nested subnets can be split"
 msgstr "只有沒有所屬的子網路的子網路可以分割"
 
-msgid "Subnet too small to be splitted"
+msgid "Subnet too small to be split"
 msgstr "子網路太小不能分割"
 
 msgid "Name prefix"
@@ -6414,7 +6414,7 @@ msgid "Zone generator method"
 msgstr "區域產生方法"
 
 msgid ""
-"Generate zone names automaticaly with the setting &quot;decimal&quot; or "
+"Generate zone names automatically with the setting &quot;decimal&quot; or "
 "&quot;hex&quot;.<br>To use your own unique zone names you can choose the "
 "option &quot;text&quot."
 msgstr ""
@@ -6716,7 +6716,7 @@ msgstr "沒有可用於 SNMP 路由表查詢的裝置"
 msgid "No new subnets found"
 msgstr "沒有找到新的子網路"
 
-msgid "SNMP module disbled"
+msgid "SNMP module disabled"
 msgstr "SNMP 模組已停用"
 
 msgid "No devices for SNMP ARP query available"
@@ -7066,7 +7066,7 @@ msgstr ""
 "可能對區域名稱或位址物件的長度有限制) "
 
 msgid ""
-"Generate zone names automaticaly with the setting &quot;decimal&quot; or "
+"Generate zone names automatically with the setting &quot;decimal&quot; or "
 "&quot;hex&quot;.<br>The maximum value for a zone in hex mode would be "
 "ffffffff (4294967295 zones).<br>To use your own unique zone names you can "
 "choose the option &quot;text&quot."
@@ -7082,7 +7082,7 @@ msgid "Autogenerate address objects"
 msgstr "自動產生位址物件"
 
 msgid ""
-"Automaticaly generate firewall address objects as an additional information "
+"Automatically generate firewall address objects as an additional information "
 "of an IP address.<br>(Works only for subnets which are bound to a firewall "
 "zone.)"
 msgstr ""
@@ -7690,7 +7690,7 @@ msgstr "發生位址狀態變更時更新位址標籤"
 msgid "Require uniques subnets"
 msgstr "需要唯一子網路"
 
-msgid "Require unique subnets accross all sections"
+msgid "Require unique subnets across all sections"
 msgstr "要求所有區段只能有唯一的子網路"
 
 msgid "Set maximum number of concurrent ICMP checks (default 128)"
@@ -7759,13 +7759,13 @@ msgstr "標記子網路已被使用完畢"
 msgid "Set subnet alert threshold"
 msgstr "設定子網路警報臨界值"
 
-msgid "Failed to set subnet permissons for subnet"
+msgid "Failed to set subnet permissions for subnet"
 msgstr "無法設定子網路的子網路權限"
 
 msgid "No result"
 msgstr "沒有結果"
 
-msgid "Subnet splitted successfully"
+msgid "Subnet split successfully"
 msgstr "子網路分割成功"
 
 msgid "Copy custom field values"
@@ -8712,7 +8712,7 @@ msgstr "選項已更新"
 msgid "Upgrade"
 msgstr "升級"
 
-msgid "Object is Natted"
+msgid "Object is NATted"
 msgstr "物件已經被NAT"
 
 msgid "Invalid generator ID"
@@ -8970,31 +8970,31 @@ msgstr "最大密碼長度"
 msgid "Minimum numbers"
 msgstr "數字最少"
 
-msgid "Minumum number of numbers"
+msgid "Minimum number of numbers"
 msgstr "最少的數字數目"
 
 msgid "Minimum letters"
 msgstr "字元最少"
 
-msgid "Minumum number of letters"
+msgid "Minimum number of letters"
 msgstr "最少的字元數目"
 
 msgid "Minimum lowercase letter"
 msgstr "小寫字母最少"
 
-msgid "Minumum number of lowercase letters"
+msgid "Minimum number of lowercase letters"
 msgstr "最少的小寫字母數目"
 
 msgid "Minimum uppercase letter"
 msgstr "大寫字母最多"
 
-msgid "Minumum number of uppercase letters"
+msgid "Minimum number of uppercase letters"
 msgstr "最少的大寫字母數目"
 
 msgid "Minimum symbols"
 msgstr "符號最少"
 
-msgid "Minumum number of symbols"
+msgid "Minimum number of symbols"
 msgstr "最少的符號字數"
 
 msgid "Maximum symbols"


### PR DESCRIPTION
PR #4187 provided several spelling corrections for messages that were user-facing. I believe this will cause language localization issues. This PR should keep the translations working correctly.