### PR TITLE
Fixed SNMP always uses default port

### DIFF
--- a/functions/classes/class.SNMP.php
+++ b/functions/classes/class.SNMP.php
@@ -489,9 +489,9 @@ class phpipamSNMP extends Common_functions {
         
         // init connection
         if ($this->snmp_session === false) {
-            if ($this->snmp_version=="1")       { $this->snmp_session = new SNMP(SNMP::VERSION_1,  $this->snmp_host, $this->snmp_community, $this->snmp_timeout * 1000, $this->snmp_retries); }
-            elseif ($this->snmp_version=="2")   { $this->snmp_session = new SNMP(SNMP::VERSION_2c, $this->snmp_host, $this->snmp_community, $this->snmp_timeout * 1000, $this->snmp_retries); }
-            elseif ($this->snmp_version=="3")   { $this->snmp_session = new SNMP(SNMP::VERSION_3,  $this->snmp_host, $this->snmp_community, $this->snmp_timeout * 1000, $this->snmp_retries);
+            if ($this->snmp_version=="1")       { $this->snmp_session = new SNMP(SNMP::VERSION_1,  $host_with_port, $this->snmp_community, $this->snmp_timeout * 1000, $this->snmp_retries); }
+            elseif ($this->snmp_version=="2")   { $this->snmp_session = new SNMP(SNMP::VERSION_2c, $host_with_port, $this->snmp_community, $this->snmp_timeout * 1000, $this->snmp_retries); }
+            elseif ($this->snmp_version=="3")   { $this->snmp_session = new SNMP(SNMP::VERSION_3,  $host_with_port, $this->snmp_community, $this->snmp_timeout * 1000, $this->snmp_retries);
                                                   $this->snmp_session->setSecurity(
                                                                                    $this->snmpv3_security->sec_level,
                                                                                    $this->snmpv3_security->auth_proto,

--- a/functions/classes/class.SNMP.php
+++ b/functions/classes/class.SNMP.php
@@ -482,6 +482,11 @@ class phpipamSNMP extends Common_functions {
      * @return void
      */
     private function connection_open () {
+        // IPv6 needs to be surrounded with brackets when specifying port  => [::1]:1161
+        $host_with_port = filter_var($this->snmp_host, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6) ? '[' . $this->snmp_host . ']' : $this->snmp_host;
+        // include port with host
+        $host_with_port = $host_with_port . ':' . $this->snmp_port;
+        
         // init connection
         if ($this->snmp_session === false) {
             if ($this->snmp_version=="1")       { $this->snmp_session = new SNMP(SNMP::VERSION_1,  $this->snmp_host, $this->snmp_community, $this->snmp_timeout * 1000, $this->snmp_retries); }


### PR DESCRIPTION
SNMP always uses the default port, even when a nonstandard port is configured.

### Changes:
- Added: Include configured port when opening the connection