### PR TITLE
Add a check when adding device in GUI to error on duplicate device

### DIFF
--- a/app/admin/devices/edit-result.php
+++ b/app/admin/devices/edit-result.php
@@ -60,9 +60,11 @@ $POST->sections = !empty($temp) ? implode(";", $temp) : null;
 if($POST->hostname == "") 											{ $Result->show("danger", _('Hostname is mandatory').'!', true); }
 
 # Check if duplicate hostname
-if(isset($devices[strtolower($POST->hostname)])) 								{ $Result->show("danger", _('Hostname already exist in database').'!', true); }
+if($POST->action == "add" && isset($devices[strtolower($POST->hostname)])) 								{ $Result->show("danger", _('Hostname already exist in database').'!', true); }
 
+# Validate ip_addr
 if(
+	$POST->action == "add" &&
     isset($POST->ip_addr) &&
     !is_blank($POST->ip_addr) &&
     !$Addresses->validate_ip($POST->ip_addr)

--- a/app/admin/devices/edit-result.php
+++ b/app/admin/devices/edit-result.php
@@ -60,11 +60,12 @@ $POST->sections = !empty($temp) ? implode(";", $temp) : null;
 if($POST->hostname == "") 											{ $Result->show("danger", _('Hostname is mandatory').'!', true); }
 
 # Check if duplicate hostname
-if($POST->action == "add" && isset($devices[strtolower($POST->hostname)])) 								{ $Result->show("danger", _('Hostname already exist in database').'!', true); }
+// Error duplicate when (action=add && duplicate found) or (action=edit && duplicate found) 
+if($POST->action != "delete" && isset($devices[strtolower($POST->hostname)]) && $devices[strtolower($POST->hostname)]['id'] != $POST->switchid ) 								{ $Result->show("danger", _('Hostname already exist in database').'!', true); }
 
 # Validate ip_addr
 if(
-	$POST->action == "add" &&
+	$POST->action != "delete" &&
     isset($POST->ip_addr) &&
     !is_blank($POST->ip_addr) &&
     !$Addresses->validate_ip($POST->ip_addr)

--- a/app/admin/devices/edit-result.php
+++ b/app/admin/devices/edit-result.php
@@ -61,7 +61,7 @@ if($POST->hostname == "") 											{ $Result->show("danger", _('Hostname is ma
 
 # Check if duplicate hostname
 // Error duplicate when (action=add && duplicate found) or (action=edit && duplicate found) 
-if($POST->action != "delete" && isset($devices[strtolower($POST->hostname)]) && $devices[strtolower($POST->hostname)]['id'] != $POST->switchid ) 								{ $Result->show("danger", _('Hostname already exist in database').'!', true); }
+if($POST->action != "delete" && isset($devices[strtolower(trim($POST->hostname))]) && $devices[strtolower(trim($POST->hostname))]['id'] != $POST->switchid ) 								{ $Result->show("danger", _('Hostname already exist in database').'!', true); }
 
 # Validate ip_addr
 if(
@@ -97,10 +97,10 @@ if ($POST->rack !== "0" && $User->get_module_permissions ("racks")>=User::ACCESS
 # set update values
 $values = array(
 				"id"          =>$POST->switchid,
-				"hostname"    =>$POST->hostname,
+				"hostname"    =>trim($POST->hostname),
 				"ip_addr"     =>$POST->ip_addr,
 				"type"        =>$POST->type,
-				"description" =>$POST->description,
+				"description" =>trim($POST->description),
 				"sections"    =>$POST->sections,
 				"location"    =>$POST->location
 				);

--- a/app/admin/devices/edit-result.php
+++ b/app/admin/devices/edit-result.php
@@ -15,6 +15,7 @@ $Tools	 	= new Tools ($Database);
 $Racks      = new phpipam_rack ($Database);
 $Result 	= new Result ();
 if (!isset($Devices)) { $Devices = new Devices ($Database); }
+if (!isset($Addresses)) { $Addresses = new Addresses ($Database); }
 
 # verify that user is logged in
 $User->check_user_session();
@@ -60,6 +61,15 @@ if($POST->hostname == "") 											{ $Result->show("danger", _('Hostname is ma
 
 # Check if duplicate hostname
 if(isset($devices[strtolower($POST->hostname)])) 								{ $Result->show("danger", _('Hostname already exist in database').'!', true); }
+
+if(
+    isset($POST->ip_addr) &&
+    !is_blank($POST->ip_addr) &&
+    !$Addresses->validate_ip($POST->ip_addr)
+   )
+{
+    $Result->show("danger", _('Invalid IP address').'!', true);
+}
 
 # rack checks
 if ($POST->rack !== "0" && $User->get_module_permissions ("racks")>=User::ACCESS_R) {


### PR DESCRIPTION
Hello,

Here is a PR to add a check in edit-result.php so that, from GUI, it is not possible to create a new device with the same name as an already existing device.
This is especially useful when importing devices via import/export" as it avoids editing the wrong device. This is because import script identifies devices by their name and not their Ids and so cannot differentiate two devices with the same names.

BR,

A.