### PR TITLE
Fix inconsistencies in devices import/export

### DIFF
--- a/app/admin/import-export/export-devices.php
+++ b/app/admin/import-export/export-devices.php
@@ -114,6 +114,18 @@ foreach ($devices as $d) {
 			$d[$k] = $deviceTypes[$d[$k]]['tname'];
 		}
 
+		if ($k == "sections"){
+			$ds = explode(";", $d[$k]);
+			$d[$k] = '';
+			foreach ($ds as $s) {
+				if (isset($section_ids[$s])){
+					$d[$k] .= $section_ids[$s]['name'];
+					$d[$k] .= ";";
+				}
+			}
+			$d[$k] = trim($d[$k],';');
+		}
+
 		$worksheet->write($curRow, $curColumn, $d[$k], $format_text);
 		$curColumn++;
     }

--- a/app/admin/import-export/import-devices-check.php
+++ b/app/admin/import-export/import-devices-check.php
@@ -117,7 +117,7 @@ foreach ($data as &$cdata) {
 		if (isset($edata['devices'][strtolower($cdata['hostname'])]) ) {
     		$cdata['id'] = $edata['devices'][strtolower($cdata['hostname'])]['id'];
 			# copy content to a variable for easier checks
-			$cedata = $edata[strtolower($cdata['hostname'])];
+			$cedata = $edata['devices'][strtolower($cdata['hostname'])];
 			# Check if we need to change any fields
 			$action = "skip"; # skip duplicate fields if identical, update if different
 			# Should we just let the database decided to update or not?  Nice for UI, but alot of

--- a/app/admin/import-export/import-devices-check.php
+++ b/app/admin/import-export/import-devices-check.php
@@ -26,7 +26,7 @@ if (!isset($custom_fields)) { $custom_fields = $Tools->fetch_custom_fields("devi
 
 # check which sections we need to care about
 $used_section = array();
-foreach ($data as &$cdata) { $used_section[strtolower($cdata['section'])]=$cdata['section']; }
+foreach ($data as &$cdata) { $used_section[strtolower($cdata['sections'])]=$cdata['sections']; }
 
 # fetch all sections and load all subnets
 $all_sections = $Sections->fetch_all_sections();
@@ -73,18 +73,18 @@ foreach ($data as &$cdata) {
 	}
 
 	# Check if section is provided and valid and link it if it is
-	if (!isset($section_names[strtolower($cdata['section'])])) {
-		$msg.= "Invalid section."; $action = "error";
+	if (!isset($section_names[strtolower($cdata['sections'])])) {
+		$msg.= "Invalid sections."; $action = "error";
 	} else {
-		$cdata['sections'] = $section_names[strtolower($cdata['section'])]['id'];
+		$cdata['sections'] = $section_names[strtolower($cdata['sections'])]['id'];
 	}
 
 	# Check if deviceType is provided and valid and link it if it is
-	if (!isset($edata['deviceTypes'][strtolower($cdata['deviceType'])])
+	if (!isset($edata['type'][strtolower($cdata['type'])])
 	    ) {
 		$msg.= "Invalid deviceType."; $action = "error";
 	} else {
-		$cdata['type'] = $edata['deviceTypes'][strtolower($cdata['deviceType'])]['tid'];
+		$cdata['type'] = $edata['type'][strtolower($cdata['type'])]['tid'];
 	}
 
 	if ($action != "error") {
@@ -118,7 +118,7 @@ foreach ($data as &$cdata) {
 			# code maintenance here.
 			if ($cdata['description'] != $cedata['description']) { $msg.= "Device description will be updated."; $action = "edit"; }
 			if ($cdata['ip_addr'] != $cedata['ip_addr']) { $msg.= "Device ip_addr will be updated."; $action = "edit"; }
-			if ($cdata['type'] != $cedata['type']) { $msg.= "DeviceType will be updated."; $action = "edit"; }
+			if ($cdata['type'] != $cedata['type']) { $msg.= "type will be updated."; $action = "edit"; }
 			if ($cdata['sectionId'] != $cedata['sectionId']) { $msg.= "sectionId will be updated."; $action = "edit"; }
 			if ($cdata['rack'] != $cedata['rack']) { $msg.= "rack will be updated."; $action = "edit"; }
 			if ($cdata['rack_start'] != $cedata['rack_start']) { $msg.= "rack_start will be updated."; $action = "edit"; }

--- a/app/admin/import-export/import-devices-check.php
+++ b/app/admin/import-export/import-devices-check.php
@@ -76,7 +76,7 @@ foreach ($data as &$cdata) {
 	$cs = explode(";", $cdata['sections']); 
 	$cdata['sections'] = '';
 	foreach ($cs as $s) {
-		if (!isset($section_names[strtolower($s)])) {
+		if (!isset($s) && !isset($section_names[strtolower($s)])) {
 			$msg.= "Invalid section(s)."; $action = "error";
 		} else {
 			$cdata['sections'] .= $section_names[strtolower($s)]['id'];
@@ -86,7 +86,7 @@ foreach ($data as &$cdata) {
 	}
 
 	# Check if deviceType is provided and valid and link it if it is
-	if (!isset($edata['deviceType'][strtolower($cdata['type'])])
+	if (!isset($cdata['type']) && !isset($edata['deviceType'][strtolower($cdata['type'])])
 	    ) {
 		$msg.= "Invalid deviceType."; $action = "error";
 	} else {

--- a/app/admin/import-export/import-devices-check.php
+++ b/app/admin/import-export/import-devices-check.php
@@ -82,8 +82,8 @@ foreach ($data as &$cdata) {
 			$cdata['sections'] .= $section_names[strtolower($s)]['id'];
 			$cdata['sections'] .= ";";
 		}
-		$d[$k] = trim($cdata['sections'],';');
 	}
+	$cdata['sections'] = trim($cdata['sections'],';');
 
 	# Check if deviceType is provided and valid and link it if it is
 	if (!isset($cdata['type']) && !isset($edata['deviceType'][strtolower($cdata['type'])])

--- a/app/admin/import-export/import-devices-check.php
+++ b/app/admin/import-export/import-devices-check.php
@@ -103,7 +103,8 @@ foreach ($data as &$cdata) {
     	        $msg.="Invalid IP address.";
     	        $action = "error";
     	    }
-		if ((!empty($cdata['hostname'])) and (!preg_match("/^(?=.{1,255}$)[0-9A-Za-z](?:(?:[0-9A-Za-z]|-){0,61}[0-9A-Za-z])?(?:\.[0-9A-Za-z](?:(?:[0-9A-Za-z]|-){0,61}[0-9A-Za-z])?)*\.?$/", $cdata['hostname']))) { $msg.="Invalid DNS name."; $action = "error"; }
+    	// Device hostnames are not checked when created via GUI ... Why retrict it on import ?
+		// if ((!empty($cdata['hostname'])) and (!preg_match("/^(?=.{1,255}$)[0-9A-Za-z](?:(?:[0-9A-Za-z]|-){0,61}[0-9A-Za-z])?(?:\.[0-9A-Za-z](?:(?:[0-9A-Za-z]|-){0,61}[0-9A-Za-z])?)*\.?$/", $cdata['hostname']))) { $msg.="Invalid DNS name."; $action = "error"; }
 #       Allow all chars in description ... Why Limit it ?
 #		if (preg_match("/[;'\"]/", $cdata['description'])) { $msg.="Invalid characters in description."; $action = "error"; }
 		if ($cdata['mac']) {

--- a/app/admin/import-export/import-devices-check.php
+++ b/app/admin/import-export/import-devices-check.php
@@ -53,7 +53,7 @@ foreach ($devices as $d) {
 
 foreach ($deviceTypes as $d) {
     $d = (array) $d;
-    $edata['deviceTypes'][strtolower($d['tname'])] = $d;
+    $edata['deviceType'][strtolower($d['tname'])] = $d;
 }
 
 #error_log ( "devicestypes : " . json_encode ($deviceTypes) ) ;
@@ -80,7 +80,7 @@ foreach ($data as &$cdata) {
 	}
 
 	# Check if deviceType is provided and valid and link it if it is
-	if (!isset($edata['type'][strtolower($cdata['type'])])
+	if (!isset($edata['deviceType'][strtolower($cdata['type'])])
 	    ) {
 		$msg.= "Invalid deviceType."; $action = "error";
 	} else {

--- a/app/admin/import-export/import-devices-check.php
+++ b/app/admin/import-export/import-devices-check.php
@@ -72,11 +72,17 @@ foreach ($data as &$cdata) {
 		if ((!isset($cdata[$creq]) or ($cdata[$creq] == ""))) { $msg.= "Required field ".$creq." missing or empty."; $action = "error"; }
 	}
 
-	# Check if section is provided and valid and link it if it is
-	if (!isset($section_names[strtolower($cdata['sections'])])) {
-		$msg.= "Invalid sections."; $action = "error";
-	} else {
-		$cdata['sections'] = $section_names[strtolower($cdata['sections'])]['id'];
+	# Check if sections are provided and valid and link them if they are
+	$cs = explode(";", $cdata['sections']); 
+	$cdata['sections'] = '';
+	foreach ($cs as $s) {
+		if (!isset($section_names[strtolower($s)])) {
+			$msg.= "Invalid section(s)."; $action = "error";
+		} else {
+			$cdata['sections'] .= $section_names[strtolower($s)]['id'];
+			$cdata['sections'] .= ";";
+		}
+		$d[$k] = trim($cdata['sections'],';');
 	}
 
 	# Check if deviceType is provided and valid and link it if it is
@@ -84,7 +90,7 @@ foreach ($data as &$cdata) {
 	    ) {
 		$msg.= "Invalid deviceType."; $action = "error";
 	} else {
-		$cdata['type'] = $edata['type'][strtolower($cdata['type'])]['tid'];
+		$cdata['type'] = $edata['deviceType'][strtolower($cdata['type'])]['tid'];
 	}
 
 	if ($action != "error") {

--- a/app/admin/import-export/import-devices-select.php
+++ b/app/admin/import-export/import-devices-select.php
@@ -23,18 +23,18 @@ $tpl_field_types = "";
 
 
 # predefine field list
-$expfields = array ("hostname", "ip_addr", "deviceType", "description", "section", "rack", "rack_start", "rack_size", "location");
+$expfields = array ("hostname", "ip_addr", "type", "description", "sections", "rack", "rack_start", "rack_size", "location");
 #$expfields = array ("hostname", "ip_addr", "deviceType", "description", "section", "snmp_community", "snmp_version", "snmp_port", "snmp_timeout", "snmp_queries", "snmp_v3_sec_level", "snmp_v3_auth_protocol", "snmp_v3_auth_pass", "snmp_v3_priv_protocol", "snmp_v3_priv_pass", "snmp_v3_ctx_name", "snmp_v3_ctx_engine_id", "rack", "rack_start", "rack_size", "location");
 //$disfields = array ("Section","IP Address","Hostname","Description","VRF","Subnet","MAC","owner","device","note","TAG");
 $mtable = "devices"; # main table where to check the fields
 
 // # extra fields
-$extfields["deviceType"]["table"] = "deviceTypes";
+$extfields["deviceType"]["table"] = "types";
 $extfields["deviceType"]["field"] = "tname";
-$extfields["deviceType"]["pname"] = "deviceType";
+$extfields["deviceType"]["pname"] = "type";
 $extfields["section"]["table"] = "sections";
 $extfields["section"]["field"] = "name";
-$extfields["section"]["pname"] = "section";
+$extfields["section"]["pname"] = "sections";
 // $extfields["subnet"]["table"] = "subnets";
 // $extfields["subnet"]["field"] = "subnet";
 // $extfields["subnet"]["pname"] = "subnet";

--- a/app/admin/import-export/import-template.php
+++ b/app/admin/import-export/import-template.php
@@ -105,9 +105,9 @@ elseif ($type == 'l2dom'){
 	// set headers
     $worksheet->write($lineCount, $curColumn++, _('hostname'));
     $worksheet->write($lineCount, $curColumn++, _('ip_addr'));
-    $worksheet->write($lineCount, $curColumn++, _('deviceType'));
+    $worksheet->write($lineCount, $curColumn++, _('type'));
     $worksheet->write($lineCount, $curColumn++, _('description'));
-    $worksheet->write($lineCount, $curColumn++, _('section'));
+    $worksheet->write($lineCount, $curColumn++, _('sections'));
 #    $worksheet->write($lineCount, $curColumn++, _('snmp_community'));
 #    $worksheet->write($lineCount, $curColumn++, _('snmp_version'));
 #    $worksheet->write($lineCount, $curColumn++, _('snmp_port'));


### PR DESCRIPTION
Hello,

Here is my small contribution to fix some inconsistencies in devices import/export feature that were making export, modify and re-import impossible:
* Issue#1: Export was putting following fields names: "type" and "sections" __VS__ Import was expecting "deviceType" and "section"
* Issue#2: Sections were exported as an array of section IDs __VS__ Import was expecting a single section name

I'm proposing the following fixes:
* Issue#1: Export and Import are now using the same field names ("type" & "sections"), and match the one in the Database. Provided xls Template as been updated too.
* Issue#2: When exporting, sections ID(s) are now resolved to name(s). When importing, section name(s) are then resolved back to ID(s)

Seems to fix Issues #2838 #4130 #2464 #1894 


Please let me know if this is ok to be merged.

Thanks,

A.