### PR TITLE
Fix: PHP was throwing Undefined array key warnings

### DIFF
--- a/app/subnets/scan/subnet-scan-execute-scan-snmp-arp.php
+++ b/app/subnets/scan/subnet-scan-execute-scan-snmp-arp.php
@@ -47,6 +47,11 @@ $devices_used = $Tools->fetch_multiple_objects ("devices", "snmp_queries", "%get
 # filter out not in this section
 if ($devices_used !== false) {
     foreach ($devices_used as $d) {
+        // Check if the 'ip' key exists and is not null
+        if (!isset($r['ip'])) {
+            // Skip to the next iteration of the loop
+            continue;
+        }
         // get possible sections
         $permitted_sections = pf_explode(";", $d->sections);
         // check

--- a/functions/classes/class.Log.php
+++ b/functions/classes/class.Log.php
@@ -1423,7 +1423,7 @@ class Logging extends Common_functions {
 
 		// loop
 		$val = array();
-		if(is_array($this->object_new['permissions'])) {
+		if(isset($this->object_new['permissions']) && is_array($this->object_new['permissions'])) {
 			foreach($this->object_new['permissions'] as $group_id=>$p) {
 				$val[] = $groups[$group_id]['g_name'] ." : ".$this->Subnets->parse_permissions($p);
 			}


### PR DESCRIPTION
Fixed Undefined array key warnings by adding _isset()_ checks to ensure the keys exist before they are accessed.