### PR TITLE
Avoid 'Attempt to read property "name" on bool' warning for location

### DIFF
--- a/app/subnets/addresses/print-address-table.php
+++ b/app/subnets/addresses/print-address-table.php
@@ -471,7 +471,7 @@ else {
 			    # print location
 			    if(in_array('location', $selected_ip_fields) && $User->get_module_permissions ("locations")>=User::ACCESS_R) {
 			    	$location_name = $Tools->fetch_object("locations", "id", $addresses[$n]->location);
-			    	print "<td class='hidden-xs hidden-sm hidden-md'>".$location_name->name."</td>";
+			    	print $location_name===false ? "<td></td>" : "<td class='hidden-xs hidden-sm hidden-md'>".$location_name->name."</td>";
 			    }
 
 				# print owner


### PR DESCRIPTION
app/subnets/addresses/print-address-table.php does not check that the returned location from $Tools->fetch_object is not false.

Added a ternary check similar to the one for customers just below.