### PR TITLE
Fix: Define subnet_ip_addresses in case no IPs are pulled

### DIFF
--- a/app/subnets/scan/subnet-scan-execute-scan-snmp-arp.php
+++ b/app/subnets/scan/subnet-scan-execute-scan-snmp-arp.php
@@ -27,6 +27,7 @@ if($Subnets->check_permission ($User->user, $POST->subnetId) != 3) 	{ $Result->s
 
 # set class
 $Snmp = new phpipamSNMP ();
+$subnet_ip_addresses = array();
 
 // fetch all existing hosts
 $all_subnet_hosts = (array) $Addresses->fetch_subnet_addresses ($POST->subnetId);


### PR DESCRIPTION
Defined subnet_ip_addresses in case no IPs are pulled.

Fixes Issue:
jQuery error when running an SNMP ARP discovery scan #3990 