### PR TITLE
Move PHP filtering calls to the SQL layer

### DIFF
--- a/api/controllers/Addresses.php
+++ b/api/controllers/Addresses.php
@@ -102,8 +102,8 @@ class Addresses_controller extends Common_api_functions  {
 	public function GET () {
 		// all
 		if (!isset($this->_params->id) || $this->_params->id == "all") {
-			// fetch all
-			$result = $this->Addresses->fetch_all_objects ("ipaddresses");
+			// fetch all - apply filter at SQL level when possible
+			$result = $this->fetch_all_with_filter("ipaddresses");
 			// check result
 			if ($result===false)						{ $this->Response->throw_exception(500, "Unable to read addresses"); }
 			else										{ return array("code"=>200, "data"=>$this->prepare_result($result, "addresses", true, true)); }
@@ -131,21 +131,11 @@ class Addresses_controller extends Common_api_functions  {
 		}
 		// address search inside predefined subnet
 		elseif($this->Tools->validate_ip ($this->_params->id)!==false && isset($this->_params->id2)) {
-            // fetch all in subnet
-            $result = $this->Tools->fetch_multiple_objects ("ipaddresses", "subnetId", $this->_params->id2);
-            if($result!==false) {
-            	$result_filtered = "";
-                foreach ($result as $k=>$r) {
-                    if($r->ip !== $this->_params->id) {
-                        unset($result[$k]);
-                    }
-                    else {
-                        $result_filtered = $r;
-                    }
-                }
-                if(sizeof($result)==0)  { $result = false;  }
-                else                    { $result = $result_filtered; }
-            }
+            // query by both subnetId and ip_addr directly using the unique key
+            $ip_decimal = $this->Subnets->transform_address($this->_params->id, "decimal");
+            $result = $this->Database->getObjectQuery("ipaddresses",
+                "SELECT * FROM `ipaddresses` WHERE `subnetId` = ? AND `ip_addr` = ? LIMIT 1",
+                array($this->_params->id2, $ip_decimal));
     		if ($result==false)                          { $this->Response->throw_exception(404, 'No addresses found'); }
             else                                         { return array("code"=>200, "data"=>$result); }
 		}
@@ -155,25 +145,14 @@ class Addresses_controller extends Common_api_functions  {
 			if (@$this->_params->id3=="addresses") {
 				// validate
 				$this->validate_tag ();
-				// fetch
-				$result = $this->Tools->fetch_multiple_objects ("ipaddresses", "state", $this->_params->id2);
-
-				// filter by subnetId
-				if ($result!==false) {
-					if(isset($this->_params->subnetId)) {
-						if (is_numeric($this->_params->subnetId)) {
-							// filter
-							foreach ($result as $k=>$v) {
-								if ($v->subnetId != $this->_params->subnetId) {
-									unset($result[$k]);
-								}
-							}
-							// any left
-							if (sizeof($result)==0) {
-								$result = false;
-							}
-						}
-					}
+				// fetch - use SQL filter when subnetId is provided
+				if(isset($this->_params->subnetId) && is_numeric($this->_params->subnetId)) {
+					$result = $this->Database->getObjectsQuery("ipaddresses",
+						"SELECT * FROM `ipaddresses` WHERE `state` = ? AND `subnetId` = ? ORDER BY `ip_addr`",
+						array($this->_params->id2, $this->_params->subnetId));
+					$result = (is_array($result) && sizeof($result) > 0) ? $result : false;
+				} else {
+					$result = $this->Tools->fetch_multiple_objects ("ipaddresses", "state", $this->_params->id2);
 				}
 
 				// result
@@ -426,21 +405,15 @@ class Addresses_controller extends Common_api_functions  {
 	public function DELETE () {
     	// delete by ip
     	if ($this->Tools->validate_ip ($this->_params->id)!==false && isset($this->_params->id2)) {
-        	// find
-        	$result = $this->Tools->fetch_multiple_objects ("ipaddresses", "ip_addr", $this->Tools->transform_address($this->_params->id, "decimal"));
-        	if($result!==false) {
-            	foreach ($result as $k=>$r) {
-                	if($r->subnetId != $this->_params->id2) {
-                    	unset($result[$k]);
-                	}
-            	}
-        	}
-        	if (sizeof($result)==0 || $result===false)   { $this->Response->throw_exception(404, "No addresses found"); }
+        	// find by both ip_addr and subnetId using unique key
+        	$ip_decimal = $this->Tools->transform_address($this->_params->id, "decimal");
+        	$result = $this->Database->getObjectQuery("ipaddresses",
+        		"SELECT * FROM `ipaddresses` WHERE `ip_addr` = ? AND `subnetId` = ? LIMIT 1",
+        		array($ip_decimal, $this->_params->id2));
+        	if ($result===false || $result===null) { $this->Response->throw_exception(404, "No addresses found"); }
         	else {
-            	// rekey
-            	$result = array_values($result);
             	// replace parameters
-            	$this->_params->id = $result[0]->id;
+            	$this->_params->id = $result->id;
         	}
     	}
 

--- a/api/controllers/Common.php
+++ b/api/controllers/Common.php
@@ -84,6 +84,14 @@ class Common_api_functions {
      */
     public $custom_fields;
 
+    /**
+     * Flag indicating filter was already applied at SQL level
+     *
+     * @var bool
+     * @access protected
+     */
+    protected $filter_applied = false;
+
 	/**
 	 * valid_keys
 	 *
@@ -324,8 +332,10 @@ class Common_api_functions {
 								{ $result = $this->add_links ($result, $controller); }
 			}
 		}
-		// filter
-		if (isset($this->_params->filter_by)) {
+		// filter - skip if already applied at SQL level
+		$filter_applied = $this->filter_applied;
+		$this->filter_applied = false;
+		if (isset($this->_params->filter_by) && !$filter_applied) {
 								{ $result = $this->filter_result ($result); }
 		}
 		// transform address
@@ -433,6 +443,130 @@ class Common_api_functions {
 			if (($last_err = preg_last_error()) != PREG_NO_ERROR)
 				$this->Response->throw_exception(400, _('Invalid regular expression')." (err=$last_err)");
 		}
+	}
+
+	/**
+	 * Converts a PCRE regex pattern (with delimiters) to a MySQL REGEXP pattern.
+	 *
+	 * @access protected
+	 * @param string $pcre_pattern
+	 * @return string|false  MySQL-compatible pattern, or false on failure
+	 */
+	protected function pcre_to_mysql_regexp($pcre_pattern) {
+		if (!is_string($pcre_pattern) || strlen($pcre_pattern) < 2)
+			return false;
+
+		$delimiter = $pcre_pattern[0];
+
+		// Validate delimiter is non-alphanumeric
+		if (ctype_alnum($delimiter) || $delimiter === '\\')
+			return false;
+
+		$last_pos = strrpos($pcre_pattern, $delimiter, 1);
+		if ($last_pos === false)
+			return false;
+
+		$pattern = substr($pcre_pattern, 1, $last_pos - 1);
+
+		// Unescape the delimiter within the pattern
+		$pattern = str_replace('\\' . $delimiter, $delimiter, $pattern);
+
+		return $pattern;
+	}
+
+	/**
+	 * Builds SQL WHERE condition from API filter parameters.
+	 *
+	 * Returns [null, []] if SQL-level filtering cannot be applied,
+	 * allowing PHP filter_result to handle it as fallback.
+	 *
+	 * Supports filter_match modes: full (=), partial (LIKE), regex (REGEXP).
+	 *
+	 * @access protected
+	 * @return array  [$where_sql, $params] or [null, []]
+	 */
+	protected function build_sql_filter_condition() {
+		if (!isset($this->_params->filter_by))
+			return [null, []];
+
+		if (!isset($this->_params->filter_value) || is_blank($this->_params->filter_value))
+			return [null, []];
+
+		if (!isset($this->_params->filter_match))
+			$this->_params->filter_match = 'full';
+
+		if (!in_array($this->_params->filter_match, ['full', 'partial', 'regex']))
+			return [null, []];
+
+		// Reverse-map API field name to DB column name
+		// Base mapping (same as remap_keys with $controller=false)
+		$reverse_keys = array("deviceId"=>"switch", "tag"=>"state", "ip"=>"ip_addr");
+		$filter_by = $this->_params->filter_by;
+		$db_column = isset($reverse_keys[$filter_by]) ? $reverse_keys[$filter_by] : $filter_by;
+
+		// Validate column exists in valid_keys
+		if (!is_array($this->valid_keys) || !in_array($db_column, $this->valid_keys))
+			return [null, []];
+
+		$db_column_escaped = $this->Database->escape($db_column);
+		if (is_blank($db_column_escaped))
+			return [null, []];
+
+		$filter_value = $this->_params->filter_value;
+
+		if ($this->_params->filter_match == 'full') {
+			return ["`$db_column_escaped` = ?", [$filter_value]];
+		} elseif ($this->_params->filter_match == 'partial') {
+			return ["`$db_column_escaped` LIKE ?", ['%' . $filter_value . '%']];
+		} elseif ($this->_params->filter_match == 'regex') {
+			$mysql_pattern = $this->pcre_to_mysql_regexp($filter_value);
+			if ($mysql_pattern === false)
+				return [null, []];
+			return ["`$db_column_escaped` REGEXP ?", [$mysql_pattern]];
+		}
+
+		return [null, []];
+	}
+
+	/**
+	 * Fetches all objects from a table, applying filter at SQL level when possible.
+	 *
+	 * If filter_by/filter_value params are set and can be converted to SQL,
+	 * the WHERE clause is pushed to the database. Otherwise falls back to
+	 * fetch_all_objects (PHP filter_result handles filtering in prepare_result).
+	 *
+	 * @access protected
+	 * @param string $table
+	 * @param string $sortField (default: 'id')
+	 * @param bool $sortAsc (default: true)
+	 * @return array|false
+	 */
+	protected function fetch_all_with_filter($table, $sortField = 'id', $sortAsc = true) {
+		list($where, $params) = $this->build_sql_filter_condition();
+
+		if ($where !== null) {
+			$escapedTable = $this->Database->escape($table);
+			$escapedSort  = $this->Database->escape($sortField);
+
+			// Handle special sort field for vlans and vrfs
+			if ($table == 'vlans' && $sortField == 'id') { $escapedSort = 'vlanId'; }
+			if ($table == 'vrf'   && $sortField == 'id') { $escapedSort = 'vrfId'; }
+
+			$sortDir = $sortAsc ? 'ASC' : 'DESC';
+			$query   = "SELECT * FROM `$escapedTable` WHERE $where ORDER BY `$escapedSort` $sortDir";
+
+			try {
+				$result = $this->Database->getObjectsQuery($table, $query, $params);
+			} catch (Exception $e) {
+				// SQL filter failed (e.g. invalid REGEXP), fall back to PHP filtering
+				return $this->Tools->fetch_all_objects($table, $sortField, $sortAsc);
+			}
+
+			$this->filter_applied = true;
+			return (is_array($result) && sizeof($result) > 0) ? $result : false;
+		}
+
+		return $this->Tools->fetch_all_objects($table, $sortField, $sortAsc);
 	}
 
 	/**

--- a/api/controllers/Devices.php
+++ b/api/controllers/Devices.php
@@ -92,7 +92,7 @@ class Devices_controller extends Common_api_functions {
         // all objects
         if (!isset($this->_params->id) || $this->_params->id == "all") {
             // fetch all devices
-            $result = $this->Tools->fetch_all_objects('devices', 'id');
+            $result = $this->fetch_all_with_filter('devices', 'id');
             // result
             if(!$result)     { return $this->Response->throw_exception(404, "No devices configured"); }
             else             { return array('code'=>200, 'data'=>$this->prepare_result($result, 'devices', true, false)); }

--- a/api/controllers/Sections.php
+++ b/api/controllers/Sections.php
@@ -148,7 +148,7 @@ class Sections_controller extends Common_api_functions {
 		# all sections
 		else {
 				// all sections
-				$result = $this->Sections->fetch_all_sections();
+				$result = $this->fetch_all_with_filter("sections", "order");
 				// check result
 				if($result===false) 					{ return array("code"=>200, "message"=>"No sections available"); }
 				else									{ return array("code"=>200, "data"=>$this->prepare_result ($result, null, true, true)); }

--- a/api/controllers/Subnets.php
+++ b/api/controllers/Subnets.php
@@ -193,17 +193,16 @@ class Subnets_controller extends Common_api_functions {
 
 			// addresses in subnet
 			if($this->_params->id2=="addresses") {
-				$result = $this->read_subnet_addresses ();
-				// if {ip} is set filter it out
+				// if {ip} is set query directly by subnetId + ip_addr
 				if(isset($this->_params->id3)) {
-					if(is_array($result)) {
-	    				foreach ($result as $k=>$r) {
-	        				if ($r->ip !== $this->_params->id3) {
-	            				unset($result[$k]);
-	        				}
-	    				}
-	    			}
-                    if(sizeof($result)==0) { $result = false; }
+					$ip_decimal = $this->Subnets->transform_address($this->_params->id3, "decimal");
+					$result = $this->Database->getObjectsQuery("ipaddresses",
+						"SELECT * FROM `ipaddresses` WHERE `subnetId` = ? AND `ip_addr` = ?",
+						array($this->_params->id, $ip_decimal));
+					$result = (is_array($result) && sizeof($result) > 0) ? $result : false;
+				}
+				else {
+					$result = $this->read_subnet_addresses ();
 				}
 				// check result
 				if($result===false)						{ $this->Response->throw_exception(404, "No addresses found"); }
@@ -720,8 +719,8 @@ class Subnets_controller extends Common_api_functions {
 	 * @return array|false
 	 */
 	private function read_all_subnets() {
-		// fetch
-		$results = $this->Subnets->fetch_all_subnets();
+		// fetch with SQL-level filter if applicable
+		$results = $this->fetch_all_with_filter("subnets", "id");
 
 		if (!is_array($results))
 			return false;
@@ -818,18 +817,12 @@ class Subnets_controller extends Common_api_functions {
 	private function read_search_subnet () {
 		// transform
 		$this->_params->id2 = $this->Subnets->transform_address ($this->_params->id2, "decimal");
-		// check
-		$subnet = $this->Tools->fetch_multiple_objects ("subnets", "subnet", $this->_params->id2);
-		// validate mask
-		if($subnet!==false) {
-			foreach($subnet as $s) {
-				if($s->mask == $this->_params->id3) {
-					$result[] = $s;
-				}
-			}
-		}
+		// query by both subnet and mask directly
+		$result = $this->Database->getObjectsQuery("subnets",
+			"SELECT * FROM `subnets` WHERE `subnet` = ? AND `mask` = ?",
+			array($this->_params->id2, $this->_params->id3));
 		# result
-		return !isset($result) ? false : $result;
+		return (is_array($result) && sizeof($result) > 0) ? $result : false;
 	}
 
 	/**

--- a/api/controllers/Tools.php
+++ b/api/controllers/Tools.php
@@ -209,7 +209,7 @@ class Tools_controller extends Common_api_functions {
 
 		# all ?
 		if (!isset($this->_params->id2)) {
-			$result = $this->Tools->fetch_all_objects ($this->_params->id,  $this->sort_key);
+			$result = $this->fetch_all_with_filter($this->_params->id, $this->sort_key);
 			// result
 			if($result===false)							{ $this->Response->throw_exception(404, 'No objects found'); }
 			else										{ return array("code"=>200, "data"=>$this->prepare_result ($result, "tools/".$this->_params->id, true, false)); }

--- a/api/controllers/Vlans.php
+++ b/api/controllers/Vlans.php
@@ -87,7 +87,7 @@ class Vlans_controller extends Common_api_functions {
 	public function GET () {
 		// all
 		if (!isset($this->_params->id) || $this->_params->id == "all") {
-			$result = $this->Tools->fetch_all_objects ("vlans", 'vlanId');
+			$result = $this->fetch_all_with_filter("vlans", "vlanId");
 			// check result
 			if($result===false)						{ $this->Response->throw_exception(404, 'No vlans configured'); }
 			else									{ return array("code"=>200, "data"=>$this->prepare_result ($result, null, true, true)); }
@@ -96,18 +96,15 @@ class Vlans_controller extends Common_api_functions {
 		elseif(@$this->_params->id2=="subnets") {
 			// first validate
 			$this->validate_vlan ();
-			// save result
-			$result = $this->Tools->fetch_multiple_objects ("subnets", "vlanId", $this->_params->id, 'id', true);
-
-			// only 1 section ?
+			// save result - filter by sectionId at SQL level if provided
 			if(isset($this->_params->id3)) {
-				if($result!=NULL) {
-					foreach ($result as $k=>$r) {
-						if($r->sectionId!=$this->_params->id3) {
-							unset($result[$k]);
-						}
-					}
-				}
+				$result = $this->Database->getObjectsQuery("subnets",
+					"SELECT * FROM `subnets` WHERE `vlanId` = ? AND `sectionId` = ? ORDER BY `id` ASC",
+					array($this->_params->id, $this->_params->id3));
+				$result = (is_array($result) && sizeof($result) > 0) ? $result : null;
+			}
+			else {
+				$result = $this->Tools->fetch_multiple_objects ("subnets", "vlanId", $this->_params->id, 'id', true);
 			}
 
 			// add gateway
@@ -285,13 +282,11 @@ class Vlans_controller extends Common_api_functions {
 
 		//if it already exist die
 		if($this->settings->vlanDuplicate==0 && $_SERVER['REQUEST_METHOD']=="POST") {
-			$check_vlan = $this->Admin->fetch_multiple_objects ("vlans", "domainId", $this->_params->domainId, "vlanId");
-			if($check_vlan!==false) {
-				foreach($check_vlan as $v) {
-					if($v->number == $this->_params->number) {
-																							{ $this->Response->throw_exception(409, "Vlan already exists"); }
-					}
-				}
+			$check_vlan = $this->Database->getObjectQuery("vlans",
+				"SELECT * FROM `vlans` WHERE `domainId` = ? AND `number` = ? LIMIT 1",
+				array($this->_params->domainId, $this->_params->number));
+			if($check_vlan!==false && $check_vlan!==null) {
+				$this->Response->throw_exception(409, "Vlan already exists");
 			}
 		}
 


### PR DESCRIPTION
## Description

This PR's intention is to improve the performance of `phpipam` by moving PHP filtering to SQL filtering wherever possible. Here are the changes made, broken down by file and changeset:

### `Common.php`

  - Added `$filter_applied` flag to skip redundant PHP filtering when SQL filter was used
  - Added `pcre_to_mysql_regexp()` - converts PCRE patterns to MySQL REGEXP syntax
  - Added `build_sql_filter_condition()` - translates API `filter_by`/`filter_value`/`filter_match` params into SQL `WHERE` clauses with proper reverse key mapping (`deviceId`→`switch`, `tag`→`state`, `ip`→`ip_addr`)
  - Added `fetch_all_with_filter()` - wraps `fetch all` queries with optional SQL-level filtering, falling back to full fetch when no filter is set

###  `Addresses.php`

  1. `GET` all - uses `fetch_all_with_filter("ipaddresses")` instead of fetching everything
  2. `GET` by IP in subnet - direct SQL query on `ip_addr` + `subnetId` instead of fetching all addresses then PHP-filtering
  3. `GET` tags with subnetId - SQL WHERE on `state` + `subnetId` instead of fetching all by state then looping
  4. `DELETE` by IP+subnet - direct SQL lookup instead of fetching all by IP then looping

### `Subnets.php`

  1. `GET /{id}/addresses/{ip}` - direct SQL query on `subnetId` + `ip_addr` instead of fetching all subnet addresses then PHP-filtering by IP
  2. `GET` all subnets - uses `fetch_all_with_filter("subnets")` for the initial fetch inside `read_all_subnets()`
  3. Search subnet - SQL `WHERE subnet = ? AND mask = ?` instead of fetching by subnet then PHP-filtering by mask

###  `Vlans.php`

  1. `GET` all - uses `fetch_all_with_filter("vlans", "vlanId")`
  2. `GET` `/{id}/subnets/{sectionId}` - SQL `WHERE vlanId = ? AND sectionId = ?` instead of fetching all VLAN subnets then PHP-filtering
  3. `validate_vlan_edit` - SQL `WHERE domainId = ? AND number = ? LIMIT 1` instead of fetching all VLANs in domain then looping

###  `Devices.php`, `Sections.php`, `Tools.php`

  - All "fetch all" GET endpoints now use `fetch_all_with_filter()` to push generic `filter_by`/`filter_value`/`filter_match` filtering down to SQL