### PR TITLE
changed text shortening for subnet descriptions

### DIFF
--- a/functions/classes/class.SubnetsMenu.php
+++ b/functions/classes/class.SubnetsMenu.php
@@ -66,15 +66,13 @@ class SubnetsMenu {
 	 * @return string
 	 */
 	private function get_subnet_description($subnet) {
-		$subnet->description = $this->Subnets->shorten_text($subnet->description, 34);
-
-		if ($subnet->isFolder == 1) {
-			return $subnet->description;
-		}
-
 		// Make use of $subnet->ip if already set by cache/previous call
 		if (!isset($subnet->ip)) {
 			$subnet->ip = $this->Subnets->transform_to_dotted($subnet->subnet);
+		}
+
+		if ($subnet->isFolder == 1 || $subnet->showName == 1) {
+			return $this->Subnets->shorten_text($subnet->description, 50);
 		}
 
 		// Generate subnet description
@@ -86,13 +84,13 @@ class SubnetsMenu {
 				break;
 
 			case 1:	// Description Only
-				$description = empty($subnet->description) ?  $subnet->ip.'/'.$subnet->mask : $subnet->description; // fix for empty
+				$description = empty($subnet->description) ?  $subnet->ip.'/'.$subnet->mask : $this->Subnets->shorten_text($subnet->description, 50); // fix for empty
 				break;
 
 			case 2:	// Subnet Network & Description
 				$description = $subnet->ip.'/'.$subnet->mask;
 				if (!empty($subnet->description)) {
-					$description = $description . ' ('.$subnet->description.')';
+					$description = $description . ' ('. $this->Subnets->shorten_text($subnet->description, 34) .')';
 				}
 				break;
 		}
@@ -152,17 +150,17 @@ class SubnetsMenu {
 			// folder - opened
 			if($subnet->isFolder == 1) {
 				$this->html[] = '<li class="folderF folder-'.$style_open.' '.$style_active.'"><i data-str_id="'.$subnet->id.'" class="fa fa-gray fa-folder fa-folder'.$style_openf.'" rel="tooltip" data-placement="right" data-html="true" title="'._('Folder contains more subnets').'<br>'._('Click on folder to open/close').'"></i>';
-				$this->html[] = '<a href="'.create_link("folder", $subnet->sectionId, $subnet->id).'">'.$description.'</a>';
+				$this->html[] = '<a href="'.create_link("folder", $subnet->sectionId, $subnet->id).'" rel="tooltip" data-placement="right" title="'.$subnet->description.'">'.$description.'</a>';
 			}
 			// print name
 			elseif($subnet->showName == 1) {
 				$this->html[] = '<li class="folder folder-'.$style_open.' '.$style_active.'"><i data-str_id="'.$subnet->id.'" class="fa fa-gray fa-folder-'.$style_open.'-o" rel="tooltip" data-placement="right" data-html="true" title="'._('Subnet contains more subnets').'<br>'._('Click on folder to open/close').'"></i>';
-				$this->html[] = '<a href="'.create_link("subnets", $subnet->sectionId, $subnet->id).'" rel="tooltip" data-placement="right" title="'.$subnet->ip.'/'.$subnet->mask.'">'.$subnet->description.'</a>';
+				$this->html[] = '<a href="'.create_link("subnets", $subnet->sectionId, $subnet->id).'" rel="tooltip" data-placement="right" title="'.$subnet->ip.'/'.$subnet->mask.(empty($subnet->description) ? "" : " (".$subnet->description.")").'">'.$description.'</a>';
 			}
 			// print subnet
 			else {
 				$this->html[] = '<li class="folder folder-'.$style_open.' '.$style_active.'"><i data-str_id="'.$subnet->id.'" class="fa fa-gray fa-folder-'.$style_open.'-o" rel="tooltip" data-placement="right" data-html="true" title="'._('Subnet contains more subnets').'<br>'._('Click on folder to open/close').'"></i>';
-				$this->html[] = '<a href="'.create_link("subnets", $subnet->sectionId, $subnet->id).'" rel="tooltip" data-placement="right" title="'.$description.'">'.$description.'</a>';
+				$this->html[] = '<a href="'.create_link("subnets", $subnet->sectionId, $subnet->id).'" rel="tooltip" data-placement="right" title="'.$subnet->description.'">'.$description.'</a>';
 			}
 
 		} else {
@@ -170,17 +168,17 @@ class SubnetsMenu {
 			// folder - opened
 			if($subnet->isFolder == 1) {
 				$this->html[] = '<li class="leaf '.$style_active.'"><i data-str_id="'.$subnet->id.'" class="fa fa-gray fa-sfolder fa-folder'.$style_openf.'"></i>';
-				$this->html[] = '<a href="'.create_link("folder", $subnet->sectionId, $subnet->id).'">'.$description.'</a></li>';
+				$this->html[] = '<a href="'.create_link("folder", $subnet->sectionId, $subnet->id).'" rel="tooltip" data-placement="right" title="'.$subnet->description.'">'.$description.'</a></li>';
 			}
 			// print name
 			elseif($subnet->showName == 1) {
 				$this->html[] = '<li class="leaf '.$style_active.'"><i data-str_id="'.$subnet->id.'" class="'.$style_leafClass.' fa fa-gray fa-angle-right"></i>';
-				$this->html[] = '<a href="'.create_link("subnets", $subnet->sectionId, $subnet->id).'" rel="tooltip" data-placement="right" title="'.$subnet->ip.'/'.$subnet->mask.'">'.$subnet->description.'</a></li>';
+				$this->html[] = '<a href="'.create_link("subnets", $subnet->sectionId, $subnet->id).'" rel="tooltip" data-placement="right" title="'.$subnet->ip.'/'.$subnet->mask.(empty($subnet->description) ? "" : " (".$subnet->description.")").'">'.$description.'</a></li>';
 			}
 			// print subnet
 			else {
 				$this->html[] = '<li class="leaf '.$style_active.'"><i data-str_id="'.$subnet->id.'" class="'.$style_leafClass.' fa fa-gray fa-angle-right"></i>';
-				$this->html[] = '<a href="'.create_link("subnets",  $subnet->sectionId,$subnet->id).'" rel="tooltip" data-placement="right" title="'.$description.'">'.$description.'</a></li>';
+				$this->html[] = '<a href="'.create_link("subnets",  $subnet->sectionId,$subnet->id).'" rel="tooltip" data-placement="right" title="'.$subnet->description.'">'.$description.'</a></li>';
 			}
 		}
 	}

--- a/misc/CHANGELOG
+++ b/misc/CHANGELOG
@@ -1,3 +1,18 @@
+== 1.7.1
+
+    New features:
+    ------------
+
+    Bugfixes:
+    ----------------------------
+
+    Enhancements, changes:
+    ----------------------------
+    + Modified the text shortening of subnet descriptions (#4279, #4280);
+
+    Security Fixes:
+    ----------------------------
+
 == 1.7.0
 
     New features:
@@ -44,7 +59,6 @@
     + Added $api_stringify_results config.php option for <PHP81 API backwards compatibility;
     + Added support for newly added widgets to be sortable with jQuery (#4711);
     + Added support for using widget parameters; added recent_logins widget (#4184);
-    + Modified the text shortening of subnet descriptions (#4279, #4280);
 
     Security Fixes:
     ----------------------------

--- a/misc/CHANGELOG
+++ b/misc/CHANGELOG
@@ -44,6 +44,7 @@
     + Added $api_stringify_results config.php option for <PHP81 API backwards compatibility;
     + Added support for newly added widgets to be sortable with jQuery (#4711);
     + Added support for using widget parameters; added recent_logins widget (#4184);
+    + Modified the text shortening of subnet descriptions (#4279, #4280);
 
     Security Fixes:
     ----------------------------


### PR DESCRIPTION
This fixes several things:
+ Fixes #4279 (Preserve full text in tooltip for subnet descriptions that are shortened)
+ Fixes #4280 (Subnet description not shortened in SubnetMenu when showasname)
+ Subnets and folders are shortened to the same length, but subnets get their subnet appended; therefore, folders ought to get more characters
+ When a folder is shortened, it does not get hover text showing its full name
+ If a subnet is `Show as name`, then the hover text is the subnet IP only, even if the name became shortened; add description to the hover text

When you are checking my work, these two notes might be helpful:
+ the `get_subnet_description` function was permantently modifying the description in the object passed to it; this is now no longer happening
+ in the `menu_item` function, `$description` is the result of the `get_subnet_description`, whereas `$subnet->description` is the raw (full, now no-longer-shortened) description