### PR TITLE
Add ENV configuration for api_allow_unsafe inside docker container

### DIFF
--- a/config.docker.php
+++ b/config.docker.php
@@ -109,3 +109,10 @@ $session_storage = "database";
  * General tweaks
  ******************************/
 $config['footer_message'] = file_env('IPAM_FOOTER_MESSAGE', $config['footer_message']);
+
+/**
+ * Allow API calls over HTTP (security = none)
+ *
+ * @var bool
+ */
+$api_allow_unsafe = file_env('API_ALLOW_UNSAFE',  $api_allow_unsafe);


### PR DESCRIPTION
api_allow_unsafe is configurable from docker compose

It also needs to add this to the docker hub image documentation. But I didn't find where it is.