### PR TITLE
Bugfix: json validation

### DIFF
--- a/functions/classes/class.Sections.php
+++ b/functions/classes/class.Sections.php
@@ -423,6 +423,7 @@ class Sections extends Common_functions {
 	public function parse_section_permissions($permissions) {
 		# save to array
 		$permissions = db_json_decode($permissions, true);
+		$permissions = is_array($permissions) ? $permissions : [];
 		# start Tools object
 		$Tools = new Tools ($this->Database);
 		if(sizeof($permissions)>0) {
@@ -451,6 +452,7 @@ class Sections extends Common_functions {
 	public function check_permission ($user, $sectionid) {
 		# decode groups user belongs to
 		$groups = db_json_decode($user->groups, true);
+		$groups = is_array($groups) ? $groups : [];
 
 		# admins always has permission rwa
 		if($user->role == "Administrator")		{ return 3; }
@@ -458,6 +460,7 @@ class Sections extends Common_functions {
 			# fetch section details and check permissions
 			$section  = $this->fetch_section ("id", $sectionid);
 			$sectionP = db_json_decode($section->permissions, true);
+			$sectionP = is_array($sectionP) ? $sectionP : [];
 
 			# default permission is no access
 			$out = 0;

--- a/functions/classes/class.Subnets.php
+++ b/functions/classes/class.Subnets.php
@@ -3025,14 +3025,17 @@ class Subnets extends Common_functions {
 		if(is_object($cached_item)) return $cached_item->result;
 
 		$subnetP = db_json_decode(@$subnet->permissions, true);
+		$subnetP = is_array($subnetP) ? $subnetP : [];
 
 		# set section permissions
 		$Section = new Sections ($this->Database);
 		$section = $Section->fetch_section ("id", $subnet->sectionId);
 		$sectionP = db_json_decode($section->permissions, true);
+		$sectionP = is_array($sectionP) ? $sectionP : [];
 
 		# get all user groups
 		$groups = db_json_decode($user->groups, true);
+		$groups = is_array($groups) ? $groups : [];
 
 		# default permission
 		$out = 0;
@@ -3089,6 +3092,7 @@ class Subnets extends Common_functions {
 			foreach ($subnets as $s) {
 				// to array
 				$s_old_perm = db_json_decode($s->permissions, true);
+				$s_old_perm = is_array($s_old_perm) ? $s_old_perm : [];
 				// removed
 				if (is_array($removed_permissions)) {
 					foreach ($removed_permissions as $k=>$p) unset($s_old_perm[$k]);


### PR DESCRIPTION
There are several placed I have discovered where you can submit invalid JSON using the phpIPAM API and cause the GUI to panic. For example, if you update the "permissions" key of a Section to something that's not JSON, you cause the "Administration > Sections" page to halt part way through.  Or, if you update the "permissions" key of a subnet to something that's not JSON, you get jQuery errors.

So, this PR is an attempt to make sure that when JSON is parsed, that the result ended up being an array.