### PR TITLE
Fix: Added LINEFEED when resolve_verbose is true

### DIFF
--- a/functions/scripts/resolveIPaddresses.php
+++ b/functions/scripts/resolveIPaddresses.php
@@ -98,6 +98,6 @@ if (is_array($ipaddresses)) {
 
 # if verbose print result so it can be emailed via cron!
 if($config['resolve_verbose'] == true && isset($res)) {
-	print implode("\n", $res);
+	print implode("\n", $res)."\n";
 }
 ?>


### PR DESCRIPTION
**Describe the bug**
With setting `resolve_verbose=true` resolveIPaddresses.php outputs a list of updated ip addresses. The bug is, that the last log line is not terminated by LINEFEED. This causes issues if piping the output to another process.

Added LINEFEED when resolve_verbose is true. Thanks to [Wiimm](https://github.com/Wiimm).

Fixes Issue: #4508