### PR TITLE
Remove useless prefix in admin bind username

### DIFF
--- a/app/admin/users/ad-search-result.php
+++ b/app/admin/users/ad-search-result.php
@@ -96,11 +96,11 @@ if(!isset($userinfo['count'])) {
 		foreach($userinfo as $u) {
 			print "<tr>";
 			print "	<td>".escape_input($u['displayname'][0])."</td>";
-			print "	<td>".escape_input($u['samaccountname'][0])."</td>";
+			print "	<td>".escape_input($esc_dname)."</td>";
 			print "	<td>".escape_input($u['mail'][0])."</td>";
 			//actions
 			print " <td style='width:10px;'>";
-			print "		<a href='' class='btn btn-sm btn-default btn-success userselect' data-uname='".escape_input($u['displayname'][0])."' data-username='".escape_input($u['samaccountname'][0])."' data-email='".escape_input($u['mail'][0])."' data-server='".escape_input($POST->server)."' data-server-type='".$server->type."'>"._('Select')."</a>";
+			print "		<a href='' class='btn btn-sm btn-default btn-success userselect' data-uname='".escape_input($u['displayname'][0])."' data-username='".escape_input($esc_dname)."' data-email='".escape_input($u['mail'][0])."' data-server='".escape_input($POST->server)."' data-server-type='".$server->type."'>"._('Select')."</a>";
 			print "	</td>";
 			print "</tr>";
 		}

--- a/functions/adLDAP/src/adLDAP.php
+++ b/functions/adLDAP/src/adLDAP.php
@@ -727,7 +727,7 @@ class adLDAP {
         $ret = true;
 
         //OpenLDAP?
-        if ($this->openLDAP == true) { $this->ldapBind = @ldap_bind($this->ldapConnection, "uid=".$username.$this->accountSuffix, $password); }
+        if ($this->openLDAP == true) { $this->ldapBind = @ldap_bind($this->ldapConnection, $username.$this->accountSuffix, $password); }
         else { $this->ldapBind = @ldap_bind($this->ldapConnection, $username.$this->accountSuffix, $password); }
 
         if (!$this->ldapBind) {


### PR DESCRIPTION
1. When using openLDAP the "uid" prefix is already set inside "$username.$this->accountSuffix" variable so it is unnecessary to add it twice. This fix solves the problem of the research when trying to reach the following form: Administration -> Users -> Create User -> Enter username. Applying this small change will allow to search the user on openLDAP using the correct admin bind user.

3. When Admin searches an LDAP user to be added it may happen, with some not standard server configurations, that the proposed username in the following form (after the search) will not be populated because it is looking for the 'samaccountname' variable which is not always clearly declared in the $userinfo. It should be better directly to give to the next form the username used in the previous research, which is stored in $esc_dname.
