### PR TITLE
Fix: PHP 8 compatibility for search

### DIFF
--- a/functions/classes/class.Tools.php
+++ b/functions/classes/class.Tools.php
@@ -214,7 +214,7 @@ class Tools extends Common_functions {
 	 */
 	private function search_subnets_range ($search_term, $high, $low, $custom_fields = array()) {
 		# reformat low/high
-		if($high==0 && $low==0)	{ $high = "1"; $low = "1"; }
+		if($high=="" && $low=="")	{ $high = "1"; $low = "1"; }
 
 		# set search query
 		$query[] = "select * from `subnets` where `description` like :search_term ";


### PR DESCRIPTION
This PR fixes a behavior change with PHP 8+.

The variables $high and $low have an empty string (https://github.com/phpipam/phpipam/blob/v1.7.3/functions/classes/class.Tools.php#L131) as their default value, so I suggest a correction with an equivalent if statement.

More information in issue #4476

Fixes:
- #4476