### PR TITLE
Bugfix: Reject '.' in custom field names

### DIFF
--- a/app/admin/custom-fields/edit-result.php
+++ b/app/admin/custom-fields/edit-result.php
@@ -50,7 +50,7 @@ else {
 	if(is_numeric(substr($POST->name, 0, 1))) 								{ $errors[] = _('Name must not start with number'); }
 
 	# only alphanumeric and _ are allowed
-	if(!preg_match('/^(\p{L}|\p{N})[(\p{L}|\p{N}) _.-]+$/u', $POST->name)) 	{ $errors[] = _('Only alphanumeric, spaces and underscore characters are allowed'); }
+	if(!preg_match('/^(\p{L}|\p{N})[(\p{L}|\p{N}) _-]+$/u', $POST->name)) 	{ $errors[] = _('Only alphanumeric, spaces and underscore characters are allowed'); }
 
 	# required must have default value
 	if($POST->NULL=="NO" && mb_strlen((string) $POST->fieldDefault)==0)			{ $errors[] = _('Required fields must have default values'); }


### PR DESCRIPTION
If a custom field name contains a dot (e.g. `foo.bar`), saving any object that uses the field silently overwrites that column with NULL.

PHP rewrites `.` to `_` in `$_POST` keys at the SAPI level, so the value never reaches `update_POST_custom_fields()` under the real field name and falls into the `else` branch that wipes it. Same dynamic as #1154 for spaces (which got the `___` mapping) — the name-validation regex in `app/admin/custom-fields/edit-result.php` still allows `.` though, so it's easy to walk into.

Minimal fix: drop `.` from the allowed character class. Existing fields with a dot need to be renamed by the admin — the column was losing its value on every save before this anyway.

Left the broader `.` ↔ `___DOT___` mapping across the import/export paths out for now to keep the diff small. Can do that as a follow-up if you'd rather have it together.