### PR TITLE
Fix PHP 8.5 compatibility issues

### DIFF
--- a/functions/PEAR/Net/DNS2.php
+++ b/functions/PEAR/Net/DNS2.php
@@ -226,7 +226,7 @@ class Net_DNS2
      * @access public
      *
      */
-    public function __construct(array $options = null)
+    public function __construct(?array $options = null)
     {
         //
         // load any options that were provided

--- a/functions/PEAR/Net/DNS2/Header.php
+++ b/functions/PEAR/Net/DNS2/Header.php
@@ -69,7 +69,7 @@ class Net_DNS2_Header
      * @access public
      *
      */
-    public function __construct(Net_DNS2_Packet &$packet = null)
+    public function __construct(?Net_DNS2_Packet &$packet = null)
     {
         if (!is_null($packet)) {
 

--- a/functions/PEAR/Net/DNS2/Notifier.php
+++ b/functions/PEAR/Net/DNS2/Notifier.php
@@ -47,7 +47,7 @@ class Net_DNS2_Notifier extends Net_DNS2
      * @access public
      *
      */
-    public function __construct($zone, array $options = null)
+    public function __construct($zone, ?array $options = null)
     {
         parent::__construct($options);
 

--- a/functions/PEAR/Net/DNS2/Question.php
+++ b/functions/PEAR/Net/DNS2/Question.php
@@ -73,7 +73,7 @@ class Net_DNS2_Question
      * @access public
      *
      */
-    public function __construct(Net_DNS2_Packet &$packet = null)
+    public function __construct(?Net_DNS2_Packet &$packet = null)
     {
         if (!is_null($packet)) {
 

--- a/functions/PEAR/Net/DNS2/RR.php
+++ b/functions/PEAR/Net/DNS2/RR.php
@@ -139,7 +139,7 @@ abstract class Net_DNS2_RR
      * @access public
      *
      */
-    public function __construct(Net_DNS2_Packet &$packet = null, array $rr = null)
+    public function __construct(?Net_DNS2_Packet &$packet = null, ?array $rr = null)
     {
         if ( (!is_null($packet)) && (!is_null($rr)) ) {
 

--- a/functions/PEAR/Net/DNS2/RR/CERT.php
+++ b/functions/PEAR/Net/DNS2/RR/CERT.php
@@ -93,7 +93,7 @@ class Net_DNS2_RR_CERT extends Net_DNS2_RR
      * @return
      *
      */
-    public function __construct(Net_DNS2_Packet &$packet = null, array $rr = null)
+    public function __construct(?Net_DNS2_Packet &$packet = null, ?array $rr = null)
     {
         parent::__construct($packet, $rr);
     

--- a/functions/PEAR/Net/DNS2/RR/OPT.php
+++ b/functions/PEAR/Net/DNS2/RR/OPT.php
@@ -81,7 +81,7 @@ class Net_DNS2_RR_OPT extends Net_DNS2_RR
      * @access public
      *
      */
-    public function __construct(Net_DNS2_Packet &$packet = null, array $rr = null)
+    public function __construct(?Net_DNS2_Packet &$packet = null, ?array $rr = null)
     {
         //
         // this is for when we're manually building an OPT RR object; we aren't

--- a/functions/PEAR/Net/DNS2/Resolver.php
+++ b/functions/PEAR/Net/DNS2/Resolver.php
@@ -31,7 +31,7 @@ class Net_DNS2_Resolver extends Net_DNS2
      * @access public
      *
      */
-    public function __construct(array $options = null)
+    public function __construct(?array $options = null)
     {
         parent::__construct($options);
     }

--- a/functions/PEAR/Net/DNS2/Updater.php
+++ b/functions/PEAR/Net/DNS2/Updater.php
@@ -48,7 +48,7 @@ class Net_DNS2_Updater extends Net_DNS2
      * @access public
      *
      */
-    public function __construct($zone, array $options = null)
+    public function __construct($zone, ?array $options = null)
     {
         parent::__construct($options);
 

--- a/functions/adLDAP/src/adLDAP.php
+++ b/functions/adLDAP/src/adLDAP.php
@@ -910,7 +910,7 @@ class adLDAP {
             }
         }
         if ($encode === true && $key != 'password') {
-            $item = utf8_encode($item);
+            $item = mb_convert_encoding($item, 'UTF-8', 'ISO-8859-1');
         }
     }
 

--- a/functions/adLDAP/src/classes/adLDAPUtils.php
+++ b/functions/adLDAP/src/classes/adLDAPUtils.php
@@ -239,7 +239,7 @@ class adLDAPUtils {
             }
         }
         if ($encode === true && $key != 'password') {
-            $item = utf8_encode($item);   
+            $item = mb_convert_encoding($item, 'UTF-8', 'ISO-8859-1');
         }
     }  
     


### PR DESCRIPTION
## Summary

This PR fixes PHP 8.5 compatibility issues found across the codebase:

- **Implicit nullable typed parameters** (deprecated in PHP 8.4): 9 constructor signatures in `functions/PEAR/Net/DNS2/` used typed parameters with `= null` default without the explicit `?` nullable prefix. Fixed by adding `?` to the type hints in:
  - `Net/DNS2.php`
  - `Net/DNS2/Resolver.php`
  - `Net/DNS2/Notifier.php`
  - `Net/DNS2/Updater.php`
  - `Net/DNS2/RR.php`
  - `Net/DNS2/RR/CERT.php`
  - `Net/DNS2/RR/OPT.php`
  - `Net/DNS2/Header.php`
  - `Net/DNS2/Question.php`

- **`utf8_encode()` removed in PHP 8.2**: Replaced with `mb_convert_encoding($item, 'UTF-8', 'ISO-8859-1')` in:
  - `functions/adLDAP/src/adLDAP.php`
  - `functions/adLDAP/src/classes/adLDAPUtils.php`

## Test plan

- [ ] Verify DNS resolution functionality works (Net_DNS2 classes)
- [ ] Verify LDAP/Active Directory authentication works (adLDAP)
- [ ] Run on PHP 8.5 and confirm no deprecation warnings or errors for the changed code

https://claude.ai/code/session_01V7PposBPc1ujq4xd61MP5x