### PR TITLE
Use same charset as in SCHEMA.sql when adding a custom field

### DIFF
--- a/functions/classes/class.Admin.php
+++ b/functions/classes/class.Admin.php
@@ -711,7 +711,7 @@ class Admin extends Common_functions {
 	    $field['fieldDefault'] = is_blank($field['fieldDefault']) ? NULL : $field['fieldDefault'];
 
 	    # character set if needed
-	    if($field['fieldType']=="varchar" || $field['fieldType']=="text" || $field['fieldType']=="set" || $field['fieldType']=="enum")	{ $charset = "CHARACTER SET utf8mb4"; }
+	    if($field['fieldType']=="varchar" || $field['fieldType']=="text" || $field['fieldType']=="set" || $field['fieldType']=="enum")	{ $charset = "CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci"; }
 	    else																															{ $charset = ""; }
 
 	    # escape fields


### PR DESCRIPTION
When creating a custom field, another charset is used (utf8mb4_0900_ai_ci). This patch extends the class.Admin.php to use the same charset as in SCHEMA.sql