### PR TITLE
Bugfix & Enhancement: Repair and expand table sorting

### DIFF
--- a/app/admin/groups/index.php
+++ b/app/admin/groups/index.php
@@ -51,26 +51,26 @@ $colspanCustom = 0;
 </div>
 
 <!-- table -->
-<table id="userPrint" class="table sorted table-striped table-top" data-cookie-id-table="admin_groups">
+<table id="userPrint" class="table sortable sorted table-striped table-top" data-cookie-id-table="admin_groups">
 
 <!-- Headers -->
 <thead>
 <tr>
-    <th><?php print _('Group'); ?></th>
-    <th><?php print _('Belonging users'); ?></th>
+    <th data-sortable='true' data-sorter='alphaSort'><?php print _('Group'); ?></th>
+    <th data-sortable='true' data-sorter='alphaSort'><?php print _('Belonging users'); ?></th>
     <th><?php print _('Section permissions'); ?></th>
 	<?php
 	if(sizeof(@$custom) > 0) {
 		foreach($custom as $field) {
 			if(!in_array($field['name'], $ffields)) {
 				$colspanCustom++;
-				print "<th>".$Tools->print_custom_field_name ($field['name'])."</th>";
+				print "<th data-sortable='true' data-sorter='alphaSort'>".$Tools->print_custom_field_name ($field['name'])."</th>";
 			}
 		}
 	}
 	?>
-    <th></th>
-    <th></th>
+    <th data-switchable='false'></th>
+    <th data-switchable='false'></th>
 </tr>
 </thead>
 

--- a/app/admin/languages/index.php
+++ b/app/admin/languages/index.php
@@ -20,7 +20,7 @@ $languages = $Admin->fetch_all_objects("lang", "l_id");
 <button class='btn btn-sm btn-default open_popup' style="margin-bottom:10px;" data-script='app/admin/languages/edit.php' data-class='700' data-action='add'><i class='fa fa-plus'></i> <?php print _('Create new language'); ?></button>
 
 
-<table class="table sorted nosearch nopagination table-striped table-auto table-top" data-cookie-id-table="admin_lang" style="min-width:400px;">
+<table class="table sortable sorted nosearch nopagination table-striped table-auto table-top" data-cookie-id-table="admin_lang" style="min-width:400px;">
 	<!-- Language list -->
 	<?php
 	/* no results */
@@ -32,9 +32,9 @@ $languages = $Admin->fetch_all_objects("lang", "l_id");
 		# headers
 		print "<thead>";
 		print "<tr>";
-		print "	<th>"._('Language code')."</th>";
-		print "	<th>"._('Language name')."</th>";
-		print "	<th>"._('Validity')."</th>";
+		print "	<th data-sortable='true'>"._('Language code')."</th>";
+		print "	<th data-sortable='true'>"._('Language name')."</th>";
+		print "	<th data-sortable='true'>"._('Validity')."</th>";
 		print "	<th>"._('Version')."</th>";
 		print "	<th></th>";
 		print "</tr>";

--- a/app/admin/sections/index.php
+++ b/app/admin/sections/index.php
@@ -42,20 +42,20 @@ if ($sections !== false) {
 
 <!-- show sections -->
 <?php if($sections!==false) { ?>
-<table class="table sorted table-striped table-condensed table-top" data-cookie-id-table="admin_sections">
+<table class="table sortable sorted table-striped table-condensed table-top" data-cookie-id-table="admin_sections">
 <!-- headers -->
 <thead>
 <tr>
-    <th><?php print _('Name'); ?></th>
-    <th><?php print _('Description'); ?></th>
-    <th><?php print _('Parent'); ?></th>
-    <th><?php print _('Strict mode'); ?></th>
-    <th><?php print _('Show subnet menu'); ?></th>
-    <th><?php print _('Show VLAN menu'); ?></th>
-    <th><?php print _('Show VRF menu'); ?></th>
-    <th><?php print _('Show only supernets'); ?></th>
-    <th><?php print _('Group Permissions'); ?></th>
-    <th></th>
+    <th data-sortable='true' data-sorter='alphaSort'><?php print _('Name'); ?></th>
+    <th data-sortable='true'><?php print _('Description'); ?></th>
+    <th data-sortable='true'><?php print _('Parent'); ?></th>
+    <th data-sortable='true'><?php print _('Strict mode'); ?></th>
+    <th data-sortable='true'><?php print _('Show subnet menu'); ?></th>
+    <th data-sortable='true'><?php print _('Show VLAN menu'); ?></th>
+    <th data-sortable='true'><?php print _('Show VRF menu'); ?></th>
+    <th data-sortable='true'><?php print _('Show only supernets'); ?></th>
+    <th data-sortable='true'><?php print _('Group Permissions'); ?></th>
+    <th data-switchable='false'></th>
 </tr>
 </thead>
 

--- a/app/admin/users/print-all.php
+++ b/app/admin/users/print-all.php
@@ -26,31 +26,31 @@ $ffields = is_array(@$ffields['users']) ? $ffields['users'] : array();
 
 
 <!-- table -->
-<table id="userPrint1" class="table sorted table-striped table-top table-td-top" data-cookie-id-table="admin_users">
+<table id="userPrint1" class="table sortable sorted table-striped table-top table-td-top" data-cookie-id-table="admin_users">
 
 <!-- Headers -->
 <thead>
 <tr>
-	<th></th>
-    <th><?php print _('Real Name'); ?></th>
-    <th><?php print _('Username'); ?></th>
-    <th><?php print _('E-mail'); ?></th>
-    <th><?php print _('Role'); ?></th>
-    <th><?php print _('Language'); ?></th>
-    <th><?php print _('Authentication'); ?></th>
+	<th data-switchable='false'></th>
+    <th data-sortable='true' data-sorter='alphaSort'><?php print _('Real Name'); ?></th>
+    <th data-sortable='true'><?php print _('Username'); ?></th>
+    <th data-sortable='true'><?php print _('E-mail'); ?></th>
+    <th data-sortable='true'><?php print _('Role'); ?></th>
+    <th data-sortable='true'><?php print _('Language'); ?></th>
+    <th data-sortable='true'><?php print _('Authentication'); ?></th>
     <th><?php print _('Module permissions'); ?></th>
-    <th><?php print _('Groups'); ?></th>
-    <th><?php print _('Last login'); ?></th>
+    <th data-sortable='true'><?php print _('Groups'); ?></th>
+    <th data-sortable='true'><?php print _('Last login'); ?></th>
 	<?php
 	if(sizeof(@$custom) > 0) {
 		foreach($custom as $field) {
 			if(!in_array($field['name'], $ffields)) {
-				print "<th>$field[name]</th>";
+				print "<th data-sortable='true'>$field[name]</th>";
 			}
 		}
 	}
 	?>
-    <th class="actions"></th>
+    <th class="actions" data-switchable='false'></th>
 </tr>
 </thead>
 

--- a/app/admin/widgets/index.php
+++ b/app/admin/widgets/index.php
@@ -23,7 +23,7 @@ print "</p>";
 <!-- Add new -->
 <button class='btn btn-sm btn-default open_popup' style="margin-bottom:10px;" data-script='app/admin/widgets/edit.php' data-class='700' data-action='add'><i class='fa fa-plus'></i> <?php print _('Create new widget'); ?></button>
 
-<table class="table sorted table-striped table-top" style="min-width:400px;" data-cookie-id-table="widgets">
+<table class="table sortable sorted table-striped table-top" style="min-width:400px;" data-cookie-id-table="widgets">
 
 	<!-- Language list -->
 	<?php
@@ -36,14 +36,14 @@ print "</p>";
 		# headers
 		print "<thead>";
 		print "<tr>";
-		print "	<th>"._('Title')."</th>";
-		print "	<th>"._('Description')."</th>";
-		print "	<th>"._('File')."</th>";
-		print "	<th>"._('Admin')."</th>";
-		print "	<th>"._('Active')."</th>";
+		print "	<th data-sortable='true'>"._('Title')."</th>";
+		print "	<th data-sortable='true'>"._('Description')."</th>";
+		print "	<th data-sortable='true'>"._('File')."</th>";
+		print "	<th data-sortable='true'>"._('Admin')."</th>";
+		print "	<th data-sortable='true'>"._('Active')."</th>";
 		print "	<th>"._('Parameters')."</th>";
 		print "	<th>"._('Validity')."</th>";
-		print "	<th></th>";
+		print "	<th data-switchable='false'></th>";
 		print "</tr>";
 		print "</thead>";
 

--- a/app/sections/all-sections.php
+++ b/app/sections/all-sections.php
@@ -38,24 +38,24 @@ $colspan = 8;
 
 <!-- show sections -->
 <?php if($sections!==false) { ?>
-<table class="table sorted table-striped table-condensed table-top table-td-top" data-cookie-id-table="all_sections">
+<table class="table sortable sorted table-striped table-condensed table-top table-td-top" data-cookie-id-table="all_sections">
 <!-- headers -->
 <thead>
 <tr>
-    <th><?php print _('Name'); ?></th>
-    <th><?php print _('Description'); ?></th>
-    <th><?php print _('Parent'); ?></th>
-    <th><?php print _('Strict mode'); ?></th>
+    <th data-sortable='true' data-sorter='alphaSort'><?php print _('Name'); ?></th>
+    <th data-sortable='true'><?php print _('Description'); ?></th>
+    <th data-sortable='true'><?php print _('Parent'); ?></th>
+    <th data-sortable='true'><?php print _('Strict mode'); ?></th>
     <?php if($User->get_module_permissions ("vlan")>=User::ACCESS_R) { ?>
-    <th><?php print _('Show VLANs'); ?></th>
+    <th data-sortable='true'><?php print _('Show VLANs'); ?></th>
     <?php $colspan--;} ?>
     <?php if ($User->get_module_permissions ("vrf")>=User::ACCESS_R) { ?>
-    <th><?php print _('Show VRFs'); ?></th>
+    <th data-sortable='true'><?php print _('Show VRFs'); ?></th>
     <?php $colspan--;} ?>
-    <th><?php print _('Subnets'); ?></th>
+    <th data-sortable='true' data-sorter='numberSort'><?php print _('Subnets'); ?></th>
     <?php if($User->is_admin(false)) { ?>
-    <th><?php print _('Group Permissions'); ?></th>
-    <th></th>
+    <th data-sortable='true'><?php print _('Group Permissions'); ?></th>
+    <th data-switchable='false'></th>
     <?php $colspan--;} ?>
 </tr>
 </thead>

--- a/app/subnets/addresses/print-address-table.php
+++ b/app/subnets/addresses/print-address-table.php
@@ -147,34 +147,41 @@ else 				{ print _("IP addresses belonging to ALL nested subnets"); }
 <thead>
 <tr class="th">
 	<?php
-	print "<th class='s_ipaddr'>"._('IP address')."</th>";
-	print "<th>"._('Hostname')."</th>";
+	print "<th class='s_ipaddr' data-sortable='true' data-sorter='ipSort'>"._('IP address')."</th>";
+	print "<th data-sortable='true'>"._('Hostname')."</th>";
 	// firewall address object - mandatory if enabled
 	if($zone) {
-		print "<th>"._('FW object')."</th>";
+		print "<th data-sortable='true'>"._('FW object')."</th>";
 	}
 	// description
-	print "<th>"._('Description')."</th>";
+	print "<th data-sortable='true'>"._('Description')."</th>";
 	// mac
 	if(in_array('mac', $selected_ip_fields)) 	{
-    	                                        { print "<th>"._('MAC')."</th>"; }
+    	                                        { print "<th data-sortable='true'>"._('MAC')."</th>"; }
     }
 	# note, device, port, owner, location
-	if(in_array('note', $selected_ip_fields)) 	{ print "<th></th>"; }
-	if(in_array('switch', $selected_ip_fields) && $User->get_module_permissions ("devices")>=User::ACCESS_R) { print "<th class='hidden-xs hidden-sm hidden-md'>"._('Device')."</th>"; }
-	if(in_array('port', $selected_ip_fields)) 	{ print "<th class='hidden-xs hidden-sm hidden-md'>"._('Port')."</th>"; }
-	if(in_array('location', $selected_ip_fields) && $User->get_module_permissions ("locations")>=User::ACCESS_R) 	{ print "<th class='hidden-xs hidden-sm hidden-md'>"._('Location')."</th>"; }
-	if(in_array('owner', $selected_ip_fields)) 	{ print "<th class='hidden-xs hidden-sm'>"._('Owner')."</th>"; }
-	if($User->settings->enableCustomers=="1" && @$cnt_obj["customer_id"]>0 && $User->get_module_permissions ("customers")>=User::ACCESS_R)	{ print "<th class='hidden-xs hidden-sm'>"._('Customer')."</th>"; }
+	if(in_array('note', $selected_ip_fields)) 	{ print "<th data-switchable='false'></th>"; }
+	if(in_array('switch', $selected_ip_fields) && $User->get_module_permissions ("devices")>=User::ACCESS_R) { print "<th class='hidden-xs hidden-sm hidden-md' data-sortable='true' data-sorter='alphaSort'>"._('Device')."</th>"; }
+	if(in_array('port', $selected_ip_fields)) 	{ print "<th class='hidden-xs hidden-sm hidden-md' data-sortable='true'>"._('Port')."</th>"; }
+	if(in_array('location', $selected_ip_fields) && $User->get_module_permissions ("locations")>=User::ACCESS_R) 	{ print "<th class='hidden-xs hidden-sm hidden-md' data-sortable='true' data-sorter='alphaSort'>"._('Location')."</th>"; }
+	if(in_array('owner', $selected_ip_fields)) 	{ print "<th class='hidden-xs hidden-sm' data-sortable='true'>"._('Owner')."</th>"; }
+	if($User->settings->enableCustomers=="1" && @$cnt_obj["customer_id"]>0 && $User->get_module_permissions ("customers")>=User::ACCESS_R)	{ print "<th class='hidden-xs hidden-sm' data-sortable='true' data-sorter='alphaSort'>"._('Customer')."</th>"; }
 	// custom fields
 	if(sizeof($custom_fields) > 0) {
 		foreach($custom_fields as $myField) 	{
-			print "<th class='hidden-xs hidden-sm hidden-md'>".$Tools->print_custom_field_name ($myField['name'])."</th>";
+			if (substr($myField['type'],0,3)=="int") {
+				$sort_function=" data-sorter='numberSort'";
+			} elseif (substr($myField['type'],0,3)=="dat") {
+				$sort_function=" data-sorter='dateSort'";
+			} else {
+				$sort_function="";
+			}
+			print "<th class='hidden-xs hidden-sm hidden-md' data-sortable='true'{$sort_function}>".$Tools->print_custom_field_name ($myField['name'])."</th>";
 		}
 	}
 	?>
 	<!-- actions -->
-	<th class="actions"></th>
+	<th class="actions" data-switchable="false"></th>
 </tr>
 </thead>
 

--- a/app/tools/circuits/logical-circuits/logical-circuits.php
+++ b/app/tools/circuits/logical-circuits/logical-circuits.php
@@ -45,26 +45,33 @@ print "<div class='btn-group'>";
 print "</div>";
 
 # table
-print '<table id="userPrint" class="table sorted table-striped table-top" data-cookie-id-table="all_logical_circuits">';
+print '<table id="userPrint" class="table sortable sorted table-striped table-top" data-cookie-id-table="all_logical_circuits">';
 
 # headers
 print "<thead>";
 print '<tr>';
-print "	<th>"._('Circuit ID')."</th>";
-print "	<th>"._('Purpose').'</th>';
-print "	<th>"._('Circuit Count').'</th>';
-print "	<th>"._('Members').'</th>';
-print "	<th>"._('Comment').'</th>';
+print "	<th data-sortable='true' data-sorter='alphaSort'>"._('Circuit ID')."</th>";
+print "	<th data-sortable='true'>"._('Purpose').'</th>';
+print "	<th data-sortable='true' data-sorter='numberSort'>"._('Circuit Count').'</th>';
+print "	<th data-sortable='true' data-sorter='alphaSort'>"._('Members').'</th>';
+print "	<th data-sortable='true'>"._('Comment').'</th>';
 $colspanCustom = 0;
 if(sizeof(@$custom_fields) > 0) {
 	foreach($custom_fields as $field) {
 		if(!in_array($field['name'], $hidden_logical_fields)) {
-			print "<th class='hidden-sm hidden-xs hidden-md'>".$Tools->print_custom_field_name ($field['name'])."</th>";
+			if (substr($field['type'],0,3)=="int") {
+				$sort_function=" data-sorter='numberSort'";
+			} elseif (substr($field['type'],0,3)=="dat") {
+				$sort_function=" data-sorter='dateSort'";
+			} else {
+				$sort_function="";
+			}
+			print "<th class='hidden-sm hidden-xs hidden-md' data-sortable='true'{$sort_function}>".$Tools->print_custom_field_name ($field['name'])."</th>";
 			$colspanCustom++;
 		}
 	}
 }
-print '	<th class="actions"></th>';
+print '	<th class="actions" data-switchable="false"></th>';
 print '</tr>';
 print "</thead>";
 

--- a/app/tools/circuits/physical-circuits/all-circuits.php
+++ b/app/tools/circuits/physical-circuits/all-circuits.php
@@ -45,31 +45,38 @@ print "<div class='btn-group'>";
 print "</div>";
 
 # table
-print '<table id="circuitManagement" class="table sorted table-striped table-top" data-cookie-id-table="all_circuits">';
+print '<table id="circuitManagement" class="table sortable sorted table-striped table-top" data-cookie-id-table="all_circuits">';
 
 # headers
 print "<thead>";
 print '<tr>';
-print "	<th>"._('Circuit ID')."</th>";
-print "	<th>"._('Provider')."</th>";
+print "	<th data-sortable='true' data-sorter='alphaSort'>"._('Circuit ID')."</th>";
+print "	<th data-sortable='true' data-sorter='alphaSort'>"._('Provider')."</th>";
 if($User->settings->enableCustomers=="1")
-print "	<th>"._('Customer').'</th>';
-print "	<th>"._('Type').'</th>';
-print "	<th><span class='hidden-sm hidden-xs'>"._('Capacity').'</span></th>';
-print "	<th><span class='hidden-sm hidden-xs'>"._('Status').'</span></th>';
-print "	<th><span class='hidden-sm hidden-xs'>"._('Point A').'</span></th>';
-print "	<th><span class='hidden-sm hidden-xs'>"._('Point B').'</span></th>';
-print "	<th><span class='hidden-sm hidden-xs'>"._('Comment').'</span></th>';
+print "	<th data-sortable='true'>"._('Customer').'</th>';
+print "	<th data-sortable='true'>"._('Type').'</th>';
+print "	<th data-sortable='true'><span class='hidden-sm hidden-xs'>"._('Capacity').'</span></th>';
+print "	<th data-sortable='true'><span class='hidden-sm hidden-xs'>"._('Status').'</span></th>';
+print "	<th data-sortable='true' data-sorter='alphaSort'><span class='hidden-sm hidden-xs'>"._('Point A').'</span></th>';
+print "	<th data-sortable='true' data-sorter='alphaSort'><span class='hidden-sm hidden-xs'>"._('Point B').'</span></th>';
+print "	<th data-sortable='true'><span class='hidden-sm hidden-xs'>"._('Comment').'</span></th>';
 $colspanCustom = 0;
 if(sizeof(@$custom_fields) > 0) {
 	foreach($custom_fields as $field) {
 		if(!in_array($field['name'], $hidden_circuit_fields)) {
-			print "<th class='hidden-sm hidden-xs hidden-md'><span rel='tooltip' data-container='body' title='"._('Sort by')." ".$Tools->print_custom_field_name ($field['name'])."'>".$Tools->print_custom_field_name ($field['name'])."</th>";
+			if (substr($field['type'],0,3)=="int") {
+				$sort_function=" data-sorter='numberSort'";
+			} elseif (substr($field['type'],0,3)=="dat") {
+				$sort_function=" data-sorter='dateSort'";
+			} else {
+				$sort_function="";
+			}
+			print "<th class='hidden-sm hidden-xs hidden-md' data-sortable='true'{$sort_function}><span rel='tooltip' data-container='body' title='"._('Sort by')." ".$Tools->print_custom_field_name ($field['name'])."'>".$Tools->print_custom_field_name ($field['name'])."</th>";
 			$colspanCustom++;
 		}
 	}
 }
-print '	<th class="actions"></th>';
+print '	<th class="actions" data-switchable="false"></th>';
 print '</tr>';
 print "</thead>";
 

--- a/app/tools/circuits/providers/all-providers.php
+++ b/app/tools/circuits/providers/all-providers.php
@@ -45,25 +45,32 @@ print "<div class='btn-group'>";
 print "</div>";
 
 # table
-print '<table id="circuitManagement" class="table sorted table-striped table-top" data-cookie-id-table="circuit_providers">';
+print '<table id="circuitManagement" class="table sortable sorted table-striped table-top" data-cookie-id-table="circuit_providers">';
 
 #headers
 print "<thead>";
 print '<tr>';
-print "	<th><span rel='tooltip' data-container='body' title='"._('Sort by Name')."'>"._('Name')."</span></th>";
-print "	<th><span rel='tooltip' data-container='body' title='"._('Sort by Description')."'>"._('Description').'</span></th>';
-print "	<th><span rel='tooltip' data-container='body' title='"._('Sort by Circuits')."'>"._('Circuits').'</span></th>';
-print "	<th><span rel='tooltip' data-container='body' title='"._('Sort by Contact')."'>"._('Contact').'</span></th>';
+print "	<th data-sortable='true' data-sorter='alphaSort'><span rel='tooltip' data-container='body' title='"._('Sort by Name')."'>"._('Name')."</span></th>";
+print "	<th data-sortable='true'><span rel='tooltip' data-container='body' title='"._('Sort by Description')."'>"._('Description').'</span></th>';
+print "	<th data-sortable='true' data-sorter='numberSort'><span rel='tooltip' data-container='body' title='"._('Sort by Circuits')."'>"._('Circuits').'</span></th>';
+print "	<th data-sortable='true'><span rel='tooltip' data-container='body' title='"._('Sort by Contact')."'>"._('Contact').'</span></th>';
 $colspanCustom = 0;
 if(sizeof(@$custom_fields) > 0) {
 	foreach($custom_fields as $field) {
 		if(!in_array($field['name'], $hidden_fields)) {
-			print "<th class='hidden-sm hidden-xs hidden-md'><span rel='tooltip' data-container='body' title='"._('Sort by')." ".$Tools->print_custom_field_name ($field['name'])."'>".$Tools->print_custom_field_name ($field['name'])."</th>";
+			if (substr($field['type'],0,3)=="int") {
+				$sort_function=" data-sorter='numberSort'";
+			} elseif (substr($field['type'],0,3)=="dat") {
+				$sort_function=" data-sorter='dateSort'";
+			} else {
+				$sort_function="";
+			}
+			print "<th class='hidden-sm hidden-xs hidden-md' data-sortable='true'{$sort_function}><span rel='tooltip' data-container='body' title='"._('Sort by')." ".$Tools->print_custom_field_name ($field['name'])."'>".$Tools->print_custom_field_name ($field['name'])."</th>";
 			$colspanCustom++;
 		}
 	}
 }
-print '	<th class="actions"></th>';
+print '	<th class="actions" data-switchable="false"></th>';
 print '</tr>';
 print "</thead>";
 

--- a/app/tools/customers/all-customers.php
+++ b/app/tools/customers/all-customers.php
@@ -41,23 +41,30 @@ print "<div class='btn-group'>";
 print "</div>";
 
 # table
-print '<table id="customers" class="table sorted table-striped table-top" data-cookie-id-table="customers">';
+print '<table id="customers" class="table sortable sorted table-striped table-top" data-cookie-id-table="customers">';
 
 # headers
 print "<thead>";
 print '<tr>';
-print "	<th>"._('Title')."</th>";
-print "	<th>"._('Address').'</th>';
-print "	<th>"._('Contact').'</th>';
+print "	<th data-sortable='true' data-sorter='alphaSort'>"._('Title')."</th>";
+print "	<th data-sortable='true'>"._('Address').'</th>';
+print "	<th data-sortable='true'>"._('Contact').'</th>';
 if(sizeof(@$custom_fields) > 0) {
 	foreach($custom_fields as $field) {
 		if(!in_array($field['name'], $hidden_fields)) {
-			print "<th class='hidden-sm hidden-xs hidden-md'>".$Tools->print_custom_field_name ($field['name'])."</th>";
+			if (substr($field['type'],0,3)=="int") {
+				$sort_function=" data-sorter='numberSort'";
+			} elseif (substr($field['type'],0,3)=="dat") {
+				$sort_function=" data-sorter='dateSort'";
+			} else {
+				$sort_function="";
+			}
+			print "<th class='hidden-sm hidden-xs hidden-md' data-sortable='true'{$sort_function}>".$Tools->print_custom_field_name ($field['name'])."</th>";
 			$colspanCustom++;
 		}
 	}
 }
-print '	<th class="actions"></th>';
+print '	<th class="actions" data-switchable="false"></th>';
 print '</tr>';
 print "</thead>";
 

--- a/app/tools/devices/all-devices.php
+++ b/app/tools/devices/all-devices.php
@@ -79,30 +79,30 @@ $colspanCustom = sizeof($custom_fields) - sizeof($hidden_fields);;
 #headers
 print "<thead>";
 print '<tr>';
-print "	<th>"._('Name')."</th>";
-print "	<th>"._('IP address')."</th>";
-print "	<th>"._('Description').'</th>';
+print "	<th data-sortable='true' data-sorter='alphaSort'>"._('Name')."</th>";
+print "	<th data-sortable='true' data-sorter='ipSort'>"._('IP address')."</th>";
+print "	<th data-sortable='true'>"._('Description').'</th>';
 if($User->settings->enableRACK=="1" && $User->get_module_permissions ("racks")>=User::ACCESS_R) {
-print '	<th>'._('Rack').'</th>';
+print '	<th data-sortable="true" data-sorter="alphaSort">'._('Rack').'</th>';
 $colspanCustom++;
 }
 if($User->settings->enableLocations=="1" && $User->get_module_permissions ("locations")>=User::ACCESS_R) {
-print "	<th>"._('Location').'</th>';
+print "	<th data-sortable='true' data-sorter='alphaSort'>"._('Location').'</th>';
 $colspanCustom++;
 }
-print "	<th style='color:#428bca'>"._('Number of hosts').'</th>';
-print "	<th class='hidden-sm'>". _('Type').'</th>';
+print "	<th style='color:#428bca' data-sortable='true' data-sorter='numberSort'>"._('Number of hosts').'</th>';
+print "	<th class='hidden-sm' data-sortable='true'>". _('Type').'</th>';
 
 if(sizeof(@$custom_fields) > 0) {
 	foreach($custom_fields as $field) {
 		if(!in_array($field['name'], $hidden_fields)) {
-			print "	<th class='hidden-xs hidden-sm hidden-md'>".$Tools->print_custom_field_name ($field['name'])."</th>";
+			print "	<th class='hidden-xs hidden-sm hidden-md' data-sortable='true'>".$Tools->print_custom_field_name ($field['name'])."</th>";
 		}
 	}
 }
 
 if($User->get_module_permissions ("devices")>=User::ACCESS_RW)
-print '	<th class="actions"></th>';
+print '	<th class="actions" data-switchable="false"></th>';
 print '</tr>';
 print "</thead>";
 

--- a/app/tools/devices/device-details/device-addresses.php
+++ b/app/tools/devices/device-details/device-addresses.php
@@ -31,20 +31,20 @@ $selected_ip_fields = $Tools->explode_filtered(";", $User->settings->IPfilter);
 print "<h4>"._("Belonging addresses")."</h4><hr>";
 
 # Hosts table
-print "<table id='switchMainTable' class='devices table sorted table-striped table-top table-condensed' data-cookie-id-table='device_addresses'>";
+print "<table id='switchMainTable' class='devices table sortable sorted table-striped table-top table-condensed' data-cookie-id-table='device_addresses'>";
 
 # headers
 print "<thead>";
 print "<tr>";
-print "	<th>"._('IP address')."</th>";
+print "	<th data-sortable='true' data-sorter='ipSort'>"._('IP address')."</th>";
 if(in_array("port", $selected_ip_fields)) {
-print "	<th>"._('Port')."</th>";
+print "	<th data-sortable='true'>"._('Port')."</th>";
 }
-print "	<th>"._('Subnet')."</th>";
-print "	<th>"._('Description')."</th>";
-print "	<th></th>";
-print "	<th class='hidden-xs'>"._('Hostname')."</th>";
-print "	<th class='hidden-xs hidden-sm'>"._('Owner')."</th>";
+print "	<th data-sortable='true' data-sorter='ipSort'>"._('Subnet')."</th>";
+print "	<th data-sortable='true'>"._('Description')."</th>";
+print "	<th data-switchable='false'></th>";
+print "	<th class='hidden-xs' data-sortable='true' data-sorter='alphaSort'>"._('Hostname')."</th>";
+print "	<th class='hidden-xs hidden-sm' data-sortable='true'>"._('Owner')."</th>";
 print "</tr>";
 print "</thead>";
 

--- a/app/tools/devices/device-details/device-circuits.php
+++ b/app/tools/devices/device-details/device-circuits.php
@@ -43,19 +43,19 @@ else {
     }
     else {
         # table
-        print '<table id="circuitManagement" class="table sorted table-condensed table-striped table-top" data-cookie-id-table="device_circuits">';
+        print '<table id="circuitManagement" class="table sortable sorted table-condensed table-striped table-top" data-cookie-id-table="device_circuits">';
 
         # headers
         print "<thead>";
         print '<tr>';
-        print " <th>"._('Circuit ID')."</th>";
-        print " <th>"._('Provider')."</th>";
-        print " <th>"._('Type').'</th>';
-        print " <th>"._('Capacity').'</th>';
-        print " <th>"._('Status').'</th>';
+        print " <th data-sortable='true' data-sorter='alphaSort'>"._('Circuit ID')."</th>";
+        print " <th data-sortable='true' data-sorter='alphaSort'>"._('Provider')."</th>";
+        print " <th data-sortable='true' data-sorter='alphaSort'>"._('Type').'</th>';
+        print " <th data-sortable='true' data-sorter='numberSort'>"._('Capacity').'</th>';
+        print " <th data-sortable='true'>"._('Status').'</th>';
         if($User->get_module_permissions ("locations")>=User::ACCESS_R) {
-        print " <th>"._('Point A').'</th>';
-        print " <th>"._('Point B').'</th>';
+        print " <th data-sortable='true' data-sorter='alphaSort'>"._('Point A').'</th>';
+        print " <th data-sortable='true' data-sorter='alphaSort'>"._('Point B').'</th>';
         }
         print '</tr>';
         print "</thead>";

--- a/app/tools/devices/device-details/device-subnets.php
+++ b/app/tools/devices/device-details/device-subnets.php
@@ -22,16 +22,16 @@ print "<h4>"._("Belonging subnets")."</h4><hr>";
 $subnets = $Tools->fetch_multiple_objects ("subnets", "device", $device['id']);
 
 # Hosts table
-print "<table id='switchMainTable' class='devices table sorted table-striped table-top table-condensed' data-cookie-id-table='device_subnets'>";
+print "<table id='switchMainTable' class='devices table sortable sorted table-striped table-top table-condensed' data-cookie-id-table='device_subnets'>";
 
 # headers
 print "<thead>";
 print "<tr>";
-print "	<th>"._('Subnet')."</th>";
-print "	<th>"._('Section')."</th>";
-print "	<th>"._('Description')."</th>";
+print "	<th data-sortable='true' data-sorter='ipSort'>"._('Subnet')."</th>";
+print "	<th data-sortable='true' data-sorter='alphaSort'>"._('Section')."</th>";
+print "	<th data-sortable='true'>"._('Description')."</th>";
 if($User->get_module_permissions ("vlan")>=User::ACCESS_R) {
-print "	<th>"._('VLAN')."</th>";
+print "	<th data-sortable='true' data-sorter='numberSort'>"._('VLAN')."</th>";
 }
 print "</tr>";
 print "</thead>";

--- a/app/tools/racks/print-racks-list.php
+++ b/app/tools/racks/print-racks-list.php
@@ -24,15 +24,15 @@ else {
     $User->settings->enableLocations=="1" ? $Racks->fetch_all_racks(true) : $Racks->fetch_all_racks(false);
 
     // table
-    print "<table class='table sorted table-striped table-top table-td-top' data-cookie-id-table='rack_list'>";
+    print "<table class='table sortable sorted table-striped table-top table-td-top' data-cookie-id-table='rack_list'>";
     // headers
     print "<thead>";
     print "<tr>";
-    print " <th>"._('Name')."</th>";
-    print " <th>"._('Size')."</th>";
-    print " <th>"._('Back side')."</th>";
-    print " <th>"._('Devices')."</th>";
-    print " <th>"._('Description')."</th>";
+    print " <th data-sortable='true' data-sorter='alphaSort'>"._('Name')."</th>";
+    print " <th data-sortable='true' data-sorter='numberSort'>"._('Size')."</th>";
+    print " <th data-sortable='true'>"._('Back side')."</th>";
+    print " <th data-sortable='true' data-sorter='numberSort'>"._('Devices')."</th>";
+    print " <th data-sortable='true'>"._('Description')."</th>";
 
     $colspan = 6;
     if($User->settings->enableCustomers=="1") {
@@ -42,12 +42,12 @@ else {
 	if(sizeof($custom) > 0) {
 		foreach($custom as $field) {
 			if(!in_array($field['name'], $hidden_custom_fields)) {
-				print "<th class='hidden-xs hidden-sm hidden-md'>".$Tools->print_custom_field_name ($field['name'])."</th>";
+				print "<th class='hidden-xs hidden-sm hidden-md' data-sortable='true'>".$Tools->print_custom_field_name ($field['name'])."</th>";
                 $colspan++;
 			}
 		}
 	}
-    print " <th style='width:80px'></th>";
+    print " <th style='width:80px' data-switchable='false'></th>";
     print "</tr>";
     print "</thead>";
 

--- a/app/tools/vaults/all-vaults.php
+++ b/app/tools/vaults/all-vaults.php
@@ -39,20 +39,27 @@ else {
 		// title
 		print "<h4 style='margin-top:30px;'>"._(ucwords($key))."</h4><hr>";
 
-		print '<table id="userPrint" class="table sorted table-striped sorted tab1le-auto" data-cookie-id-table="admin_vaults">';
+		print '<table id="userPrint" class="table sortable sorted table-striped tab1le-auto" data-cookie-id-table="admin_vaults">';
 		# headers
 		print "<thead>";
 		print '<tr>';
-	    print "<th data-width='300' data-width-unit='px'>"._('Name').'</th>';
+	    print "<th data-width='300' data-width-unit='px' data-sortable='true' data-sorter='alphaSort'>"._('Name').'</th>';
 	    print "<th data-width='120' data-width-unit='px'>"._('Status').'</th>';
-		print "<th>"._('Description').'</th>';
+		print "<th data-sortable='true'>"._('Description').'</th>';
 		// custom
 		if(sizeof(@$custom_fields_v) > 0) {
 			foreach($custom_fields_v as $field) {
-				print "	<th class='hidden-xs hidden-sm hidden-md'>".$Tools->print_custom_field_name ($field['name'])."</th>";
+				if (substr($field['type'],0,3)=="int") {
+					$sort_function=" data-sorter='numberSort'";
+				} elseif (substr($field['type'],0,3)=="dat") {
+					$sort_function=" data-sorter='dateSort'";
+				} else {
+					$sort_function="";
+				}
+				print "	<th class='hidden-xs hidden-sm hidden-md' data-sortable='true'{$sort_function}>".$Tools->print_custom_field_name ($field['name'])."</th>";
 			}
 		}
-	    print '<th></th>';
+	    print '<th data-switchable="false"></th>';
 		print '</tr>';
 		print "</thead>";
 

--- a/js/magic.js
+++ b/js/magic.js
@@ -2946,3 +2946,46 @@ $('table#manageSubnets').on('click','button.add_folder', function() {
 
 return false;
 });
+/* parses a string and strips out html tags */
+function stripTags(a) {/* the jQuery .text() method does not work how i want if a plain string is not wrapped in something, so this is a workaround */ a='<div>'+a+'</div>'; return $(a).text().trim();}
+/* takes two arguments and returns -1, 0, or 1 based upon which argument should be "first" */
+function alphaSort(a,b) { a=(a===undefined)?"":a=stripTags(a).toLowerCase(); b=(b===undefined)?"":b=stripTags(b).toLowerCase(); if (a>b) {return 1;} else if (a<b) {return -1;} else {return 0;}}
+/* takes two arguments and returns -1, 0, or 1 based upon which argument should be "first" */
+function numberSort(a,b) { a=(a===undefined)?"":stripTags(a); a=a.match(/^\d+/); a=(a==null)?null:Number(a[0]); b=(b===undefined)?"":b=stripTags(b); b=b.match(/^\d+/); b=(b==null)?null:Number(b[0]); if (a==null && b==null) {return 0} else if (a==null) {return 1} else if (b==null) {return -1} else {if(a>b) {return 1} else if (a<b) {return -1} else {return 0}}}
+/* takes two arguments and returns -1, 0, or 1 based upon which argument should be "first" */
+function ipSort(a,b) {
+ a=(a===undefined)?"":a=stripTags(a);
+ c=a.match(/^\d+\.\d+\.\d+\.\d+/);
+ b=(b===undefined)?"":b=stripTags(b);
+ d=b.match(/^\d+\.\d+\.\d+\.\d+/);
+ if (c==null && d==null) {
+  if (a.length==0 && b.length==0) {return 0}
+  else if (a.length==0) {return 1}
+  else if (b.length==0) {return -1}
+  else {
+   if(a<b) {return -1;} else if (a>b) {return 1;} else {return 0;}
+  }}
+ else if (c==null) {return 1}
+ else if (d==null) {return -1}
+ else {
+  i=c[0].split(".");
+  ii=d[0].split(".");
+  for (let idx=0; idx<i.length; ++idx) {
+   if (Number(i[idx])<Number(ii[idx])) {return -1}
+   else if (Number(i[idx])>Number(ii[idx])) {return 1}
+  }
+  return 0;
+ }
+}
+function dateSort(a,b) {
+ a=new Date(a);
+ a=a.getTime();
+ b=new Date(b);
+ b=b.getTime();
+ if (isNaN(a) && isNaN(b)) {return 0;}
+ else if (isNaN(a)) {return 1}
+ else if (isNaN(b)) {return -1}
+ else {
+  if (a<b) {return -1} else if (a>b) {return 1} else {return 0}
+ }
+}


### PR DESCRIPTION
It appears as though table sorting used to work several versions ago, but does not in recent versions. This PR adds html class tags to engage the built-in Bootstrap-Table sort capabilities. In addition, it also implements a few custom javascript sort functions for sorting decimal IP addresses, sorting text-stored-as-numbers, sorting dates, and extracting text out of `div` and `span` tags.
+ Fixes #875
+ Fixes #2082
+ Fixes #2495
+ Fixes #2783
+ Fixes #4106
+ Fixes #4218

coming soon
2132 (fw zones)
2193 (inactive)
4046 (locations)