### PR TITLE
Bugfix: Nameserver undefined variable, plus sorting and display enhancements

### DIFF
--- a/app/admin/nameservers/edit-result.php
+++ b/app/admin/nameservers/edit-result.php
@@ -56,6 +56,7 @@ foreach($_POST as $key=>$line) {
 $_POST['namesrv1'] = isset($all_nameservers) ? implode(";", $all_nameservers) : "";
 
 // set sections
+$temp = array();
 foreach($_POST as $key=>$line) {
 	if (!is_blank(strstr($key,"section-"))) {
 		$key2 = str_replace("section-", "", $key);

--- a/app/admin/nameservers/edit.php
+++ b/app/admin/nameservers/edit.php
@@ -108,7 +108,7 @@ $nameservers['namesrv1'] = !isset($nameservers) ? array(" ") : pf_explode(";", $
 	<!-- sections -->
 	<tr>
 		<td style="vertical-align: top !important"><?php print _('Sections to display nameserver set in'); ?>:</td>
-		<td>
+		<td style="padding-left:20px">
 		<?php
 		# select sections
 		$sections = $Sections->fetch_all_sections();

--- a/app/admin/nameservers/index.php
+++ b/app/admin/nameservers/index.php
@@ -8,7 +8,7 @@
 $User->check_user_session();
 
 # fetch all vrfs
-$all_nameservers = $Admin->fetch_all_objects("nameservers", "id");
+$all_nameservers = $Admin->fetch_all_objects("nameservers", "name");
 ?>
 
 <h4><?php print _('Manage Nameserver sets'); ?></h4>

--- a/functions/classes/class.Sections.php
+++ b/functions/classes/class.Sections.php
@@ -380,7 +380,7 @@ class Sections extends Common_functions {
 	public function fetch_section_nameserver_sets ($sectionId) {
 		# first fetch all nameserver sets
 		$Admin = new Admin ($this->Database, false);
-		$nameservers = $Admin->fetch_all_objects ("nameservers");
+		$nameservers = $Admin->fetch_all_objects ("nameservers","name");
 		# loop and check
 		if ($nameservers!==false) {
     		$permitted = array();

--- a/misc/CHANGELOG
+++ b/misc/CHANGELOG
@@ -29,6 +29,7 @@
     + Fixed Custom field not working in Routing module (#4174);
     + Fixed Circuit Type showing differently in two windows (#4104);
     + Fixed Vault Item Custom Field not writable (#4058);
+    + Fixed Undefined variable when adding nameserver (#4230);
 
     Enhancements, changes:
     ----------------------------


### PR DESCRIPTION
A few nameserver fixes.
+ Fixes #4230
+ Fixes #3760
+ Also indents the checkboxes for proper column alignment. Checkboxes receive a margin of -20px, so i padded the `<td>` positive 20px.
> ![image](https://github.com/user-attachments/assets/87606cc2-ee8a-4f70-8dd5-9ae6237f9bfe)

is now
> ![image](https://github.com/user-attachments/assets/8b6bf1d5-ade5-48a6-9dcb-f1d5a7bcd8b8)