### PR TITLE
Remove environment variable "LANGUAGE" for windows compatibility

### DIFF
--- a/functions/global_functions.php
+++ b/functions/global_functions.php
@@ -156,11 +156,7 @@ function set_ui_language($default_lang = null) {
 			continue;
 
 		putenv("LC_ALL=".$lang);
-
-		// https://help.ubuntu.com/community/EnvironmentVariables
-		// Unlike "LANG" and "LC_*", "LANGUAGE" should not be assigned a complete locale name including the encoding part (e.g. ".UTF-8").
 		putenv("LANG=".$lang);
-		putenv("LANGUAGE=".preg_replace("/\.utf-?8/i", "", $lang));
 
 		setlocale(LC_ALL, $lang);
 


### PR DESCRIPTION
Translation with Windows IIS as webserver does only work when I remove the "LANGUAGE" environment variable.
It seems that the other both "putenv" are also not necessary