### PR TITLE
Enhancement: added logging to truncate function

### DIFF
--- a/app/tools/changelog/index.php
+++ b/app/tools/changelog/index.php
@@ -63,10 +63,12 @@ if($User->settings->enableChangelog == 1) {
 		<button id="clearChangeLogs" class="btn btn-sm btn-default pull-left"><i class="fa fa-trash-o"></i> <?php print _('Clear logs'); ?></button>
 	</div>
 
+	<div class="normalTable logs" style="clear:both;">
 	<?php
 	# printout
 	include_once('changelog-print.php');
 }
 else {
 	$Result->show("info",_("Change logging is disabled. You can enable it under administration")."!", false);
-}
+} ?>
+	</div>		<!-- end normalTable logs div -->

--- a/functions/classes/class.Admin.php
+++ b/functions/classes/class.Admin.php
@@ -336,6 +336,7 @@ class Admin extends Common_functions {
 				return false;
 			}
 			# result
+			$this->Log->write( _("Database table cleared").": ".$table, NULL, 0);
 			return true;
 		}
 	}


### PR DESCRIPTION
When clearing the log, no message is left behind indicating when or by whom the log was cleared. Also, clearing the changelog doesn't update the screen because there is no `<div>` with the class "logs" for the JS to put the result into.
+ Fixes #4200