### PR TITLE
Add html_entity_decode for hostname, description, sections and type fields on device import

### DIFF
--- a/app/admin/import-export/import-devices-check.php
+++ b/app/admin/import-export/import-devices-check.php
@@ -72,6 +72,12 @@ foreach ($data as &$cdata) {
 		if ((!isset($cdata[$creq]) or ($cdata[$creq] == ""))) { $msg.= "Required field ".$creq." missing or empty."; $action = "error"; }
 	}
 
+	# Decode HTML entity in text fields
+	if (isset($cdata['hostname'])) { $cdata['hostname'] = html_entity_decode($cdata['hostname']); }
+	if (isset($cdata['description'])) { $cdata['description'] = html_entity_decode($cdata['description']); }
+	if (isset($cdata['sections'])) { $cdata['sections'] = html_entity_decode($cdata['sections']); }
+	if (isset($cdata['type'])) { $cdata['type'] = html_entity_decode($cdata['type']); }
+
 	# Check if section is provided and valid and link it if it is
 	if (!isset($section_names[strtolower($cdata['section'])])) {
 		$msg.= "Invalid section."; $action = "error";

--- a/app/admin/import-export/import-devices-check.php
+++ b/app/admin/import-export/import-devices-check.php
@@ -48,7 +48,12 @@ foreach ($all_sections as $section) {
 
 foreach ($devices as $d) {
     $d = (array) $d;
-    $edata['devices'][strtolower($d['hostname'])] = $d;
+	# Decode HTML entity in text fields
+    $d['hostname'] = html_entity_decode($d['hostname']);
+    $d['description'] = html_entity_decode($d['description']);
+    $d['sections'] = html_entity_decode($d['sections']);
+    $d['type'] = html_entity_decode($d['type']);
+    $edata['devices'][html_entity_decode(strtolower($d['hostname']))] = $d;
 }
 
 foreach ($deviceTypes as $d) {
@@ -73,10 +78,11 @@ foreach ($data as &$cdata) {
 	}
 
 	# Decode HTML entity in text fields
-	if (isset($cdata['hostname'])) { $cdata['hostname'] = html_entity_decode($cdata['hostname']); }
-	if (isset($cdata['description'])) { $cdata['description'] = html_entity_decode($cdata['description']); }
-	if (isset($cdata['sections'])) { $cdata['sections'] = html_entity_decode($cdata['sections']); }
-	if (isset($cdata['type'])) { $cdata['type'] = html_entity_decode($cdata['type']); }
+	# Double decode needed as "&" is also encoded on import...
+	if (isset($cdata['hostname'])) { $cdata['hostname'] = html_entity_decode(html_entity_decode($cdata['hostname'])); }
+	if (isset($cdata['description'])) { $cdata['description'] = html_entity_decode(html_entity_decode($cdata['description'])); }
+	if (isset($cdata['sections'])) { $cdata['sections'] = html_entity_decode(html_entity_decode($cdata['sections'])); }
+	if (isset($cdata['type'])) { $cdata['type'] = html_entity_decode(html_entity_decode($cdata['type'])); }
 
 	# Check if section is provided and valid and link it if it is
 	if (!isset($section_names[strtolower($cdata['section'])])) {
@@ -117,7 +123,7 @@ foreach ($data as &$cdata) {
 		if (isset($edata['devices'][strtolower($cdata['hostname'])]) ) {
     		$cdata['id'] = $edata['devices'][strtolower($cdata['hostname'])]['id'];
 			# copy content to a variable for easier checks
-			$cedata = $edata[strtolower($cdata['hostname'])];
+			$cedata = $edata['devices'][strtolower($cdata['hostname'])];
 			# Check if we need to change any fields
 			$action = "skip"; # skip duplicate fields if identical, update if different
 			# Should we just let the database decided to update or not?  Nice for UI, but alot of

--- a/app/admin/import-export/import-devices.php
+++ b/app/admin/import-export/import-devices.php
@@ -40,11 +40,11 @@ foreach ($data as &$cdata) {
 
 		$values = array(
             'id'	    =>$cdata['id'],
-            'hostname'	    =>$cdata['hostname'],
+            'hostname'	    =>html_entity_decode($cdata['hostname']),
             'ip_addr'	    =>$cdata['ip_addr'],
-            'type'	    =>$cdata['type'],
-            'description'	    =>$cdata['description'],
-            'sections'	    =>$cdata['sections'],
+            'type'	    =>html_entity_decode($cdata['type']),
+            'description'	    =>html_entity_decode($cdata['description']),
+            'sections'	    =>html_entity_decode($cdata['sections']),
 #            'snmp_community'	    =>$cdata['snmp_community'],
 #            'snmp_version'	    =>$cdata['snmp_version'],
 #            'snmp_port'	    =>$cdata['snmp_port'],


### PR DESCRIPTION
Hello,

Small contribution to add html_entity_decode on hostname, description, sections and type fields when importing devices.
The issue was for characters like "é" or "â" in device names and descriptions, that once exported to excel where HTML encoded like "&eacute;" and "&acirc;". 
Adding here the php function html_entity_decode to this fields to decode these char if they are present.

We need a "double decode" here because when re-imported, the script encode again the strings. The "&" char is then encoded too which makes them like "&amp;eacute;" and "&amp;acirc;"

To be more clear, here is the previous (before this fix) workflow:
"é" (in database) -> "&eacute;" (in exported xls) -> "&amp;eacute;" (in import script) and gets compared to "&eacute;" from database fetched string.

BR,

A.