### PR TITLE
Add api_allow_unsage is configurable from ENV for docker compose

### DIFF
--- a/config.docker.php
+++ b/config.docker.php
@@ -104,8 +104,16 @@ $cookie_samesite = file_env('COOKIE_SAMESITE', $cookie_samesite);
  */
 $session_storage = "database";
 
+/**
+ * Allow API calls over HTTP (security = none)
+ *
+ * @var bool
+ */
+$api_allow_unsafe = file_env('API_ALLOW_UNSAFE',  $api_allow_unsafe);
+
 
 /**
  * General tweaks
  ******************************/
 $config['footer_message'] = file_env('IPAM_FOOTER_MESSAGE', $config['footer_message']);
+


### PR DESCRIPTION
Configuration option $api_allow_unsafe is configurable from docker compose
It also needs to add this to the docker hub image documentation. But I didn't find where it is.