### PR TITLE
Publish GET method for API OPTIONS request

### DIFF
--- a/api/controllers/Addresses.php
+++ b/api/controllers/Addresses.php
@@ -62,7 +62,8 @@ class Addresses_controller extends Common_api_functions  {
 		// methods
 		$result = array();
 		$result['methods'] = array(
-								array("href"=>"/api/".$this->_params->app_id."/addresses/", 	"methods"=>array(array("rel"=>"options", "method"=>"OPTIONS"))),
+								array("href"=>"/api/".$this->_params->app_id."/addresses/", 	"methods"=>array(array("rel"=>"options","method"=>"OPTIONS"),
+																												 array("rel"=>"read",	"method"=>"GET"))),
 								array("href"=>"/api/".$this->_params->app_id."/addresses/{id}/","methods"=>array(array("rel"=>"read", 	"method"=>"GET"),
 																												 array("rel"=>"create", "method"=>"POST"),
 																												 array("rel"=>"update", "method"=>"PATCH"),

--- a/api/controllers/Circuits.php
+++ b/api/controllers/Circuits.php
@@ -95,12 +95,13 @@ class Circuits_controller extends Common_api_functions {
 
 		// methods
 		$result['methods'] = array(
-								array("href"=>"/api/".$this->_params->app_id."/circuits/", 					"methods"=>array(array("rel"=>"options", "method"=>"OPTIONS"))),
+								array("href"=>"/api/".$this->_params->app_id."/circuits/", 					"methods"=>array(array("rel"=>"options","method"=>"OPTIONS"),
+																															 array("rel"=>"read",	"method"=>"GET"))),
 								array("href"=>"/api/".$this->_params->app_id."/circuits/{id}/", 			"methods"=>array(array("rel"=>"read", 	"method"=>"GET"),
 																												 			 array("rel"=>"create", "method"=>"POST"),
 																												 			 array("rel"=>"update", "method"=>"PATCH"),
 																												 			 array("rel"=>"delete", "method"=>"DELETE"))),
-								array("href"=>"/api/".$this->_params->app_id."/circuits/providers/", 		"methods"=>array(array("rel"=>"options", "method"=>"OPTIONS"))),
+								array("href"=>"/api/".$this->_params->app_id."/circuits/providers/", 		"methods"=>array(array("rel"=>"options","method"=>"OPTIONS"))),
 								array("href"=>"/api/".$this->_params->app_id."/circuits/providers/{id}/", 	"methods"=>array(array("rel"=>"read", 	"method"=>"GET"),
 																												 			 array("rel"=>"create", "method"=>"POST"),
 																												 			 array("rel"=>"update", "method"=>"PATCH"),

--- a/api/controllers/Devices.php
+++ b/api/controllers/Devices.php
@@ -58,7 +58,8 @@ class Devices_controller extends Common_api_functions {
         // methods
         $result = array();
         $result['methods'] = array(
-                                array("href"=>"/api/".$this->_params->app_id."/devices/",                     "methods"=>array(array("rel"=>"options", "method"=>"OPTIONS"))),
+                                array("href"=>"/api/".$this->_params->app_id."/devices/",                     "methods"=>array(array("rel"=>"options","method"=>"OPTIONS"),
+                                                                                                                               array("rel"=>"read",	  "method"=>"GET"))),
                                 array("href"=>"/api/".$this->_params->app_id."/devices/search/{search_term}", "methods"=>array(array("rel"=>"search", "method"=>"GET"))),
                                 array("href"=>"/api/".$this->_params->app_id."/devices/{id}/",                "methods"=>array(array("rel"=>"read", "method"=>"GET"),
                                                                                                                                array("rel"=>"create", "method"=>"POST"),

--- a/api/controllers/L2domains.php
+++ b/api/controllers/L2domains.php
@@ -47,7 +47,8 @@ class L2domains_controller extends Common_api_functions {
 		// methods
 		$result = array();
 		$result['methods'] = array(
-								array("href"=>"/api/l2domains/".$this->_params->app_id."/", 		"methods"=>array(array("rel"=>"options", "method"=>"OPTIONS"))),
+								array("href"=>"/api/l2domains/".$this->_params->app_id."/", 		"methods"=>array(array("rel"=>"options","method"=>"OPTIONS"),
+																													 array("rel"=>"read",	"method"=>"GET"))),
 								array("href"=>"/api/l2domains/".$this->_params->app_id."/{id}/", 	"methods"=>array(array("rel"=>"read", 	"method"=>"GET"),
 																												 	array("rel"=>"create", "method"=>"POST"),
 																												 	array("rel"=>"update", "method"=>"PATCH"),

--- a/api/controllers/Nat.php
+++ b/api/controllers/Nat.php
@@ -118,7 +118,8 @@ class Nat_controller extends Common_api_functions {
         // methods
         $result = array();
         $result['methods'] = array(
-            array("href"=>"/api/".$this->_params->app_id."/nat/",       "methods"=>array(array("rel"=>"options", "method"=>"OPTIONS"))),
+            array("href"=>"/api/".$this->_params->app_id."/nat/",       "methods"=>array(array("rel"=>"options", "method"=>"OPTIONS"),
+                                                                                         array("rel"=>"read",    "method"=>"GET"))),
             array("href"=>"/api/".$this->_params->app_id."/nat/{id}/",  "methods"=>array(array("rel"=>"read",    "method"=>"GET"),
                                                                                          array("rel"=>"create",  "method"=>"POST"),
                                                                                          array("rel"=>"update",  "method"=>"PATCH"),

--- a/api/controllers/Prefix.php
+++ b/api/controllers/Prefix.php
@@ -354,7 +354,8 @@ class Prefix_controller extends Common_api_functions {
         // methods
         $result = array();
         $result['methods'] = array(
-                                array("href"=>"/api/".$this->_params->app_id."/sections/",      "methods"=>array(array("rel"=>"options","method"=>"OPTIONS"))),
+                                array("href"=>"/api/".$this->_params->app_id."/sections/",      "methods"=>array(array("rel"=>"options","method"=>"OPTIONS"),
+                                                                                                                 array("rel"=>"read",   "method"=>"GET"))),
                                 array("href"=>"/api/".$this->_params->app_id."/sections/{id}/", "methods"=>array(array("rel"=>"read",   "method"=>"GET"),
                                                                                                                  array("rel"=>"create", "method"=>"POST")))
                             );

--- a/api/controllers/Sections.php
+++ b/api/controllers/Sections.php
@@ -45,7 +45,8 @@ class Sections_controller extends Common_api_functions {
 		// methods
 		$result = array();
 		$result['methods'] = array(
-								array("href"=>"/api/".$this->_params->app_id."/sections/", 			"methods"=>array(array("rel"=>"options", "method"=>"OPTIONS"))),
+								array("href"=>"/api/".$this->_params->app_id."/sections/", 			"methods"=>array(array("rel"=>"options","method"=>"OPTIONS"),
+																													 array("rel"=>"read",	"method"=>"GET"))),
 								array("href"=>"/api/".$this->_params->app_id."/sections/{id}/", 	"methods"=>array(array("rel"=>"read", 	"method"=>"GET"),
 																													 array("rel"=>"create", "method"=>"POST"),
 																													 array("rel"=>"update", "method"=>"PATCH"),

--- a/api/controllers/Subnets.php
+++ b/api/controllers/Subnets.php
@@ -55,7 +55,8 @@ class Subnets_controller extends Common_api_functions {
 		// methods
 		$result = array();
 		$result['methods'] = array(
-								array("href"=>"/api/".$this->_params->app_id."/subnets/", 		"methods"=>array(array("rel"=>"options", "method"=>"OPTIONS"))),
+								array("href"=>"/api/".$this->_params->app_id."/subnets/", 		"methods"=>array(array("rel"=>"options", "method"=>"OPTIONS"),
+																												 array("rel"=>"read",	 "method"=>"GET"))),
 								array("href"=>"/api/".$this->_params->app_id."/subnets/{id}/", 	"methods"=>array(array("rel"=>"read", 	"method"=>"GET"),
 																												 array("rel"=>"create", "method"=>"POST"),
 																												 array("rel"=>"update", "method"=>"PATCH"),

--- a/api/controllers/Vlans.php
+++ b/api/controllers/Vlans.php
@@ -55,7 +55,8 @@ class Vlans_controller extends Common_api_functions {
 
 		// methods
 		$result['methods'] = array(
-								array("href"=>"/api/".$this->_params->app_id."/vlans/", 		"methods"=>array(array("rel"=>"options", "method"=>"OPTIONS"))),
+								array("href"=>"/api/".$this->_params->app_id."/vlans/", 		"methods"=>array(array("rel"=>"options","method"=>"OPTIONS"),
+																												 array("rel"=>"read",	"method"=>"GET"))),
 								array("href"=>"/api/".$this->_params->app_id."/vlans/{id}/", 	"methods"=>array(array("rel"=>"read", 	"method"=>"GET"),
 																												 array("rel"=>"create", "method"=>"POST"),
 																												 array("rel"=>"update", "method"=>"PATCH"),

--- a/api/controllers/Vrfs.php
+++ b/api/controllers/Vrfs.php
@@ -46,7 +46,8 @@ class Vrfs_controller extends Common_api_functions {
 
 		// methods
 		$result['methods'] = array(
-								array("href"=>"/api/".$this->_params->app_id."/vrfs/", 		"methods"=>array(array("rel"=>"options", "method"=>"OPTIONS"))),
+								array("href"=>"/api/".$this->_params->app_id."/vrfs/", 		"methods"=>array(array("rel"=>"options","method"=>"OPTIONS"),
+																											 array("rel"=>"read",	"method"=>"GET"))),
 								array("href"=>"/api/".$this->_params->app_id."/vrfs/{id}/", "methods"=>array(array("rel"=>"read", 	"method"=>"GET"),
 																											 array("rel"=>"create", "method"=>"POST"),
 																											 array("rel"=>"update", "method"=>"PATCH"),


### PR DESCRIPTION
An OPTIONS request for an API root should include the GET option which provides a list of all objects of that type. This patch publishes the GET option for the identifiers that support object lists.