### PR TITLE
Quiet php warning during ldap login in class.User.php

### DIFF
--- a/functions/classes/class.User.php
+++ b/functions/classes/class.User.php
@@ -1032,8 +1032,8 @@ class User extends Common_functions {
             $dirparams['use_tls'] = false;
             // Support the pre-1.2 auth settings as well as the current version
             // TODO: remove legacy support at some point
-            if ($authparams['ldap_security'] == 'tls' || $authparams['use_tls'] == 1)         { $dirparams['use_tls'] = true; }
-            elseif ($authparams['ldap_security'] == 'ssl' || $authparams['use_ssl'] == 1)     { $dirparams['use_ssl'] = true; }
+            if ($authparams['ldap_security'] == 'tls' || !empty($authparams['use_tls']))         { $dirparams['use_tls'] = true; }
+            elseif ($authparams['ldap_security'] == 'ssl' || !empty($authparams['use_ssl']))     { $dirparams['use_ssl'] = true; }
             if (isset($authparams['admin_username']) && isset($authparams['admin_password'])) {
                 $dirparams['admin_username'] = $authparams['adminUsername'];
                 $dirparams['admin_password'] = $authparams['adminPassword'];


### PR DESCRIPTION
A PHP "Undefined array key" warning is issued during ldap login because the 'use_tls' and 'use_ssl' parameters don't exist (they do in other auth types).  This switches the comparison from "$ == 1" to "!empty($)" to avoid the warning about the undefined array key.