### PR TITLE
Bugfix: Fixed display of circuit type

### DIFF
--- a/app/tools/circuits/index.php
+++ b/app/tools/circuits/index.php
@@ -21,6 +21,9 @@ $User->check_user_session();
 $hidden_circuit_fields = pf_json_decode($User->settings->hiddenCustomFields, true);
 $hidden_circuit_fields = is_array(@$hidden_circuit_fields['circuits']) ? $hidden_circuit_fields['circuits'] : array();
 
+$hidden_logical_fields = pf_json_decode($User->settings->hiddenCustomFields, true);
+$hidden_logical_fields = is_array(@$hidden_logical_fields['circuits']) ? $hidden_logical_fields['circuitsLogical'] : array();
+
 $hidden_provider_fields = pf_json_decode($User->settings->hiddenCustomFields, true);
 $hidden_provider_fields = is_array(@$hidden_provider_fields['circuitProviders']) ? $hidden_provider_fields['circuitProviders'] : array();
 

--- a/app/tools/circuits/logical-circuits/logical-circuits.php
+++ b/app/tools/circuits/logical-circuits/logical-circuits.php
@@ -58,7 +58,7 @@ print "	<th>"._('Comment').'</th>';
 $colspanCustom = 0;
 if(sizeof(@$custom_fields) > 0) {
 	foreach($custom_fields as $field) {
-		if(!in_array($field['name'], $hidden_circuit_fields)) {
+		if(!in_array($field['name'], $hidden_logical_fields)) {
 			print "<th class='hidden-sm hidden-xs hidden-md'>".$Tools->print_custom_field_name ($field['name'])."</th>";
 			$colspanCustom++;
 		}
@@ -99,7 +99,7 @@ else {
 		//custom
 		if(sizeof(@$custom_fields) > 0) {
 			foreach($custom_fields as $field) {
-				if(!in_array($field['name'], $hidden_circuit_fields)) {
+				if(!in_array($field['name'], $hidden_logical_fields)) {
 					// create html links
 					$circuit->{$field['name']} = $User->create_links($circuit->{$field['name']}, $field['type']);
 

--- a/app/tools/circuits/physical-circuits/all-circuits.php
+++ b/app/tools/circuits/physical-circuits/all-circuits.php
@@ -75,7 +75,8 @@ print "</thead>";
 
 // no circuits
 if($circuits===false) {
-	$colspan = 6 + $colspanCustom;
+	$colspan = 9 + $colspanCustom;
+	if($User->settings->enableCustomers=="1") $colspan++;
 	print "<tr>";
 	print "	<td colspan='$colspan'>".$Result->show('info', _('No results')."!", false, false, true)."</td>";
 	print "</tr>";

--- a/app/tools/circuits/providers/all-providers.php
+++ b/app/tools/circuits/providers/all-providers.php
@@ -69,7 +69,7 @@ print "</thead>";
 
 // no circuits
 if($circuit_providers===false) {
-	$colspan = 3 + $colspanCustom;
+	$colspan = 5 + $colspanCustom;
 	print "<tr>";
 	print "	<td colspan='$colspan'>".$Result->show('info', _('No results')."!", false, false, true)."</td>";
 	print "</tr>";

--- a/app/tools/circuits/providers/provider-details.php
+++ b/app/tools/circuits/providers/provider-details.php
@@ -17,6 +17,9 @@ is_numeric($_GET['sPage']) ? : $Result->show("danger", _("Invalid ID"), true);
 
 # fetch provider
 $provider = $Tools->fetch_object ("circuitProviders", "id", $_GET['sPage']);
+$circuit_types = $Tools->fetch_all_objects ("circuitTypes", "ctname");
+$type_hash = [];
+foreach($circuit_types as $t){ $type_hash[$t->id] = $t->ctname; }
 
 // print back link
 print "<div class='btn-group'>";
@@ -163,7 +166,7 @@ if($provider!==false) {
 			print '<tr>'. "\n";
 			print "	<td><a class='btn btn-xs btn-default' href='".create_link($_GET['page'],"circuits",$circuit->id)."'><i class='fa fa-random prefix'></i> $circuit->cid</a></td>";
 			print "	<td>$circuit->name</td>";
-			print "	<td>$circuit->type</td>";
+			print "	<td>{$type_hash[$circuit->type]}</td>";
 			print " <td class='hidden-xs hidden-sm'>$circuit->capacity</td>";
 			print " <td class='hidden-xs hidden-sm'>$circuit->status</td>";
 			print "	<td class='hidden-xs hidden-sm'>$locationA_html</td>";

--- a/app/tools/devices/device-details/device-circuits.php
+++ b/app/tools/devices/device-details/device-circuits.php
@@ -13,6 +13,10 @@ $User->check_module_permissions ("circuits", User::ACCESS_R, true, false);
 
 # fetch custom fields
 $custom = $Tools->fetch_custom_fields('circuits');
+# fetch circuit types
+$circuit_types = $Tools->fetch_all_objects ("circuitTypes", "ctname");
+$type_hash = [];
+foreach($circuit_types as $t){ $type_hash[$t->id] = $t->ctname; }
 # get hidden fields */
 $hidden_fields = pf_json_decode($User->settings->hiddenCustomFields, true);
 $hidden_fields = is_array(@$hidden_fields['circuits']) ? $hidden_fields['circuits'] : array();
@@ -75,7 +79,7 @@ else {
             print '<tr>'. "\n";
             print " <td><a class='btn btn-xs btn-default' href='".create_link("tools","circuits",$circuit->id)."'><i class='fa fa-random prefix'></i> $circuit->cid</a></td>";
             print " <td><a href='".create_link("tools","circuits","providers",$circuit->pid)."'>$circuit->name</a></td>";
-            print " <td>$circuit->type</td>";
+            print " <td>{$type_hash[$circuit->type]}</td>";
             print " <td class='hidden-xs hidden-sm'>$circuit->capacity</td>";
             print " <td class='hidden-xs hidden-sm'>$circuit->status</td>";
             if($User->get_module_permissions ("locations")>=User::ACCESS_R) {

--- a/misc/CHANGELOG
+++ b/misc/CHANGELOG
@@ -20,6 +20,7 @@
     + Fixed Ripe import results in jQuery error (#4007);
     + Fixed Ripe import crashes if too many subnets are found (#4180);
     + Fixed Devices with height 0 crash Rack image generation (#4193);
+    + Fixed Circuit Type showing differently in two windows (#4104);
 
     Enhancements, changes:
     ----------------------------


### PR DESCRIPTION
On the "Circuit Providers" tab of the Circuits module, circuit types show by number (`id` from database).
+ Fixes #4104
+ Fixes #4210
+ Fixes issue where hidden fields don't hide (i didn't bother documenting an issue for this)
+ Fixes #3641