### PR TITLE
Fix: line 57 for undefined $q, also changed wording for consistency.

### DIFF
--- a/app/subnets/scan/subnet-scan-execute-snmp-route-all.php
+++ b/app/subnets/scan/subnet-scan-execute-snmp-route-all.php
@@ -54,14 +54,14 @@ foreach ($devices_used as $d) {
        // remove those not in subnet
        if (sizeof($res)>0) {
            // save for debug
-           $debug[$d->hostname][$q] = $res;
+           $debug[$d->hostname]["get_routing_table"] = $res;
 
            // save result
-           $found[$d->id]["get_vlan_table"] = $res;
+           $found[$d->id]["get_routing_table"] = $res;
         }
     } catch (Exception $e) {
        // save for debug
-       $debug[$d->hostname]["get_vlan_table"] = $res ?? null;
+       $debug[$d->hostname]["get_routing_table"] = $res ?? null;
 
        $errors[] = $e->getMessage();
 	}


### PR DESCRIPTION
**Warning:** [07-Nov-2025 17:44:47 UTC] PHP Warning:  Undefined variable $q in /var/www/phpipam/app/subnets/scan/subnet-scan-execute-snmp-route-all.php on line 57

### Summary
*   Fixed line 57 for undefined $q warning.
*   **Does the word matter?** For the logic of the `foreach` loop, **no**. For writing clear, maintainable code, **yes, absolutely**.
*   Changed `"get_vlan_table"` to `"get_routing_table"` to accurately reflect the data being stored.
*   The second loop still works because `foreach ($device as $query_result)` iterates over the *values* of the `$device` array, regardless of what the keys are named. (So no change in code)