### PR TITLE
Feature: Allow child subnet with same size as parent one.

### DIFF
--- a/api/controllers/Subnets.php
+++ b/api/controllers/Subnets.php
@@ -926,7 +926,10 @@ class Subnets_controller extends Common_api_functions {
 			else {
 				// not for folders
 				if(@$this->_params->isFolder!=1 && $master_subnet->isFolder!=1) {
-					if(!$this->Subnets->verify_subnet_nesting ($this->_params->masterSubnetId, $this->_params->subnet."/".$this->_params->mask))
+					$section = $this->Tools->fetch_object ("sections", "id", $this->_params->sectionId);
+					if($section===false) { $this->Response->throw_exception(400, "Invalid section Id"); }
+
+					if(!$this->Subnets->verify_subnet_nesting ($this->_params->masterSubnetId, $this->_params->subnet."/".$this->_params->mask, $section->sameSizeAllowed == 1))
 																									{ $this->Response->throw_exception(409, "Subnet is not within boundaries of its master subnet"); }
 				}
 				// set permissions
@@ -1025,7 +1028,7 @@ class Subnets_controller extends Common_api_functions {
 		    //disable checks for folders and if strict check enabled
 		    if($section->strictMode==1 && !$parent_is_folder ) {
 			    //verify that nested subnet is inside root subnet
-		        if (!$this->Subnets->verify_subnet_nesting($this->_params->masterSubnetId, $cidr)) 	{ $this->Response->throw_exception(409, "Nested subnet not in root subnet"); }
+		        if (!$this->Subnets->verify_subnet_nesting($this->_params->masterSubnetId, $cidr, $section->sameSizeAllowed == 1)) 	{ $this->Response->throw_exception(409, "Nested subnet not in root subnet"); }
 
 			    //nested?
 		        $overlap = $this->Subnets->verify_nested_subnet_overlapping($cidr, $this->_params->vrfId, $this->_params->masterSubnetId);

--- a/app/admin/sections/edit-result.php
+++ b/app/admin/sections/edit-result.php
@@ -101,6 +101,7 @@ else {
 					"name"             => $POST->name,
 					"description"      => $POST->description,
 					"strictMode"       => $POST->strictMode,
+					"sameSizeAllowed"  => $POST->sameSizeAllowed,
 					"subnetOrdering"   => $POST->subnetOrdering,
 					"showSubnet"       => $POST->showSubnet,
 					"showVLAN"         => $POST->showVLAN,

--- a/app/admin/sections/edit.php
+++ b/app/admin/sections/edit.php
@@ -99,6 +99,18 @@ if (!is_object($section)) {
 			</td>
 		</tr>
 
+		<!-- Allow same size -->
+		<tr>
+			<td><?php print _('Allow same size'); ?></td>
+			<td colspan="2">
+				<select name="sameSizeAllowed" class="input-small form-control input-sm input-w-auto pull-left" <?php if($POST->action=="delete") print 'disabled="disabled"'; ?>>
+					<option value="1"><?php print _('Yes'); ?></option>
+					<option value="0" <?php if($section->sameSizeAllowed == "0") print "selected='selected'"; ?>><?php print _('No'); ?></option>
+				</select>
+				<span class="help-inline info2"><?php print _('Yes allow create child subnet with the same size (address and mask) as parent. Usually when managing subnets from cloud provider.'); ?></span>
+			</td>
+		</tr>
+
 		<!-- Show Subnets -->
 		<tr>
 			<td><?php print _('Show subnet menu'); ?></td>

--- a/app/admin/sections/index.php
+++ b/app/admin/sections/index.php
@@ -49,7 +49,8 @@ if ($sections !== false) {
     <th><?php print _('Name'); ?></th>
     <th><?php print _('Description'); ?></th>
     <th><?php print _('Parent'); ?></th>
-    <th><?php print _('Strict mode'); ?></th>
+	<th><?php print _('Strict mode'); ?></th>
+    <th><?php print _('Allow same size'); ?></th>
     <th><?php print _('Show subnet menu'); ?></th>
     <th><?php print _('Show VLAN menu'); ?></th>
     <th><?php print _('Show VRF menu'); ?></th>
@@ -82,6 +83,9 @@ if(isset($sections_sorted)) {
 	    //strictMode
 	    $mode = $section['strictMode']==0 ? "<span class='badge badge1 badge5 alert-danger'>"._("No") : "<span class='badge badge1 badge5 alert-success'>"._("Yes");
 	    print '	<td>'. $mode .'</span></td>'. "\n";
+		//sameSizeAllowed
+	    $sameSizeAllowed = $section['sameSizeAllowed']==0 ? "<span class='badge badge1 badge5 alert-danger'>"._("No") : "<span class='badge badge1 badge5 alert-success'>"._("Yes");
+	    print '	<td>'. $sameSizeAllowed .'</span></td>'. "\n";
 	    //Show Subnets
 	    print " <td>";
 	    print @$section['showSubnet']==1 ? "<span class='badge badge1 badge5 alert-success'>"._("Yes") : "<span class='badge badge1 badge5 alert-danger'>"._("No");

--- a/app/admin/subnets/edit-result.php
+++ b/app/admin/subnets/edit-result.php
@@ -107,7 +107,7 @@ if ($POST->action=="add") {
 	    // we are adding nested subnet
 	    if($POST->masterSubnetId!=0) {
     	    //verify that nested subnet is inside its parent
-	        if (!$Subnets->verify_subnet_nesting($POST->masterSubnetId, $POST->cidr)) {
+	        if (!$Subnets->verify_subnet_nesting($POST->masterSubnetId, $POST->cidr, $section['sameSizeAllowed']==1)) {
 	            $errors[] = _('Nested subnet not in root subnet!');
 	        }
 	        else {
@@ -189,7 +189,7 @@ elseif ($POST->action=="edit") {
     	if ($parent_is_folder===false) {
     		/* verify that nested subnet is inside root subnet */
 	    	if($POST->masterSubnetId != 0) {
-		    	if (!$overlap = $Subnets->verify_subnet_nesting($POST->masterSubnetId, $POST->cidr)) {
+		    	if (!$overlap = $Subnets->verify_subnet_nesting($POST->masterSubnetId, $POST->cidr, $section['sameSizeAllowed'] == 1)) {
 		    		$errors[] = _('Nested subnet not in root subnet!');
 		    	}
 	    	}

--- a/app/subnets/mastersubnet-dropdown.php
+++ b/app/subnets/mastersubnet-dropdown.php
@@ -21,14 +21,14 @@ $User->check_user_session();
  * @param  array|string $result_fields
  * @return array
  */
-function get_strict_subnets($Subnets, $sectionId, $cidr, $result_fields="*") {
+function get_strict_subnets($Subnets, $sectionId, $cidr, $result_fields="*", $sameSizeAllowed=false) {
 	$strict_subnets = $Subnets->fetch_overlapping_subnets($cidr, 'sectionId', $sectionId, $result_fields);
 	if (!is_array($strict_subnets)) return array();
 
 	list(,$cidr_mask) = $Subnets->cidr_network_and_mask($cidr);
 
 	foreach ($strict_subnets as $i => $subnet) {
-		if ($subnet->mask >= $cidr_mask) unset($strict_subnets[$i]); else break;
+		if (($subnet->mask > $cidr_mask && $sameSizeAllowed) or ($subnet->mask == $cidr_mask && !$sameSizeAllowed)) unset($strict_subnets[$i]); else break;
 	}
 	return $strict_subnets;
 }
@@ -44,7 +44,7 @@ if (!is_object($section)) { return ''; }
 // Don't fetch all fields
 $fields = array('id','masterSubnetId','isFolder','subnet','mask','description');
 
-$strict_subnets = get_strict_subnets($Subnets, $sectionId, $cidr, $fields);
+$strict_subnets = get_strict_subnets($Subnets, $sectionId, $cidr, $fields, $section->sameSizeAllowed==1);
 
 $folders = $Subnets->fetch_section_subnets($sectionId, 'isFolder', '1', $fields);
 if (!is_array($folders)) $folders = array();

--- a/db/SCHEMA.sql
+++ b/db/SCHEMA.sql
@@ -132,6 +132,7 @@ CREATE TABLE `sections` (
   `masterSection` INT(11)  NULL  DEFAULT '0',
   `permissions` varchar(1024) DEFAULT NULL, /* __no_html_escape__ */
   `strictMode` BINARY(1)  NOT NULL  DEFAULT '1',
+  `sameSizeAllowed` BINARY(1)  NOT NULL  DEFAULT '0',
   `subnetOrdering` VARCHAR(16)  NULL  DEFAULT NULL,
   `order` INT(3)  NULL  DEFAULT NULL,
   `editDate` TIMESTAMP  NULL  ON UPDATE CURRENT_TIMESTAMP,
@@ -1081,5 +1082,5 @@ CREATE TABLE `nominatim_cache` (
 # Dump of table -- for autofix comment, leave as it is
 # ------------------------------------------------------------
 
-UPDATE `settings` SET `version` = "1.73";
-UPDATE `settings` SET `dbversion` = 43;
+UPDATE `settings` SET `version` = "1.74";
+UPDATE `settings` SET `dbversion` = 44;

--- a/functions/classes/class.Subnets.php
+++ b/functions/classes/class.Subnets.php
@@ -2376,7 +2376,7 @@ class Subnets extends Common_functions {
 	 * @param mixed $cidr
 	 * @return bool
 	 */
-	public function verify_subnet_nesting ($masterSubnetId, $cidr) {
+	public function verify_subnet_nesting ($masterSubnetId, $cidr, $sameSizeAllowed = false) {
 		//first get details for root subnet
 		$master_details = $this->fetch_subnet (null, $masterSubnetId);
 
@@ -2389,7 +2389,7 @@ class Subnets extends Common_functions {
 
 		// if child same as parent return error
 		if ($cidr == $this->transform_address($master_details->subnet)."/".$master_details->mask) {
-    		return false;
+    		return $sameSizeAllowed;
 		}
 		else {
     		//check
@@ -2438,7 +2438,7 @@ class Subnets extends Common_functions {
 					$parent_subnet = $this->fetch_subnet(null, $masterSubnetId);
 					if($parent_subnet->isFolder!=1) {
 						//check that new is inside its master subnet
-						if(!$this->verify_subnet_nesting ($parent_subnet->id, $this->transform_to_dotted($subnet)."/".$mask)) {
+						if(!$this->verify_subnet_nesting ($parent_subnet->id, $this->transform_to_dotted($subnet)."/".$mask, $section->sameSizeAllowed=="1")) {
 							$this->Result->show("danger", _("New subnet not in master subnet")."!", true);
 						}
 						// it cannot be same !

--- a/functions/upgrade_queries/upgrade_queries_1.7.php
+++ b/functions/upgrade_queries/upgrade_queries_1.7.php
@@ -68,3 +68,7 @@ $upgrade_queries["1.72.43"][] = "UPDATE `settings` set `version` = '1.72';";
 $upgrade_queries["1.73.43"]   = [];
 $upgrade_queries["1.73.43"][] = "-- Version update";
 $upgrade_queries["1.73.43"][] = "UPDATE `settings` set `version` = '1.73';";
+
+$upgrade_queries["1.74.44"]   = [];
+$upgrade_queries["1.74.44"][] = "ALTER TABLE `sections` ADD `sameSizeAllowed` BINARY(1)  NOT NULL  DEFAULT '0'  AFTER `strictMode`;";
+$upgrade_queries["1.74.44"][] = "UPDATE `settings` set `version` = '1.74';";

--- a/functions/version.php
+++ b/functions/version.php
@@ -1,8 +1,8 @@
 <?php
 /* set latest version */
-define("VERSION", "1.73");									//decimal release version e.g 1.32
+define("VERSION", "1.74");									//decimal release version e.g 1.32
 /* set latest version */
-define("VERSION_VISIBLE", "1.7.3");							//visible version in footer e.g 1.3.2
+define("VERSION_VISIBLE", "1.7.4");							//visible version in footer e.g 1.3.2
 /* set latest revision */
 define("REVISION", "001");									//increment on static content changes (js/css) or point releases to avoid caching issues
 /* set last possible upgrade */


### PR DESCRIPTION
This PR is to address lack of creating child subnet with same size as master.

In some cases, subnet with same size as parent should be allowed. This use case can be applied when managing cloud network where you have one virtual network and one subnet in this network with the same size

changes:
- add new option `Allow same size` to section entity
- if this option is enabled master subent validation and overlap validation will allow subnet with same size as master in strict mode

Fixes:
- #4440 