### PR TITLE
Bugfix: Prepopulate the "name" field of the powerDNS "Record Edit" form, fixes #4363

### DIFF
--- a/app/admin/powerDNS/record-edit.php
+++ b/app/admin/powerDNS/record-edit.php
@@ -44,6 +44,10 @@ else {
 	// from IP table
 	// we provide record hostname and strip domain from it
 	if (!is_numeric($POST->domain_id) && !is_numeric($POST->id)) {
+		// Keep a copy of the textual $POST->domain_id, before it's dereferenced into
+		// a numeric idetifier, so that we can prepopulate the "Name" edit field.
+		$POST->name = $POST->domain_id;
+
 		// fetch all domains
 		$all_domains = $PowerDNS->fetch_all_domains ();
 		if ($all_domains!==false) {
@@ -82,6 +86,7 @@ else {
 		}
 		else {
 			$record = new Params ();
+			$record->name = $POST->name;
 			$record->ttl = (isset($pdns->ttl) && $pdns->ttl > 0) ? $pdns->ttl : 3600;
 			$record->content = $POST->id;
 		}

--- a/app/admin/powerDNS/record-edit.php
+++ b/app/admin/powerDNS/record-edit.php
@@ -86,9 +86,9 @@ else {
 		}
 		else {
 			$record = new Params ();
-			$record->name = $POST->name;
+			$record->name = escape_input($POST->name);
 			$record->ttl = (isset($pdns->ttl) && $pdns->ttl > 0) ? $pdns->ttl : 3600;
-			$record->content = $POST->id;
+			$record->content = escape_input($POST->id);
 		}
 	}
 }
@@ -99,7 +99,7 @@ $domain!==false ? : $Result->show("danger", _("Invalid ID"), true, true);
 
 // default
 if (!isset($record)) {
-	$record = new StdClass ();
+	$record = new Params ();
 	$record->ttl = (isset($pdns->ttl) && $pdns->ttl > 0) ? $pdns->ttl : 3600;
 	$record->name = $domain->name;
 }


### PR DESCRIPTION
Resolve a regression in behaviour introduced by d3d51b6e02285846cef979fcc5a2661626a76d2d that caused the "Name" field of the powerDS "Record Edit" form to no longer be prepoluated with the value in the POST variable "domain_id".

Fixes #4363 