### PR TITLE
Bugfix: Added logic for custom_fields

### DIFF
--- a/app/admin/routing/edit-bgp-submit.php
+++ b/app/admin/routing/edit-bgp-submit.php
@@ -8,15 +8,16 @@ $User 		= new User ($Database);
 $Admin	 	= new Admin ($Database, false);
 $Tools	 	= new Tools ($Database);
 $Result 	= new Result ();
+$Params		= new Params ($User->strip_input_tags ($_POST));
 
 # verify that user is logged in
 $User->check_user_session();
 
 # create csrf token
-$User->Crypto->csrf_cookie ("validate", "routing_bgp", $_POST['csrf_cookie']) === false ? $Result->show("danger", _("Invalid CSRF cookie"), true) : "";
+$User->Crypto->csrf_cookie ("validate", "routing_bgp", $Params->csrf_cookie) === false ? $Result->show("danger", _("Invalid CSRF cookie"), true) : "";
 
 # perm check popup
-if($_POST['action']=="edit") {
+if($Params->action=="edit") {
     $User->check_module_permissions ("routing", User::ACCESS_RW, true, true);
 }
 else {
@@ -24,56 +25,81 @@ else {
 }
 
 # validate
-if ($_POST['action']=="edit" || $_POST['action']=="add") {
-	if(!is_numeric($_POST['local_as']))  				{ $Result->show("danger",  _("Invalid local AS"), true); }
-	if(!is_numeric($_POST['peer_as'])) 					{ $Result->show("danger",  _("Invalid peer AS"), true); }
-	if(!$Tools->validate_ip ($_POST['local_address']))	{ $Result->show("danger",  _("Invalid local address"), true); }
-	if(!$Tools->validate_ip ($_POST['peer_address']))	{ $Result->show("danger",  _("Invalid peer address"), true); }
+if ($Params->action=="edit" || $Params->action=="add") {
+	if(!is_numeric($Params->local_as))  				{ $Result->show("danger",  _("Invalid local AS"), true); }
+	if(!is_numeric($Params->peer_as)) 					{ $Result->show("danger",  _("Invalid peer AS"), true); }
+	if(!$Tools->validate_ip ($Params->local_address))	{ $Result->show("danger",  _("Invalid local address"), true); }
+	if(!$Tools->validate_ip ($Params->peer_address))	{ $Result->show("danger",  _("Invalid peer address"), true); }
 }
-if ($_POST['action']=="edit" || $_POST['action']=="delete") {
-	if(!is_numeric($_POST['id']))  						{ $Result->show("danger",  _("Invalid ID"), true); }
+if ($Params->action=="edit" || $Params->action=="delete") {
+	if(!is_numeric($Params->id))						{ $Result->show("danger",  _("Invalid ID"), true); }
 }
 
 # permission recheck for modules
-if(isset($_POST['vrf_id'])) {
+if(isset($Params->vrf_id)) {
 	if( $User->get_module_permissions ("vrf")==User::ACCESS_NONE)  		{ $Result->show("danger",  _("Insufficient permissions for module VRF"), true); }
-	if(!is_numeric($_POST['vrf_id']))  					{ $Result->show("danger",  _("Invalid VRF ID"), true); }
+	if(!is_numeric($Params->vrf_id))  					{ $Result->show("danger",  _("Invalid VRF ID"), true); }
 }
-if(isset($_POST['circuit_id'])) {
+if(isset($Params->circuit_id)) {
 	if( $User->get_module_permissions ("circuits")==User::ACCESS_NONE)  { $Result->show("danger",  _("Insufficient permissions for module Circuits"), true); }
-	if(!is_numeric($_POST['circuit_id']))  				{ $Result->show("danger",  _("Invalid Circuits ID"), true); }
+	if(!is_numeric($Params->circuit_id))  				{ $Result->show("danger",  _("Invalid Circuits ID"), true); }
 }
-if(isset($_POST['customer_id'])) {
+if(isset($Params->customer_id)) {
 	if( $User->get_module_permissions ("customers")==User::ACCESS_NONE) { $Result->show("danger",  _("Insufficient permissions for module Customers"), true); }
-	if(!is_numeric($_POST['customer_id']))  			{ $Result->show("danger",  _("Invalid Customer ID"), true); }
+	if(!is_numeric($Params->customer_id))  			{ $Result->show("danger",  _("Invalid Customer ID"), true); }
+}
+
+# fetch custom fields
+$custom = $Tools->fetch_custom_fields('routing_bgp');
+if(sizeof($custom) > 0) {
+	foreach($custom as $myField) {
+
+		//replace possible ___ back to spaces
+		$myField['nameTest'] = str_replace(" ", "___", $myField['name']);
+		if(isset($Params->{$myField['nameTest']})) { $Params->{$myField['name']} = $Params->{$myField['nameTest']};}
+
+		//booleans can be only 0 and 1!
+		if($myField['type']=="tinyint(1)") {
+			if($Params->{$myField['name']}>1) {
+				$Params->{$myField['name']} = 0;
+			}
+		}
+		//not null!
+		if($myField['Null']=="NO" && is_blank($Params->{$myField['name']})) { $Result->show("danger", $myField['name']." "._("can not be empty!"), true); }
+
+		# save to update array
+		$update[$myField['name']] = $Params->{$myField['nameTest']};
+	}
 }
 
 # create update array
 $values = [
-			"id"			=> $_POST['id'],
-			"bgp_type"      => $Tools->strip_xss ($_POST['bgp_type']),
-			"local_as"      => $_POST['local_as'],
-			"local_address" => $_POST['local_address'],
-			"peer_name"     => $Tools->strip_xss ($_POST['peer_name']),
-			"peer_as"       => $_POST['peer_as'],
-			"peer_address"  => $_POST['peer_address'],
-			"description"   => $Tools->strip_xss ($_POST['description']),
+			"id"			=> isset($Params->id) ? $Params->id : null,
+			"bgp_type"      => $Tools->strip_xss ($Params->bgp_type),
+			"local_as"      => $Params->local_as,
+			"local_address" => $Params->local_address,
+			"peer_name"     => $Tools->strip_xss ($Params->peer_name),
+			"peer_as"       => $Params->peer_as,
+			"peer_address"  => $Params->peer_address,
+			"description"   => $Tools->strip_xss ($Params->description),
 			];
 # modules
-if(isset($_POST['vrf_id'])) {
-	$values['vrf_id'] = $_POST['vrf_id']!=0 ? $_POST['vrf_id'] : NULL;
+if(isset($Params->vrf_id)) {
+	$values['vrf_id'] = $Params->vrf_id!=0 ? $Params->vrf_id : NULL;
 }
-if(isset($_POST['circuit_id'])) {
-	$values['circuit_id'] = $_POST['circuit_id']!=0 ? $_POST['circuit_id'] : NULL;
+if(isset($Params->circuit_id)) {
+	$values['circuit_id'] = $Params->circuit_id!=0 ? $Params->circuit_id : NULL;
 }
-if(isset($_POST['customer_id'])) {
-	$values['customer_id'] = $_POST['customer_id']!=0 ? $_POST['customer_id'] : NULL;
-
+if(isset($Params->customer_id)) {
+	$values['customer_id'] = $Params->customer_id!=0 ? $Params->customer_id : NULL;
 }
-
+# custom fields
+if(isset($update)) {
+	$values = array_merge($values, $update);
+}
 
 # execute update
-if(!$Admin->object_modify ("routing_bgp", $_POST['action'], "id", $values)) {
+if(!$Admin->object_modify ("routing_bgp", $Params->action, "id", $values)) {
     $Result->show("danger", _("BGP")." ".$User->get_post_action()." "._("failed"), false);
 }
 else {
@@ -81,6 +107,6 @@ else {
 }
 
 # add
-if($_POST['action']=="add") {
+if($Params->action=="add") {
     print "<div class='new_nat_id hidden'>$Admin->lastId</div>";
 }

--- a/misc/CHANGELOG
+++ b/misc/CHANGELOG
@@ -20,6 +20,7 @@
     + Fixed Ripe import results in jQuery error (#4007);
     + Fixed Ripe import crashes if too many subnets are found (#4180);
     + Fixed Devices with height 0 crash Rack image generation (#4193);
+    + Fixed Custom field not working in Routing module (#4174);
 
     Enhancements, changes:
     ----------------------------


### PR DESCRIPTION
When you have Custom BGP Routing fields, they are not validated or included when adding or editing a BGP Peer. This PR copies some example code from `app\admin\devices\edit-results.php` so that `app/admin/routing/edit-bgp-submit.php` gets similar functionality.
+ Fixes #4174