### PR TITLE
Fix: Line warnings 230 and 252 in app/subnets/scan/subnet-scan-execute-snmp-route-all.php

### DIFF
--- a/app/subnets/scan/subnet-scan-execute-snmp-route-all.php
+++ b/app/subnets/scan/subnet-scan-execute-snmp-route-all.php
@@ -227,7 +227,7 @@ else {
                         	foreach($permitted_domains as $d) {
                         		//more than default
                     			print "<optgroup label='".$d['domain']->name."'>";
-                    			if($d['vlans'][0]!==null) {
+                    			if(!empty($d['vlans']) && is_array($d['vlans'])) {
                     				foreach($d['vlans'] as $v) {
                     					// set print
                     					$printVLAN = $v->number;
@@ -249,7 +249,7 @@ else {
                             //blank
                             print '<option disabled="disabled">'._('Select VRF').'</option>';
                             print '<option value="0">'._('None').'</option>';
-                            if($vrfs!=false) {
+                            if(!empty($vrfs)) {
                     	        foreach($vrfs as $vrf) {
                         	        // set permitted
                         	        $permitted_sections = pf_explode(";", $vrf->sections);


### PR DESCRIPTION
**Warning:** [06-Nov-2025 23:02:35 UTC] PHP Warning:  Trying to access array offset on value of type bool in /var/www/phpipam/app/subnets/scan/subnet-scan-execute-snmp-route-all.php on line 230

## Here's why this new line of code works and is safer:
- `!empty($d['vlans'])`: The empty() function in PHP checks if a variable is empty. It returns true for false, null, an empty string, an empty array, and the number 0.
- `is_array($d['vlans'])`: This function explicitly checks if the variable is an array. While !empty() often suffices, adding is_array() makes the code more robust by ensuring that you are only proceeding if you are working with the expected data type. This prevents potential issues if $d['vlans'] were to be a non-empty value that is not an array (like a string or a number).

**Warning:** [06-Nov-2025 23:02:35 UTC] PHP Warning:  Undefined variable $vrfs in /var/www/phpipam/app/subnets/scan/subnet-scan-execute-snmp-route-all.php on line 252

## Here is why this is the correct solution:
- **Handles Undefined Variables:** The empty() construct does not throw a warning if the variable doesn't exist. It will simply return true (meaning the variable is "empty"), and the if condition will correctly evaluate to false.
- **Checks for "Falsey" Values:** The !empty() check will also correctly handle the case where $vrfs is explicitly set to false, null, or an empty array []. In all of these scenarios, the foreach loop should not run, and this new condition prevents it.