### PR TITLE
Fix SNMP querying all available devices

### DIFF
--- a/app/admin/admin-menu-config.php
+++ b/app/admin/admin-menu-config.php
@@ -58,6 +58,7 @@ $admin_menu[_('IP related management')][] = ["show"=>true, "icon"=>"fa-magic",  
 
 # device managements
 $admin_menu[_('Device management')][] =     ["show"=>true, "icon"=>"fa-desktop",        "href"=>"devices",                "name"=>_("Devices"),                  "description"=>_("Device management")];
+$admin_menu[_('Device management')][] =     ["show"=>true, "icon"=>"fa-object-group",   "href"=>"device-groups",          "name"=>_("Device Groups"),            "description"=>_("Device group management")];
 if($User->settings->enableRACK == 1)
 $admin_menu[_('Device management')][] =     ["show"=>true, "icon"=>"fa-bars",           "href"=>"racks",                  "name"=>_("Racks"),                    "description"=>_("Rack management")];
 if($User->settings->enableCircuits == 1)
@@ -80,6 +81,7 @@ $admin_menu_items = [
                     "custom-fields"          => _("custom-fields"),
                     "dhcp"                   => _("dhcp"),
                     "devices"                => _("devices"),
+                    "device-groups"          => _("device-groups"),
                     "device-types"           => _("device-types"),
                     "filter-fields"          => _("filter-fields"),
                     "required-fields"        => _("required-fields"),

--- a/app/admin/device-groups/add-devices-result.php
+++ b/app/admin/device-groups/add-devices-result.php
@@ -1,0 +1,46 @@
+<?php
+
+/**
+ * Script to display usermod result
+ *************************************/
+
+
+/* functions */
+require_once( dirname(__FILE__) . '/../../../functions/functions.php' );
+
+# initialize user object
+$Database 	= new Database_PDO;
+$User 		= new User ($Database);
+$Admin	 	= new Admin ($Database);
+$Tools	 	= new Tools ($Database);
+$Devices 	= new Devices ($Database);
+$Result 	= new Result ();
+
+# verify that user is logged in
+$User->check_user_session();
+# verify that user has permission to module
+$User->check_module_permissions ("devices", User::ACCESS_R, true, false);
+
+# check if site is demo
+$User->is_demo();
+# check maintaneance mode
+$User->check_maintaneance_mode ();
+
+if(!is_numeric($POST->g_id))		{ $Result->show("danger", _("Invalid Device group ID"), true, true); }
+
+$values = [];
+
+# parse result
+foreach($POST as $k=>$p) {
+	if(substr($k, 0,6) == "device") {
+		# create array of values for modification
+		$values['d_id'] = substr($k, 6);
+		$values['g_id'] = $POST->g_id;
+
+		if(!$Devices->object_modify("device_to_group", "add", "id", $values)) {
+			$Result->show("danger",  _("Device")." ". substr($k, 6) . " ".$User->get_post_action()." "._("error")."!", false);
+		} else {
+			$Result->show("success", _("Device")." ". substr($k, 6) . " ".$User->get_post_action()." "._("success")."!", false);
+		}
+	}
+}

--- a/app/admin/device-groups/add-devices.php
+++ b/app/admin/device-groups/add-devices.php
@@ -1,0 +1,95 @@
+<?php
+
+/**
+ * Script to add devices to group
+ *************************************************/
+
+/* functions */
+require_once( dirname(__FILE__) . '/../../../functions/functions.php' );
+
+# initialize user object
+$Database 	= new Database_PDO;
+$User 		= new User ($Database);
+$Admin	 	= new Admin ($Database);
+$Tools	 	= new Tools ($Database);
+$Devices 	= new Devices ($Database);
+$Result 	= new Result ();
+
+# verify that user is logged in
+$User->check_user_session();
+# verify that user has permission to module
+$User->check_module_permissions ("devices", User::ACCESS_R, true, false);
+
+# id must be numeric
+if(!is_numeric($POST->g_id))		{ $Result->show("danger", _("Invalid ID"), true, true); }
+
+# get group details
+$group   = $Tools->fetch_object("deviceGroups", "id", $POST->g_id);
+# devices in group - array of ids
+$group_members = $Tools->fetch_multiple_objects("device_to_group", "g_id", $POST->g_id, 'g_id');
+$group_members = (array) $group_members;
+# not in group - array of ids
+$missing = $Devices->group_fetch_missing_devices($POST->g_id);
+?>
+
+
+<!-- header -->
+<div class="pHeader"><?php print _('Add devices to group'); ?> <b><i> <?php print $group->name; ?> </i></b> </div>
+
+
+<!-- content -->
+<div class="pContent">
+
+	<?php if(sizeof($missing) > 0) { ?>
+
+	<form id="groupAddDevices" name="groupAddDevices">
+	<table class="groupEdit table table-condensed table-hover table-top">
+
+	<tr>
+		<th>
+			<input type="hidden" name="g_id" value="<?php print escape_input($POST->g_id); ?>">
+		</th>
+		<th><?php print _('Name'); ?></th>
+		<th><?php print _('IP address'); ?></th>
+		<th><?php print _('Description'); ?></th>
+	</tr>
+
+	<?php
+	# show missing
+	foreach($missing as $k=>$m) {
+		# get user details
+		$d = $Devices->fetch_object("devices", "id", $m);
+
+		print "<tr>";
+
+		print "	<td>";
+		print "	<input type='checkbox' name='device$d->id'>";
+		print "	</td>";
+
+		print "	<td>$d->hostname</td>";
+		print "	<td>$d->ip_addr</td>";
+		print "	<td>$d->description</td>";
+
+		print "</tr>";
+	}
+	?>
+
+    </table>
+    </form>
+
+    <?php } else { $Result->show("info", _('No available devices to add to group'), false); } ?>
+</div>
+
+
+<!-- footer -->
+<div class="pFooter">
+	<div class="btn-group">
+		<button class="btn btn-sm btn-default hidePopups"><?php print _("Cancel"); ?></button>
+		<?php if(sizeof($missing) > 0) { ?>
+		<button class='btn btn-sm btn-success submit_popup' data-script="app/admin/device-groups/add-devices-result.php" data-result_div="groupAddDevicesResult" data-form='groupAddDevices'><?php print _("Add selected devices"); ?></button>
+		<?php } ?>
+	</div>
+
+	<!-- Result -->
+	<div id="groupAddDevicesResult"></div>
+</div>

--- a/app/admin/device-groups/edit-group-result.php
+++ b/app/admin/device-groups/edit-group-result.php
@@ -1,0 +1,53 @@
+<?php
+
+/**
+ * Script to display usermod result
+ *************************************/
+
+
+/* functions */
+require_once( dirname(__FILE__) . '/../../../functions/functions.php' );
+
+# initialize user object
+$Database 	= new Database_PDO;
+$User 		= new User ($Database);
+$Admin	 	= new Admin ($Database);
+$Tools	 	= new Tools ($Database);
+$Result 	= new Result ();
+
+# verify that user is logged in
+$User->check_user_session();
+# verify that user has permission to module
+$User->check_module_permissions ("devices", User::ACCESS_R, true, false);
+
+# check if site is demo
+$User->is_demo();
+# check maintaneance mode
+$User->check_maintaneance_mode ();
+
+# validate csrf cookie
+$User->Crypto->csrf_cookie ("validate", "group", $POST->csrf_cookie) === false ? $Result->show("danger", _("Invalid CSRF cookie"), true) : "";
+
+
+# remove devices from this group if delete and remove group
+if($POST->action == "delete") {
+	#$Admin->remove_group_from_users($POST->g_id);
+	#$Admin->remove_group_from_sections($POST->g_id);
+}
+else {
+	if(strlen($POST->name) < 2)											{ $Result->show("danger", _('Name must be at least 2 characters long')."!", true); }
+}
+
+# unique name
+if($POST->action=="add") {
+if($Tools->fetch_object("deviceGroups", "name", $POST->name)!==false)	{ $Result->show("danger", _('Group already exists')."!", true); }
+}
+
+# create array of values for modification
+$values = array("id"   => $POST->id,
+				"name" => $POST->name,
+				"desc" => $POST->desc);
+
+/* try to execute */
+if(!$Admin->object_modify("deviceGroups", $POST->action, "id", $values)) 	{ $Result->show("danger",  _("Group")." ".$User->get_post_action()." "._("error")."!", false); }
+else 					 													{ $Result->show("success", _("Group")." ".$User->get_post_action()." "._("success")."!", false); }

--- a/app/admin/device-groups/edit-group.php
+++ b/app/admin/device-groups/edit-group.php
@@ -1,0 +1,89 @@
+<?php
+
+/**
+ * Script to print add / edit / delete group
+ *************************************************/
+
+/* functions */
+require_once( dirname(__FILE__) . '/../../../functions/functions.php' );
+
+# initialize user object
+$Database 	= new Database_PDO;
+$User 		= new User ($Database);
+$Admin	 	= new Admin ($Database);
+$Tools      = new Tools ($Database);
+$Result 	= new Result ();
+
+# verify that user is logged in
+$User->check_user_session();
+# verify that user has permission to module
+$User->check_module_permissions ("devices", User::ACCESS_R, true, false);
+
+# create csrf token
+$csrf = $User->Crypto->csrf_cookie ("create", "group");
+# validate action
+$Admin->validate_action(false);
+
+# fetch group and set title
+if($POST->action=="add") {
+	$title = _('Add new group');
+} else {
+    # ID
+    if(!is_numeric($POST->g_id))   $Result->show("danger", _("Invalid Id"), true, true);
+
+	//fetch all group details
+    $group = (array) $Tools->fetch_object("deviceGroups", "id", $POST->g_id);
+    //false die
+    $group !== false ? : $Result->show("danger", _("Invalid ID"), true, true);
+
+	$title = $User->get_post_action().' '._('group').' ' . "<b><i>" . $group['name'] . "</i></b>";
+}
+?>
+
+<!-- header -->
+<div class="pHeader"><?php print $title; ?></div>
+
+<!-- content -->
+<div class="pContent">
+
+	<form id="groupEdit" name="groupEdit">
+	<table class="groupEdit table table-noborder table-condensed">
+
+	<!-- name -->
+	<tr>
+	    <td><?php print _('Group name'); ?></td>
+	    <td><input type="text" name="name" class="form-control input-sm" value="<?php print @$group['name']; ?>" <?php if($POST->action == "delete") print "readonly"; ?>></td>
+       	<td class="info2"><?php print _('Enter group name'); ?></td>
+    </tr>
+
+    <!-- description -->
+    <tr>
+    	<td><?php print _('Description'); ?></td>
+    	<td>
+    		<input type="text" name="desc" class="form-control input-sm" value="<?php print @$group['desc']; ?>" <?php if($POST->action == "delete") print "readonly"; ?>>
+
+    		<input type="hidden" name="id" value="<?php print escape_input($POST->g_id); ?>">
+    		<input type="hidden" name="action" value="<?php print escape_input($POST->action); ?>">
+    		<input type="hidden" name="csrf_cookie" value="<?php print $csrf; ?>">
+    	</td>
+    	<td class="info2"><?php print _('Enter description'); ?></td>
+    </tr>
+
+</table>
+</form>
+
+</div>
+
+
+<!-- footer -->
+<div class="pFooter">
+	<div class="btn-group">
+		<button class="btn btn-sm btn-default hidePopups"><?php print _('Cancel'); ?></button>
+        <button class='btn btn-sm btn-default submit_popup <?php if($POST->action=="delete") { print "btn-danger"; } else { print "btn-success"; } ?>' data-script="app/admin/device-groups/edit-group-result.php" data-result_div="groupEditResult" data-form='groupEdit'>
+            <i class="fa <?php if($POST->action=="add") { print "fa-plus"; } elseif ($POST->action=="delete") { print "fa-trash-o"; } else { print "fa-check"; } ?>"></i> <?php print $User->get_post_action(); ?>
+        </button>
+	</div>
+
+	<!-- Result -->
+	<div id="groupEditResult"></div>
+</div>

--- a/app/admin/device-groups/index.php
+++ b/app/admin/device-groups/index.php
@@ -1,0 +1,8 @@
+<?php
+
+/**
+ * Script to print device groups
+ *********************************/
+
+require (dirname(__FILE__)."/../../tools/device-groups/index.php");
+?>

--- a/app/admin/device-groups/remove-devices-result.php
+++ b/app/admin/device-groups/remove-devices-result.php
@@ -1,0 +1,46 @@
+<?php
+
+/**
+ * Script to display usermod result
+ *************************************/
+
+
+/* functions */
+require_once( dirname(__FILE__) . '/../../../functions/functions.php' );
+
+# initialize user object
+$Database 	= new Database_PDO;
+$User 		= new User ($Database);
+$Admin	 	= new Admin ($Database);
+$Tools	 	= new Tools ($Database);
+$Devices 	= new Devices ($Database);
+$Result 	= new Result ();
+
+# verify that user is logged in
+$User->check_user_session();
+# verify that user has permission to module
+$User->check_module_permissions ("devices", User::ACCESS_R, true, false);
+
+# check if site is demo
+$User->is_demo();
+# check maintaneance mode
+$User->check_maintaneance_mode ();
+
+if(!is_numeric($POST->g_id))		{ $Result->show("danger", _("Invalid Device group ID"), true, true); }
+
+$values = [];
+
+# parse result
+foreach($POST as $k=>$p) {
+	if(substr($k, 0,6) == "device") {
+		# create array of values for modification
+		$values['d_id'] = substr($k, 6);
+		$values['g_id'] = $POST->g_id;
+
+		if(!$Devices->object_modify("device_to_group", "delete", "d_id", $values, [], "g_id", $values)) {
+			$Result->show("danger",  _("Device")." ". substr($k, 6) . " ".$User->get_post_action()." "._("error")."!", false);
+		} else {
+			$Result->show("success", _("Device")." ". substr($k, 6) . " ".$User->get_post_action()." "._("success")."!", false);
+		}
+	}
+}

--- a/app/admin/device-groups/remove-devices.php
+++ b/app/admin/device-groups/remove-devices.php
@@ -1,0 +1,93 @@
+<?php
+
+/**
+ * Script to remove devices from group
+ *************************************************/
+
+/* functions */
+require_once( dirname(__FILE__) . '/../../../functions/functions.php' );
+
+# initialize user object
+$Database 	= new Database_PDO;
+$User 		= new User ($Database);
+$Admin	 	= new Admin ($Database);
+$Tools	 	= new Tools ($Database);
+$Result 	= new Result ();
+
+# verify that user is logged in
+$User->check_user_session();
+# verify that user has permission to module
+$User->check_module_permissions ("devices", User::ACCESS_R, true, false);
+
+
+# id must be numeric
+if(!is_numeric($POST->g_id))		{ $Result->show("danger", _("Invalid ID"), true, true); }
+
+# get group details
+$group   = $Tools->fetch_object("deviceGroups", "id", $POST->g_id);
+# devices in group - array of ids
+$group_members = $Tools->fetch_multiple_objects("device_to_group", "g_id", $POST->g_id, 'g_id');
+$group_members = ($group_members !== false) && isset($group_members) ? (array)$group_members : [];
+?>
+
+
+<!-- header -->
+<div class="pHeader"><?php print _('Remove devices from group'); ?> <b><i> <?php print $group->name; ?></i></b></div>
+
+
+<!-- content -->
+<div class="pContent">
+
+	<?php if(sizeof($group_members) > 0) { ?>
+
+	<form id="groupRemoveDevices" name="groupRemoveDevices">
+	<table class="groupEdit table table-condensed table-top">
+
+	<tr>
+		<th>
+			<input type="hidden" name="g_id" value="<?php print escape_input($POST->g_id); ?>">
+		</th>
+		<th><?php print _('Name'); ?></th>
+		<th><?php print _('IP address'); ?></th>
+		<th><?php print _('Description'); ?></th>
+	</tr>
+
+	<?php
+	# show group members
+	foreach($group_members as $k => $m) {
+		# get user details
+		$d = (array)$Tools->fetch_object("devices", "id", $m->d_id);
+
+		print "<tr>";
+
+		print "	<td>";
+		print "	<input type='checkbox' name='device$d[id]'>";
+		print "	</td>";
+
+		print "	<td>$d[hostname]</td>";
+		print "	<td>$d[ip_addr]</td>";
+		print "	<td>$d[description]</td>";
+
+		print "</tr>";
+	}
+	?>
+
+    </table>
+    </form>
+
+    <?php } else { $Result->show("info", _('No devices in this group'), false);  } ?>
+</div>
+
+
+<!-- footer -->
+<div class="pFooter">
+	<div class="btn-group">
+		<button class="btn btn-sm btn-default hidePopups"><?php print _('Cancel'); ?></button>
+		<?php if(sizeof($group_members) > 0) { ?>
+		<button class='btn btn-sm btn-success submit_popup' data-script="app/admin/device-groups/remove-devices-result.php" data-result_div="groupRemoveDevicesResult" data-form='groupRemoveDevices'><?php print _('Remove selected devices'); ?></button>
+		<?php } ?>
+	</div>
+
+	<!-- Result -->
+	<div id="groupRemoveDevicesResult"></div>
+</div>

--- a/app/admin/subnets/edit-result.php
+++ b/app/admin/subnets/edit-result.php
@@ -294,6 +294,7 @@ else {
 					"DNSrecords"     => $Admin->verify_checkbox($POST->DNSrecords),
 					"nameserverId"   => $POST->nameserverId,
 					"device"         => $POST->device,
+					"deviceGroup"    => $POST->deviceGroup,
 					"isFull"         => $Admin->verify_checkbox($POST->isFull),
 					"isPool"         => $Admin->verify_checkbox($POST->isPool)
 					);

--- a/app/admin/subnets/edit-result.php
+++ b/app/admin/subnets/edit-result.php
@@ -32,6 +32,11 @@ if($POST->action=="add") {
 	$User->Crypto->csrf_cookie ("validate", "subnet_".$POST->subnetId, $POST->csrf_cookie) === false ? $Result->show("danger", _("Invalid CSRF cookie"), true) : "";
 }
 
+# if device and device group is set -> fail
+if($POST->device != 0 && $POST->deviceGroup != 0) {
+	$Result->show("danger", _("Device and Device group can not be used at the same time!"), true);
+}
+
 # if show name than description must be set
 if($POST->showName==1 && is_blank($POST->description)) 	{ $Result->show("danger", _("Please enter subnet description to show as name!"), true); }
 

--- a/app/admin/subnets/edit.php
+++ b/app/admin/subnets/edit.php
@@ -290,6 +290,27 @@ $("input[name='subnet']").change(function() {
 		</td>
 		<td class="info2"><?php print _('Select device where subnet is located'); ?></td>
     </tr>
+
+	<!-- Device group -->
+	<tr>
+		<td class="middle"><?php print _('Device group'); ?></td>
+		<td id="deviceDropdown">
+			<select name="deviceGroup" class="form-control input-sm input-w-auto">
+				<option value="0"><?php print _('None'); ?></option>
+				<?php
+				// fetch all device groups
+				$device_groups = $Admin->fetch_all_objects("deviceGroups", "name");
+				$device_groups = ($device_groups !== false) ? $device_groups : [];
+				
+				// loop
+				foreach($device_groups as $device_group) {					
+					print '<option value="' . $device_group->id . (($device_group->id == @$subnet_old_details['deviceGroup']) ? '" selected>' : '">') . $device_group->name . '</option>';
+				}
+				?>
+			</select>
+		</td>
+		<td class="info2"><?php print _('Select device group where subnet is located'); ?></td>
+    </tr>
     <?php } ?>
 
 	<!-- Nameservers -->

--- a/app/subnets/scan/subnet-scan-execute-scan-snmp-arp.php
+++ b/app/subnets/scan/subnet-scan-execute-scan-snmp-arp.php
@@ -42,8 +42,28 @@ if (sizeof($all_subnet_hosts)>0) {
 $selected_ip_fields = $User->settings->IPfilter;
 $selected_ip_fields = pf_explode(";", $selected_ip_fields);
 
-# fetch devices that use get_routing_table query
-$devices_used = $Tools->fetch_multiple_objects ("devices", "snmp_queries", "%get_arp_table%", "id", true, true);
+// if deviceGroup is defined -> use deviceGroup
+// else use traditional method of device selection
+if ($subnet->deviceGroup != 0) {
+    $deviceGroup_members = $Tools->fetch_multiple_objects("device_to_group", "g_id", $subnet->deviceGroup, "d_id");
+    $devices_used = false;
+
+    if ($deviceGroup_members !== false && sizeof($deviceGroup_members) > 0) {
+        $devices_used = [];
+
+        foreach ($deviceGroup_members as $deviceGroup_member) {
+            $device = $Tools->fetch_object("devices", "id", $deviceGroup_member->d_id);
+
+            // Only add devices with corresponding SNMP-query
+            if (str_contains($device->snmp_queries, "get_arp_table")) {
+                $devices_used[] = $device;
+            }
+        }
+    }
+} else {
+    # fetch devices that use get_routing_table query
+    $devices_used = $Tools->fetch_multiple_objects ("devices", "snmp_queries", "%get_arp_table%", "id", true, true);
+}
 
 # filter out not in this section
 if ($devices_used !== false) {

--- a/app/subnets/scan/subnet-scan-execute-snmp-route-all.php
+++ b/app/subnets/scan/subnet-scan-execute-snmp-route-all.php
@@ -32,8 +32,29 @@ if ($section===false)                           { $Result->show("danger", "Inval
 # check section permissions
 if($Subnets->check_permission ($User->user, $POST->sectionId) != 3) { $Result->show("danger", _('You do not have permissions to add new subnet in this section')."!", true, $ajax_loaded); }
 
-# fetch devices that use get_routing_table query
-$devices_used = $Tools->fetch_multiple_objects ("devices", "snmp_queries", "%get_routing_table%", "id", true, true);
+// if deviceGroup is defined -> use deviceGroup
+// else use traditional method of device selection
+$subnet = $Tools->fetch_object("subnets", "id", $POST->subnetId);
+if ($subnet !== false && $subnet->deviceGroup != 0) {
+    $deviceGroup_members = $Tools->fetch_multiple_objects("device_to_group", "g_id", $subnet->deviceGroup, "d_id");
+    $devices_used = false;
+
+    if ($deviceGroup_members !== false && sizeof($deviceGroup_members) > 0) {
+        $devices_used = [];
+
+        foreach ($deviceGroup_members as $deviceGroup_member) {
+            $device = $Tools->fetch_object("devices", "id", $deviceGroup_member->d_id);
+
+            // Only add devices with corresponding SNMP-query
+            if (str_contains($device->snmp_queries, "get_routing_table")) {
+                $devices_used[] = $device;
+            }
+        }
+    }
+} else {
+    # fetch devices that use get_routing_table query
+    $devices_used = $Tools->fetch_multiple_objects ("devices", "snmp_queries", "%get_routing_table%", "id", true, true);
+}
 
 # recalculate ids for info
 foreach ($devices_used as $d) {

--- a/app/subnets/scan/subnet-scan-execute-update-snmp-arp.php
+++ b/app/subnets/scan/subnet-scan-execute-update-snmp-arp.php
@@ -37,8 +37,28 @@ if (sizeof($all_subnet_hosts)>0) {
         $result[$h->ip_addr]['status'] = "Offline";
     }
 
-    # fetch devices that use get_routing_table query
-    $devices_used = $Tools->fetch_multiple_objects ("devices", "snmp_queries", "%get_arp_table%", "id", true, true);
+    // if deviceGroup is defined -> use deviceGroup
+    // else use traditional method of device selection
+    if ($subnet->deviceGroup != 0) {
+        $deviceGroup_members = $Tools->fetch_multiple_objects("device_to_group", "g_id", $subnet->deviceGroup, "d_id");
+        $devices_used = false;
+
+        if ($deviceGroup_members !== false && sizeof($deviceGroup_members) > 0) {
+            $devices_used = [];
+
+            foreach ($deviceGroup_members as $deviceGroup_member) {
+                $device = $Tools->fetch_object("devices", "id", $deviceGroup_member->d_id);
+
+                // Only add devices with corresponding SNMP-query
+                if (str_contains($device->snmp_queries, "get_arp_table")) {
+                    $devices_used[] = $device;
+                }
+            }
+        }
+    } else {
+        # fetch devices that use get_routing_table query
+        $devices_used = $Tools->fetch_multiple_objects ("devices", "snmp_queries", "%get_arp_table%", "id", true, true);
+    }
 
     # filter out not in this section
     if ($devices_used !== false) {

--- a/app/tools/device-groups/all-device-groups.php
+++ b/app/tools/device-groups/all-device-groups.php
@@ -1,0 +1,114 @@
+<script>
+/* fix for ajax-loading tooltips */
+$('body').tooltip({ selector: '[rel=tooltip]' });
+</script>
+
+<?php
+
+/**
+ * Script to display device groups
+ *
+ */
+
+# verify that user is logged in
+$User->check_user_session();
+# verify that user has permission to module
+$User->check_module_permissions ("devices", User::ACCESS_R, true, false);
+
+# filter devices or fetch print all?
+$device_groups = $Tools->fetch_all_objects("deviceGroups", "name");
+
+// filter flag
+$filter = false;
+?>
+
+<h4> <?php print _('Device group management') ?></h4>
+<hr><br>
+
+<!-- Add new -->
+<div class='btn-group'>
+	<button class='btn btn-sm btn-default open_popup' data-script='app/admin/device-groups/edit-group.php' data-class='700' data-action='add'><i class='fa fa-plus'></i> <?php print _('Create device group') ?> </button>
+</div>
+
+<!-- table -->
+<table id='deviceGroupManagement' class='table sorted table-striped table-top' data-cookie-id-table='device_groups'>
+
+<!-- Headers -->
+<thead>
+ <tr>
+  <th> <?php print _('Device group') ?> </th>
+  <th> <?php print _('Belonging devices') ?> </th>
+  <th> <?php print _('Description') ?> </th>
+  <th></th>
+  <th></th>
+ </tr>
+</thead>
+
+<tbody>
+
+<?php
+
+// no device groups available
+if($device_groups === false) {
+	$colspan = 5;
+	print "<tr>";
+	print "	<td colspan='$colspan'>".$Result->show('info', _('No results')."!", false, false, true)."</td>";
+	print "</tr>";
+}
+// result
+else {
+	foreach ($device_groups as $device_group) {
+		//cast
+		$device_group = (array) $device_group;
+
+		// print details
+		print '<tr>';		
+
+		print " <td><span class='badge badge1 badge-white'>" . $device_group['name'] . "</span></td>";
+
+		# filter devices or fetch print all?
+		$device_group_memberships = $Tools->fetch_multiple_objects("device_to_group", "g_id", $device_group['id'], 'g_id');
+		
+		print " <td>";
+		if ($device_group_memberships === false) {
+			print "<span class='text-muted'>"._("No devices")."</span>";
+		} else {
+			//cast
+			$device_group_memberships = (array) $device_group_memberships;
+
+			foreach ($device_group_memberships as $k => $device_group_membership) {
+				$device = $Tools->fetch_object("devices", "id", $device_group_membership->d_id);
+
+				print "<a class='btn btn-xs btn-default' href='".create_link("tools", "devices", $device->id)."'><i class='fa fa-desktop prefix'></i> ". $device->hostname .'</a><br>';
+			}
+		}
+		print " </td>";
+
+		print "<td class='description'>" . $device_group['desc'] ."</td>";
+
+		# actions
+		if($User->get_module_permissions ("devices") >= User::ACCESS_RW) {
+			# add/remove users
+			print "	<td class='actions'>";
+			print "	<div class='btn-group'>";
+			print "		<a class='btn btn-xs btn-default open_popup' data-script='app/admin/device-groups/add-devices.php'    data-class='700' data-action='add'    data-g_id='$device_group[id]' rel='tooltip' data-container='body'  title='" . _('add device to this group')      . "'><i class='fa fa-plus' ></i></a>";
+			print "		<a class='btn btn-xs btn-default open_popup' data-script='app/admin/device-groups/remove-devices.php' data-class='700' data-action='remove' data-g_id='$device_group[id]' rel='tooltip' data-container='body'  title='" . _('remove device from this group') . "'><i class='fa fa-minus'></i></a>";
+			print "	</div>";
+			print "</td>";
+
+			# edit, delete
+			print "<td class='actions'>";
+			print "	<div class='btn-group'>";
+			print "		<a class='btn btn-xs btn-default open_popup' data-script='app/admin/device-groups/edit-group.php' data-class='700' data-action='edit'   data-g_id='$device_group[id]'><i class='fa fa-pencil'></i></a>";
+			print "		<a class='btn btn-xs btn-default open_popup' data-script='app/admin/device-groups/edit-group.php' data-class='700' data-action='delete' data-g_id='$device_group[id]'><i class='fa fa-times' ></i></a>";
+			print "	</div>";
+			print "</td>";
+		} else {
+			print "<td></td><td></td>";
+		}
+
+		print "</tr>";
+	}
+}
+print "</tbody>";
+print '</table>';

--- a/app/tools/device-groups/index.php
+++ b/app/tools/device-groups/index.php
@@ -1,0 +1,13 @@
+<?php
+
+/**
+ * Script to display device groups
+ *
+ */
+
+# verify that user is logged in
+$User->check_user_session();
+# verify that user has permission to module
+$User->check_module_permissions ("devices", User::ACCESS_R, true, true);
+
+require('all-device-groups.php');

--- a/app/tools/tools-menu-config.php
+++ b/app/tools/tools-menu-config.php
@@ -19,6 +19,7 @@ $tools_menu_items = [
 						"changelog"          => _("changelog"),
 						"dhcp"               => _("dhcp"),
 						"devices"            => _("devices"),
+						"device-groups"      => _("device-groups"),
 						"favourites"         => _("favourites"),
 						"firewall-zones"     => _("firewall-zones"),
 						"instructions"       => _("instructions"),
@@ -122,8 +123,10 @@ if($User->settings->enableThreshold==1)
 $tools_menu[_('Subnets')][] =   ["show"=>true, "icon"=>"fa-bullhorn",    "href"=>"threshold",                   "name"=>_("Threshold"),            "description"=>_("List of thresholded subnets")];
 
 # devices
-if($User->get_module_permissions ("devices")>=User::ACCESS_R)
+if($User->get_module_permissions ("devices")>=User::ACCESS_R) {
 $tools_menu[_('Devices')][] =   ["show"=>true, "icon"=>"fa-desktop",     "href"=>"devices",                     "name"=>_("Devices"),              "description"=>_("All configured devices")];
+$tools_menu[_('Devices')][] =   ["show"=>true, "icon"=>"fa-object-group","href"=>"device-groups",               "name"=>_("Device groups"),        "description"=>_("All configured device groups")];
+}
 if($User->settings->enableRACK == 1 && $User->get_module_permissions ("racks")>=User::ACCESS_R)
 $tools_menu[_('Devices')][] =   ["show"=>true, "icon"=>"fa-bars",        "href"=>"racks",                       "name"=>_("Racks"),                "description"=>_("Rack information")];
 if($User->settings->enableCircuits == 1 && $User->get_module_permissions ("circuits")>=User::ACCESS_R)

--- a/db/SCHEMA.sql
+++ b/db/SCHEMA.sql
@@ -274,6 +274,7 @@ CREATE TABLE `subnets` (
   `vlanId` INT(11)  UNSIGNED  NULL  DEFAULT NULL,
   `showName` BOOL NOT NULL DEFAULT '0',
   `device` INT  UNSIGNED  NULL  DEFAULT '0',
+  `deviceGroup` INT UNSIGNED NULL DEFAULT NULL,
   `permissions` varchar(1024) DEFAULT NULL, /* __no_html_escape__ */
   `pingSubnet` BOOL NOT NULL DEFAULT '0',
   `discoverSubnet` BOOL NOT NULL DEFAULT '0',
@@ -342,6 +343,33 @@ CREATE TABLE `devices` (
   PRIMARY KEY (`id`),
   KEY `hostname` (`hostname`),
   KEY `location` (`location`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+
+# Dump of table deviceGroups
+# ------------------------------------------------------------
+DROP TABLE IF EXISTS `deviceGroups`;
+
+CREATE TABLE `deviceGroups` (
+  `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
+  `name` varchar(32) DEFAULT NULL,
+  `desc` varchar(1024) DEFAULT NULL,
+  `editDate` TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+
+# Dump of table device_to_group
+# ------------------------------------------------------------
+DROP TABLE IF EXISTS `device_to_group`;
+
+CREATE TABLE `device_to_group` (
+  `d_id` int(11) unsigned,
+  `g_id` int(11) unsigned,
+  `editDate` TIMESTAMP  NULL  ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`g_id`, `d_id`),
+  FOREIGN KEY (`d_id`) REFERENCES `devices`      (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
+  FOREIGN KEY (`g_id`) REFERENCES `deviceGroups` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 

--- a/db/SCHEMA.sql
+++ b/db/SCHEMA.sql
@@ -299,7 +299,8 @@ CREATE TABLE `subnets` (
   KEY `sectionId` (`sectionId`),
   KEY `vrfId` (`vrfId`),
   KEY `customer_subnets` (`customer_id`),
-  CONSTRAINT `customer_subnets` FOREIGN KEY (`customer_id`) REFERENCES `customers` (`id`) ON DELETE SET NULL ON UPDATE CASCADE
+  CONSTRAINT `customer_subnets` FOREIGN KEY (`customer_id`) REFERENCES `customers` (`id`) ON DELETE SET NULL ON UPDATE CASCADE,
+  CONSTRAINT `subnets_deviceGroup` FOREIGN KEY (`deviceGroup`) REFERENCES `deviceGroups` (`id`) ON DELETE SET NULL ON UPDATE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /* insert default values */
 INSERT INTO `subnets` (`id`, `subnet`, `mask`, `sectionId`, `description`, `vrfId`, `masterSubnetId`, `allowRequests`, `vlanId`, `showName`, `permissions`, `isFolder`)

--- a/functions/classes/class.Devices.php
+++ b/functions/classes/class.Devices.php
@@ -52,4 +52,128 @@ class Devices extends Common_functions {
 	}
 
 
+	/**
+	 * Fetches all devices that are not in group
+	 *
+	 * @access public
+	 * @param int $group_id
+	 * @return array
+	 */
+	public function group_fetch_missing_devices($group_id) {
+		$out = [];
+
+		# get all devices
+		$devices = $this->fetch_all_objects("devices");
+		$devices = ($devices !== false) && isset($devices) ? (array)$devices : [];
+		
+		// get current group members
+		$current_group_members = $this->fetch_multiple_objects("device_to_group", "g_id", $group_id, 'g_id', result_fields: "d_id");
+		$current_group_members = ($current_group_members !== false) && isset($current_group_members) ? (array)$current_group_members : [];
+
+		foreach ($devices as $d) {
+			$found = false;
+
+			foreach ($current_group_members as $member) {
+				if ($d->id === $member->d_id) {
+					$found = true;
+					break;
+				}
+			}
+
+			if (!$found) {
+				array_push($out, $d->id);
+			}
+		}
+		return $out;
+	}
+
+		/**
+	 * Modify database object
+	 *
+	 * @param string $table
+	 * @param string $action
+	 * @param string|array $field
+	 * @param array $values
+	 * @param array $values_log
+	 * @return void
+	 */
+	public function object_modify ($table, $action=null, $field="id", $values = [], $values_log = [], $field2 = null, $values2 = null) {
+		if (!is_string($table) || is_blank($table)) return false;
+		# strip tags
+		$values     = $this->strip_input_tags ($values);
+		$values_log = $this->strip_input_tags ($values_log);
+
+		# if empty values_log inherit from values to preserve old functionality
+		if(sizeof($values_log)==0)	{ $values_log = $values; }
+
+		# execute based on action
+		if($action=="add")					{ return $this->object_add ($table, $values, $values_log); }
+		elseif($action=="delete")			{ return $this->object_delete ($table, $field, $values[$field], $field2, $values2[$field2]); }
+		else								{ return $this->Result->show("danger", _("Invalid action"), true); }
+	}
+
+	/**
+	 * Create new database object
+	 *
+	 *		$values are all values that should be passed to create object
+	 *
+	 * @access private
+	 * @param mixed $table
+	 * @param mixed $values
+	 * @param array $values_log		//log variables
+	 * @return boolean
+	 */
+	private function object_add ($table, $values, $values_log) {
+		# null empty values
+		$values = $this->reformat_empty_array_fields ($values, null);
+
+		# execute
+		try { $this->Database->insertObject($table, $values); }
+		catch (Exception $e) {
+			$this->Result->show("danger", _("Error: ").$e->getMessage(), false);
+			$this->Log->write( $table." "._("object creation"), _("Failed to create new")." ".$table." "._("database object").".<hr>".$e->getMessage()."<hr>".$this->array_to_log($this->reformat_empty_array_fields ($values_log, "NULL")), 2);
+			return false;
+		}
+		# save ID
+		$this->save_last_insert_id ();
+		# ok
+		$this->Log->write( $table." "._("Object creation"), _("A new")." ".$table." "._("database object created").".<hr>".$this->array_to_log($this->reformat_empty_array_fields ($values_log, "NULL")), 0);
+		return true;
+	}
+
+	/**
+	 * Delete object in table by specified object id
+	 *
+	 * @access private
+	 * @param mixed $table		//table to update
+	 * @param string $field		//field selection (where $field = $id)
+	 * @param mixed $id			//field identifier
+	 * @return boolean
+	 */
+	private function object_delete ($table, $field, $id, $field2, $id2) {
+		# execute
+		try { $this->Database->deleteRow($table, $field, $id, $field2, $id2); }
+		catch (Exception $e) {
+			$this->Log->write( $table." "._("object")." ".$id." "._("delete"), _("Failed to delete object")." ".$field=$id." "._("in")." ".$table.".<hr>".$e->getMessage(), 2);
+			$this->Result->show("danger", _("Error: ").$e->getMessage(), false);
+			return false;
+		}
+		# save ID
+		$this->save_last_insert_id ();
+		# ok
+		$this->Log->write( $table." "._("object")." ".$id." "._("edit"), _("Object")." ".$field=$id." "._("in")." ".$table." "._("deleted").".", 0);
+		return true;
+	}
+
+	public $lastId = null;
+
+	/**
+	 * Saves last insert ID on object modification.
+	 *
+	 * @access public
+	 * @return void
+	 */
+	public function save_last_insert_id () {
+		$this->lastId = $this->Database->lastInsertId();
+	}
 }

--- a/functions/upgrade_queries/upgrade_queries_1.8.php
+++ b/functions/upgrade_queries/upgrade_queries_1.8.php
@@ -23,3 +23,23 @@ $upgrade_queries["1.8.45"][] = "CREATE TABLE `apiLock` (
 $upgrade_queries["1.8.45"][] = "INSERT INTO `apiLock` (`id`, `description`) VALUES (1, 'API POST lock');";
 $upgrade_queries["1.8.45"][] = "-- Database version bump";
 $upgrade_queries["1.8.45"][] = "UPDATE `settings` SET `dbversion` = '45';";
+
+
+$upgrade_queries["1.8.deviceGroup"]   = [];
+$upgrade_queries["1.8.deviceGroup"][] = "CREATE TABLE `deviceGroups` (
+  `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
+  `name` varchar(32) DEFAULT NULL,
+  `desc` varchar(1024) DEFAULT NULL,
+  `editDate` TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;";
+$upgrade_queries["1.8.deviceGroup"][] = "CREATE TABLE `device_to_group` (
+  `d_id` int(11) unsigned,
+  `g_id` int(11) unsigned,
+  `editDate` TIMESTAMP  NULL  ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`g_id`, `d_id`),
+  FOREIGN KEY (`d_id`) REFERENCES `devices`      (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
+  FOREIGN KEY (`g_id`) REFERENCES `deviceGroups` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;";
+$upgrade_queries["1.8.deviceGroup"][] = "ALTER TABLE `subnets` ADD `deviceGroup` INT UNSIGNED NULL DEFAULT NULL AFTER `device`;";
+$upgrade_queries["1.8.deviceGroup"][] = "ALTER TABLE `subnets` ADD CONSTRAINT `subnets_deviceGroup` FOREIGN KEY (`deviceGroup`) REFERENCES `deviceGroups` (`id`) ON DELETE SET NULL ON UPDATE CASCADE;";


### PR DESCRIPTION
During an SNMP query, all devices in the subnet's section that match the SNMP query are scanned.
This causes unrelated devices to be scanned, increasing the overall scan duration.

This PR changes this behavior by adding support for device groups.
When a subnet has a device group set, the SNMP scan will only query the members of that group.

### Changes
- added database support for device groups
  - added upgrade queries in [upgrade_queries_1.8.php](https://github.com/phpipam/phpipam/compare/develop...krds0:fix/SNMP-scan-optimization?expand=1#diff-f6e9ff2b75a6a3329aa61e0186f9867451fb7109a95679b318a59b2cfba31d29)
   (subversion is an invalid value, must be changed to release version)
- added device group management in the GUI
- added device group field to subnet edit form
  - setting both 'device' and 'deviceGroup' field results in an error
    (this is the easiest approach, but not the prettiest)

### Closes
- #2555
- #3776