### PR TITLE
Add support for timeservers

### DIFF
--- a/db/SCHEMA.sql
+++ b/db/SCHEMA.sql
@@ -283,6 +283,7 @@ CREATE TABLE `subnets` (
   `DNSrecursive` BOOL NOT NULL DEFAULT '0',
   `DNSrecords` BOOL NOT NULL DEFAULT '0',
   `nameserverId` INT(11) NULL DEFAULT '0',
+  `timeserverId` INT(11) NULL DEFAULT '0',
   `scanAgent` INT(11)  DEFAULT NULL,
   `customer_id` INT(11) unsigned NULL default NULL,
   `isFolder` BOOL NOT NULL DEFAULT '0',
@@ -514,6 +515,25 @@ CREATE TABLE `nameservers` (
 INSERT INTO `nameservers` (`name`, `namesrv1`, `description`, `permissions`)
 VALUES
 	('Google NS', '8.8.8.8;8.8.4.4', 'Google public nameservers', '1;2');
+
+
+# Dump of table timeservers
+# ------------------------------------------------------------
+DROP TABLE IF EXISTS `timeservers`;
+
+CREATE TABLE `timeservers` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `name` varchar(255) NOT NULL,
+  `timesrv1` varchar(255) DEFAULT NULL,
+  `description` text,
+  `permissions` varchar(128) DEFAULT NULL, /* __no_html_escape__ */
+  `editDate` TIMESTAMP  NULL  ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/* insert default values */
+INSERT INTO `timeservers` (`name`, `timesrv1`, `description`, `permissions`)
+VALUES
+	('NTP pool servers', '0.pool.ntp.org;1.pool.ntp.org', 'NTP pool project servers', '1;2');
 
 
 
@@ -1103,4 +1123,4 @@ CREATE TABLE `nominatim_cache` (
 # ------------------------------------------------------------
 
 UPDATE `settings` SET `version` = "1.9";
-UPDATE `settings` SET `dbversion` = 46;
+UPDATE `settings` SET `dbversion` = 47;

--- a/functions/classes/class.Log.php
+++ b/functions/classes/class.Log.php
@@ -193,6 +193,7 @@ class Logging extends Common_functions {
 						"DNSrecursive"          => "Create recursive PowerDNS records",
 						"DNSrecords"            => "Show PowerDNS records",
 						"nameserverId"          => "Nameserver",
+						"timeserverId"           => "Timeserver",
 						"scanAgent"             => "Scan agent index",
 						"isFolder"              => "Object is folder",
 						"isFull"                => "Subnet is marked as full",
@@ -903,6 +904,8 @@ class Logging extends Common_functions {
 			elseif($k == "permissions") 	{ $this->object_new[$k] = $this->changelog_format_permission_diff ($k, $v); }
 			// nameserver index
 			elseif($k == "nameserverId") 	{ $this->object_new[$k] = $this->changelog_format_ns_diff ($k, $v); }
+			// timeserver index
+			elseif($k == "timeserverId") 	{ $this->object_new[$k] = $this->changelog_format_time_diff ($k, $v); }
 		}
 	}
 
@@ -941,6 +944,8 @@ class Logging extends Common_functions {
 			elseif($k == "permissions") 	{ $this->object_old[$k] = $this->changelog_format_permission_diff ($k, $v); }
 			// nameserver index
 			elseif($k == "nameserverId") 	{ $this->object_old[$k] = $this->changelog_format_ns_diff ($k, $v); }
+			// timeserver index
+			elseif($k == "timeserverId") 	{ $this->object_old[$k] = $this->changelog_format_time_diff ($k, $v); }
 		}
 	}
 
@@ -1003,6 +1008,8 @@ class Logging extends Common_functions {
 				elseif($k == "permissions") 	{ $v = $this->changelog_format_permission_diff ($k, $v); }
 				// nameserver index
 				elseif($k == "nameserverId") 	{ $v = $this->changelog_format_ns_diff ($k, $v); }
+				// timeserver index
+				elseif($k == "timeserverId") 	{ $v = $this->changelog_format_time_diff ($k, $v); }
 				// make booleans
 				$v = $this->changelog_make_booleans ($k, $v);
 				//set log
@@ -1330,6 +1337,37 @@ class Logging extends Common_functions {
 			$ns = $this->Tools->fetch_object("nameservers", "id", $v);
 			if (is_object($ns))
 				$v = $ns->name." [".$ns->namesrv1."]";
+		}
+		//result
+		return $v;
+	}
+
+	/**
+	 * Format timeserver if change
+	 *
+	 * @access private
+	 * @param string $k
+	 * @param mixed $v
+	 * @return void
+	 */
+	private function changelog_format_time_diff ($k, $v) {
+		//old none
+		if(is_null($this->object_old) || !isset($this->object_old[$k]) || $this->object_old[$k] == 0)	{
+			$this->object_old[$k] = _("None");
+		}
+		elseif($this->object_old[$k] != "NULL") {
+			$time = $this->Tools->fetch_object("timeservers", "id", $this->object_old[$k]);
+			if (is_object($time))
+				$this->object_old[$k] = $time->name." [".$time->timesrv1."]";
+		}
+		// new none
+		if($v == 0)	{
+			$v = _("None");
+		}
+		elseif($v != "NULL") {
+			$time = $this->Tools->fetch_object("timeservers", "id", $v);
+			if (is_object($time))
+				$v = $time->name." [".$time->timesrv1."]";
 		}
 		//result
 		return $v;

--- a/functions/classes/class.Sections.php
+++ b/functions/classes/class.Sections.php
@@ -404,6 +404,40 @@ class Sections extends Common_functions {
 		}
 	}
 
+	/**
+	 * Fetches timeserver sets to belong to section
+	 *
+	 * @access public
+	 * @param mixed $sectionId
+	 * @return array|bool
+	 */
+	public function fetch_section_timeserver_sets ($sectionId) {
+		# first fetch all timeserver sets
+		$Admin = new Admin ($this->Database, false);
+		$timeservers = $Admin->fetch_all_objects ("timeservers","name");
+		# loop and check
+		if ($timeservers!==false) {
+    		$permitted = [];
+			foreach($timeservers as $n) {
+				//default
+				if($n->id==1) {
+						$permitted[] = $n->id;
+				}
+				else {
+					//array
+					if(in_array($sectionId, explode(";", (string) $n->permissions))) {
+						$permitted[] = $n->id;
+					}
+				}
+			}
+			# return permitted
+			return $permitted;
+		}
+		else {
+			return false;
+		}
+	}
+
 
 
 

--- a/functions/classes/class.Subnets.php
+++ b/functions/classes/class.Subnets.php
@@ -420,6 +420,7 @@ class Subnets extends Common_functions {
 							"showName"       => @$subnet['showName'],
 							"permissions"    => $subnet['permissions'],
 							"nameserverId"   => $subnet_old->nameserverId,
+							"timeserverId"    => $subnet_old->timeserverId,
 							"device"		 => $subnet_old->device,
 							"isPool"		 => $subnet_old->isPool,
 							];

--- a/functions/classes/class.Tools.php
+++ b/functions/classes/class.Tools.php
@@ -1255,6 +1255,12 @@ class Tools extends Common_functions {
 				$mail['DNS servers'] = $v;
 				}
 			}
+			// timeservers
+			elseif ($k=="time") {
+				if (!is_blank($v)) {
+				$mail['Timeservers'] = $v;
+				}
+			}
 			// vlans
 			elseif ($k=="vlan") {
 				if (!is_blank($v)) {

--- a/functions/scripts/merge_databases.php
+++ b/functions/scripts/merge_databases.php
@@ -179,6 +179,10 @@ foreach ($old_data as $table => $table_content) {
 			if ($value_obj->nameserverId > 0) {
 				$new_data[$table][$lk]->nameserverId = $highest_ids_append["nameservers"] + $value_obj->nameserverId;
 			}
+			// time
+			if ($value_obj->timeserverId > 0) {
+				$new_data[$table][$lk]->timeserverId = $highest_ids_append["timeservers"] + $value_obj->timeserverId;
+			}
 			// location
 			if ($value_obj->location > 0) {
 				$new_data[$table][$lk]->location = $highest_ids_append["locations"] + $value_obj->location;
@@ -326,6 +330,22 @@ foreach ($old_data as $table => $table_content) {
 	}
 	// update nameservers
 	elseif ($table == "nameservers") {
+		// go through each table and update
+		foreach ($table_content as $lk=>$value_obj) {
+			$new_data[$table][$lk]->id = $highest_ids_append[$table] + $value_obj->id;
+			// permissions
+			if(!is_blank($value_obj->permissions)) {
+				$fs_tmp = explode(";", (string) $value_obj->permissions);
+				$fs_new = [];
+				foreach ($fs_tmp as $gid) {
+					$fs_new[] = $gid+$highest_ids_append["sections"];
+				}
+				$new_data[$table][$lk]->permissions = implode(";", $fs_new);
+			}
+		}
+	}
+	// update timeservers
+	elseif ($table == "timeservers") {
 		// go through each table and update
 		foreach ($table_content as $lk=>$value_obj) {
 			$new_data[$table][$lk]->id = $highest_ids_append[$table] + $value_obj->id;

--- a/functions/upgrade_queries/upgrade_queries_1.9.php
+++ b/functions/upgrade_queries/upgrade_queries_1.9.php
@@ -6,3 +6,18 @@
 $upgrade_queries["1.9.46"]   = [];
 $upgrade_queries["1.9.46"][] = "-- Version update";
 $upgrade_queries["1.9.46"][] = "UPDATE `settings` set `version` = '1.9';";
+
+$upgrade_queries["1.9.47"]   = [];
+$upgrade_queries["1.9.47"][] = "CREATE TABLE `timeservers` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `name` varchar(255) NOT NULL,
+  `timesrv1` varchar(255) DEFAULT NULL,
+  `description` text,
+  `permissions` varchar(128) DEFAULT NULL,
+  `editDate` TIMESTAMP  NULL  ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;";
+$upgrade_queries["1.9.47"][] = "INSERT INTO `timeservers` (`name`, `timesrv1`, `description`, `permissions`) VALUES ('NTP pool servers', '0.pool.ntp.org;1.pool.ntp.org', 'NTP pool project servers', '1;2');";
+$upgrade_queries["1.9.47"][] = "ALTER TABLE `subnets` ADD `timeserverId` INT(11) NULL DEFAULT '0' AFTER `nameserverId`;";
+$upgrade_queries["1.9.47"][] = "-- Database version bump";
+$upgrade_queries["1.9.47"][] = "UPDATE `settings` SET `dbversion` = '47';";

--- a/public/api/controllers/Common.php
+++ b/public/api/controllers/Common.php
@@ -830,6 +830,7 @@ class Common_api_functions {
 		if($controller=="l2domains"){ $this->keys['permissions'] = "sections"; }
 		if($this->_params->controller=="tools" && $tools_table=="deviceTypes")  { $this->keys['tid'] = "id"; }
 		if($this->_params->controller=="tools" && $tools_table=="nameservers")  { $this->keys['permissions'] = "sections"; }
+		if($this->_params->controller=="tools" && $tools_table=="timeservers")   { $this->keys['permissions'] = "sections"; }
 		if($this->_params->controller=="subnets" )  								  { $this->keys['ip'] = "ip_addr"; }
 
 		// special keys for POST / PATCH
@@ -959,5 +960,15 @@ class Common_api_functions {
 	 */
 	protected function read_subnet_nameserver($nsid) {
 		return (is_numeric($nsid) && $nsid > 0) ? $this->Tools->fetch_object("nameservers", "id", $nsid) : false;
+	}
+
+	/**
+	 * Returns timeserver details
+	 *
+	 * @param int $tsid
+	 * @return object|false
+	 */
+	protected function read_subnet_timeserver($tsid) {
+		return (is_numeric($tsid) && $tsid > 0) ? $this->Tools->fetch_object("timeservers", "id", $tsid) : false;
 	}
 }

--- a/public/api/controllers/Prefix.php
+++ b/public/api/controllers/Prefix.php
@@ -144,6 +144,7 @@ class Prefix_controller extends Common_api_functions {
                                         "DNSrecursive",
                                         "DNSrecords",
                                         "nameserverId",
+                                        "timeserverId",
                                         "scanAgent",
                                         "isFull",
                                         "state",

--- a/public/api/controllers/Sections.php
+++ b/public/api/controllers/Sections.php
@@ -105,6 +105,12 @@ class Sections_controller extends Common_api_functions {
 						$result[$k]->nameservers = $ns;
 					}
 
+					//timeservers
+					$time = $this->read_subnet_timeserver ($r->timeserverId);
+					if ($time!==false) {
+						$result[$k]->timeservers = $time;
+					}
+
 					// get usage
 					$result[$k]->usage = $this->read_subnet_usage($r->id);
 

--- a/public/api/controllers/Subnets.php
+++ b/public/api/controllers/Subnets.php
@@ -698,6 +698,11 @@ class Subnets_controller extends Common_api_functions {
                 $result->nameservers = $ns;
             }
 
+            $time = $this->read_subnet_timeserver($result->timeserverId);
+            if ($time!==false) {
+                $result->timeservers = $time;
+            }
+
     		$gateway = $this->read_subnet_gateway(null);
     		if ( $gateway!== false) {
         		$result->gatewayId = $gateway->id;
@@ -741,6 +746,11 @@ class Subnets_controller extends Common_api_functions {
 			$ns = $this->read_subnet_nameserver($result->nameserverId);
 			if ($ns!==false) {
 				$result->nameservers = $ns;
+			}
+
+			$time = $this->read_subnet_timeserver($result->timeserverId);
+			if ($time!==false) {
+				$result->timeservers = $time;
 			}
 
 			if (isset($subnet_gws[$result->id])) {

--- a/public/api/controllers/Tools.php
+++ b/public/api/controllers/Tools.php
@@ -84,6 +84,7 @@ class Tools_controller extends Common_api_functions {
 										"vlans"       => "vlans",
 										"vrf"         => "vrfs",
 										"nameservers" => "nameservers",
+										"timeservers"  => "timeservers",
 										"scanAgents"  => "scanagents",
 										"locations"   => "locations",
 										"racks"       => "racks",
@@ -106,6 +107,7 @@ class Tools_controller extends Common_api_functions {
 								"vlans"       => ["id2", "id3"],
 								"vrf"         => ["id2", "id3"],
 								"nameservers" => ["id2"],
+								"timeservers"  => ["id2"],
 								"scanAgents"  => ["id2"],
 								"locations"   => ["id2", "id3"],
 								"racks"       => ["id2", "id3"],
@@ -157,6 +159,7 @@ class Tools_controller extends Common_api_functions {
 						["rel"=>"vlans",		"href"=>"/api/".$_GET['app_id']."/vlan/"],
 						["rel"=>"vrfs",		"href"=>"/api/".$_GET['app_id']."/vrf/"],
 						["rel"=>"nameservers",	"href"=>"/api/".$_GET['app_id']."/tools/nameservers/"],
+						["rel"=>"timeservers",	"href"=>"/api/".$_GET['app_id']."/tools/timeservers/"],
 						["rel"=>"scanAgents",	"href"=>"/api/".$_GET['app_id']."/tools/scanagents/"],
 						["rel"=>"locations",	"href"=>"/api/".$_GET['app_id']."/tools/locations/"],
 						["rel"=>"racks",	    "href"=>"/api/".$_GET['app_id']."/tools/racks/"],
@@ -239,6 +242,11 @@ class Tools_controller extends Common_api_functions {
                 		$ns = $this->read_subnet_nameserver ($r->nameserverId);
                         if ($ns!==false) {
                             $result[$k]->nameservers = $ns;
+                        }
+                    	//timeservers
+                		$time = $this->read_subnet_timeserver ($r->timeserverId);
+                        if ($time!==false) {
+                            $result[$k]->timeservers = $time;
                         }
     				}
     			}

--- a/public/app/admin/admin-menu-config.php
+++ b/public/app/admin/admin-menu-config.php
@@ -44,6 +44,7 @@ $admin_menu[_('IP related management')][] = ["show"=>true, "icon"=>"fa-exchange"
 if($User->settings->enableRouting==1)
 $admin_menu[_('IP related management')][] = ["show"=>true, "icon"=>"fa-exchange",       "href"=>"routing",                "name"=>_("Routing"),                  "description"=>_("Routing management")];
 $admin_menu[_('IP related management')][] = ["show"=>true, "icon"=>"fa-cloud",          "href"=>"nameservers",            "name"=>_("Nameservers"),              "description"=>_("Recursive nameserver sets for subnets")];
+$admin_menu[_('IP related management')][] = ["show"=>true, "icon"=>"fa-clock-o",        "href"=>"timeservers",            "name"=>_("Timeservers"),              "description"=>_("Timeserver sets for subnets")];
 if($User->settings->enableFirewallZones == 1)
 $admin_menu[_('IP related management')][] = ["show"=>true, "icon"=>"fa-fire",           "href"=>"firewall-zones",         "name"=>_("Firewall Zones"),           "description"=>_("Firewall zone management")];
 $admin_menu[_('IP related management')][] = ["show"=>true, "icon"=>"fa-upload",         "href"=>"import-export",          "name"=>_("Import / Export"),          "description"=>_("Import/Export IP related data (VRF, VLAN, Subnets, IP, Devices)")];
@@ -90,6 +91,7 @@ $admin_menu_items = [
                     "languages"              => _("languages"),
                     "mail"                   => _("mail"),
                     "nameservers"            => _("nameservers"),
+                    "timeservers"            => _("timeservers"),
                     "powerDNS"               => _("powerDNS"),
                     "racks"                  => _("racks"),
                     "replace-fields"         => _("replace-fields"),

--- a/public/app/admin/requests/edit-result.php
+++ b/public/app/admin/requests/edit-result.php
@@ -98,6 +98,9 @@ else {
 	//set dns
 	$dns = $Tools->fetch_object ("nameservers", "id", $subnet['nameserverId']);
 	$tmp['dns'] = $dns==false ? "" : $dns->description." <br> ".str_replace(";", ", ", (string) $dns->namesrv1);
+	//set time
+	$time = $Tools->fetch_object ("timeservers", "id", $subnet['timeserverId']);
+	$tmp['time'] = $time==false ? "" : $time->description." <br> ".str_replace(";", ", ", (string) $time->timesrv1);
 
 	$POST->read($tmp);
 

--- a/public/app/admin/subnets/edit-result.php
+++ b/public/app/admin/subnets/edit-result.php
@@ -288,6 +288,7 @@ else {
 					"DNSrecursive"   => $Admin->verify_checkbox($POST->DNSrecursive),
 					"DNSrecords"     => $Admin->verify_checkbox($POST->DNSrecords),
 					"nameserverId"   => $POST->nameserverId,
+					"timeserverId"    => $POST->timeserverId,
 					"device"         => $POST->device,
 					"isFull"         => $Admin->verify_checkbox($POST->isFull),
 					"isPool"         => $Admin->verify_checkbox($POST->isPool)
@@ -377,6 +378,7 @@ else {
 					"vlanId"       =>$POST->vlanId,
 					"vrfId"        =>$POST->vrfId,
 					"nameserverId" =>$POST->nameserverId,
+					"timeserverId"  =>$POST->timeserverId,
 					"scanAgent"    =>$POST->scanAgent,
 					"device"       =>$POST->device,
 					"isFull"       =>$Admin->verify_checkbox($POST->isFull),

--- a/public/app/admin/subnets/edit-timeserver-dropdown.php
+++ b/public/app/admin/subnets/edit-timeserver-dropdown.php
@@ -1,0 +1,74 @@
+<?php
+
+/*
+ * Print select timeserver set in subnets
+ *******************************/
+
+/* required functions */
+if(!is_object($User)) {
+	/* functions */
+	require_once  __DIR__ . '/../../../../functions/functions.php';
+
+	# initialize user object
+	$Database 	= new Database_PDO;
+	$User 		= new User ($Database);
+	$Tools	 	= new Tools ($Database);
+	$Sections	= new Sections ($Database);
+	$Result 	= new Result ();
+}
+
+# verify that user is logged in
+$User->check_user_session();
+
+# fetch all permitted timeserver sets
+$permitted_timeservers = $Sections->fetch_section_timeserver_sets ($POST->sectionId);
+
+# fetch all belonging timeserver set
+$cnt = 0;
+
+# Only parse timeservers if any exists
+if($permitted_timeservers != false) {
+	foreach($permitted_timeservers as $k=>$n) {
+		// fetch timeserver sets and append
+		$timeserver_set = $Tools->fetch_multiple_objects("timeservers", "id", $n, "name", "timesrv1");
+
+		//save to array
+		$tsout[$n] = $timeserver_set;
+
+		//count add
+		$cnt++;
+	}
+	//filter out empty
+	$permitted_timeservers = isset($tsout) ? array_filter($tsout) : false;
+}
+
+?>
+
+<select name="timeserverId" class="form-control input-sm input-w-auto">
+	<optgroup label='<?php print _('Select timeserver set'); ?>'>
+
+	<option value="0"><?php print _('No timeservers'); ?></option>
+	<?php
+	# print all available timeserver sets
+	if ($permitted_timeservers!==false) {
+		foreach($permitted_timeservers as $n) {
+
+			if($n[0]!==null) {
+				foreach($n as $time) {
+					// set print
+					$printTS = "$time->name";
+					$printTS .= " (" . array_shift(explode(";",(string) $time->timesrv1)).",...)";
+
+					/* selected? */
+					if(@$subnet_old_details['timeserverId']==$time->id) 	{ print '<option value="'. $time->id .'" selected>'. $printTS .'</option>'. "\n"; }
+					elseif($POST->timeserverId == $time->id) 			{ print '<option value="'. $time->id .'" selected>'. $printTS .'</option>'. "\n"; }
+					else 												{ print '<option value="'. $time->id .'">'. $printTS .'</option>'. "\n"; }
+				}
+			}
+		}
+	}
+	?>
+	</optgroup>
+
+
+</select>

--- a/public/app/admin/subnets/edit.php
+++ b/public/app/admin/subnets/edit.php
@@ -73,6 +73,7 @@ else {
     	$subnet_old_details['pingSubnet'] 	    = @$subnet_old_temp['pingSubnet'];        // inherit pingSubnet
     	$subnet_old_details['discoverSubnet']   = @$subnet_old_temp['discoverSubnet'];    // inherit discovery
     	$subnet_old_details['nameserverId']     = @$subnet_old_temp['nameserverId'];      // inherit nameserver
+    	$subnet_old_details['timeserverId']      = @$subnet_old_temp['timeserverId'];       // inherit timeserver
     	if($User->settings->enableLocations=="1")
     	$subnet_old_details['location']         = @$subnet_old_temp['location'];          // inherit location
         if($User->settings->enableCustomers=="1")
@@ -299,6 +300,15 @@ $("input[name='subnet']").change(function() {
 			<?php include('edit-nameserver-dropdown.php'); ?>
 		</td>
 		<td class="info2"><?php print _('Select nameserver set'); ?></td>
+    </tr>
+
+	<!-- Timeservers -->
+	<tr>
+		<td class="middle"><?php print _('Timeservers'); ?></td>
+		<td id="timeserverDropdown">
+			<?php include('edit-timeserver-dropdown.php'); ?>
+		</td>
+		<td class="info2"><?php print _('Select timeserver set'); ?></td>
     </tr>
 
     <!-- Master subnet -->

--- a/public/app/admin/timeservers/edit-result.php
+++ b/public/app/admin/timeservers/edit-result.php
@@ -1,0 +1,82 @@
+<?php
+
+/**
+ * Script to edit timeserver sets
+ ***************************/
+
+/* functions */
+require_once  __DIR__ . '/../../../../functions/functions.php';
+
+# initialize user object
+$Database 	= new Database_PDO;
+$User 		= new User ($Database);
+$Admin	 	= new Admin ($Database);
+$Result 	= new Result ();
+
+# verify that user is logged in
+$User->check_user_session();
+# admin check
+$User->is_admin();
+
+# check maintaneance mode
+$User->check_maintaneance_mode ();
+# validate csrf cookie
+$User->Crypto->csrf_cookie ("validate", "time", $POST->csrf_cookie) === false ? $Result->show("danger", _("Invalid CSRF cookie"), true) : "";
+
+
+# Name and primary timeserver must be present!
+if ($POST->action!="delete") {
+
+	$m=1;
+	$timeservers_reindexed =  [];
+	# reindex
+	foreach($POST as $k=>$v) {
+		if(strpos((string) $k, "timesrv-")!==false) {
+			$timeservers_reindexed["timesrv-".$m] = $v;
+			$m++;
+			unset($POST->{$k});
+		}
+	}
+	# join
+	$POST->read($timeservers_reindexed);
+
+	if($POST->name == "") 				{ $Result->show("danger", _("Name is mandatory"), true); }
+	if(trim($POST->{'timesrv-1'}) == "") { $Result->show("danger", _("Primary timeserver is mandatory"), true); }
+}
+
+// merge timeservers
+foreach($POST as $key=>$line) {
+	if (!is_blank(strstr((string) $key,"timesrv-"))) {
+		if (!is_blank($line)) {
+			$all_timeservers[] = trim((string) $line);
+		}
+	}
+}
+$POST->timesrv1 = isset($all_timeservers) ? implode(";", $all_timeservers) : "";
+
+// set sections
+$temp = [];
+foreach($POST as $key=>$line) {
+	if (!is_blank(strstr((string) $key,"section-"))) {
+		$key2 = str_replace("section-", "", (string) $key);
+		$temp[] = $key2;
+		unset($POST->{$key});
+	}
+}
+# glue sections together
+$POST->permissions = sizeof($temp)>0 ? implode(";", $temp) : null;
+
+# set update array
+$values = ["id"=>$POST->timeserverid,
+				"name"=>$POST->name,
+				"permissions"=>$POST->permissions,
+				"timesrv1"=>$POST->timesrv1,
+				"description"=>$POST->description
+				];
+# update
+if(!$Admin->object_modify("timeservers", $POST->action, "id", $values))	{ $Result->show("danger", _("Failed to")." ".$User->get_post_action()." "._("timeserver set").'!', true); }
+else { $Result->show("success", _("Timeserver set")." ".$User->get_post_action()." "._("successful").'!', false); }
+
+
+# remove all references if delete
+if($POST->action=="delete") { $Admin->remove_object_references ("subnets", "timeserverId", $POST->timeserverid); }

--- a/public/app/admin/timeservers/edit.php
+++ b/public/app/admin/timeservers/edit.php
@@ -1,0 +1,152 @@
+<?php
+
+/**
+ *	Print all available timeserver sets and configurations
+ ************************************************/
+
+/* functions */
+require_once  __DIR__ . '/../../../../functions/functions.php';
+
+# initialize user object
+$Database 	= new Database_PDO;
+$User 		= new User ($Database);
+$Admin	 	= new Admin ($Database);
+$Tools	 	= new Tools ($Database);
+$Sections	= new Sections ($Database);
+$Result 	= new Result ();
+
+# verify that user is logged in
+$User->check_user_session();
+# admin check
+$User->is_admin();
+
+# create csrf token
+$csrf = $User->Crypto->csrf_cookie ("create", "time");
+
+# validate action
+$Admin->validate_action();
+
+# get Timeserver sets
+if($POST->action!="add") {
+	$timeservers = $Admin->fetch_object ("timeservers", "id", $POST->timeserverid);
+	$timeservers!==false ? : $Result->show("danger", _("Invalid ID"), true, true);
+} else {
+	$timeservers = new Params();
+}
+
+
+# disable edit on delete
+$readonly = $POST->action=="delete" ? "readonly" : "";
+
+# set timeservers
+$timeservers->timesrv1 = !is_string($timeservers->timesrv1) ? [" "] : explode(";", $timeservers->timesrv1);
+?>
+
+
+<!-- header -->
+<div class="pHeader"><?php print $User->get_post_action(); ?> <?php print _('Timeserver set'); ?></div>
+
+<!-- content -->
+<div class="pContent">
+
+	<form id="timeserverManagementEdit">
+	<table id="timeserverManagementEdit2" class="table table-noborder table-condensed">
+
+	<tbody>
+	<!-- name  -->
+	<tr>
+		<td style="width: 200px;"><?php print _('Name'); ?></td>
+		<td>
+			<input type="text" class="name form-control input-sm" name="name" placeholder="<?php print _('Timeserver set'); ?>" value="<?php print $timeservers->name; ?>" <?php print $readonly; ?>>
+		</td>
+		<td></td>
+	</tr>
+	</tbody>
+
+	<tbody id="timeservers">
+	<!-- Timeservers -->
+	<?php
+	//loop
+	$m=1;
+	foreach ($timeservers->timesrv1 as $time) {
+		print "<tr id='timesrv-$m'>";
+		print "	<td>"._("Timeserver")." $m</td>";
+		print "	<td>";
+		print "	<input type='text' class='rd form-control input-sm' name='timesrv-$m' value='$time' $readonly>";
+		print "	</td>";
+		print "	<td><button class='btn btn-sm btn-default' id='remove_timeserver' data-id='timesrv-".$m."'><i class='fa fa-trash-o'></i></button></td>";
+		print "</tr>";
+		//next
+		$m++;
+	}
+	?>
+	</tbody>
+
+	<tbody>
+	<!-- add new -->
+	<tr>
+		<td></td>
+		<td>
+			<button class="btn btn-sm btn-default" id="add_timeserver" data-id='<?php print $m; ?>' <?php print $readonly; ?>><i class="fa fa-plus"></i> <?php print _('Add timeserver'); ?></button>
+		</td>
+		<td></td>
+	</tr>
+
+	<!-- Description -->
+	<tr>
+		<td><?php print _('Description'); ?></td>
+		<td>
+			<?php
+			if( ($POST->action == "edit") || ($POST->action == "delete") ) { print '<input type="hidden" name="timeserverid" value="'. escape_input($POST->timeserverid) .'">'. "\n";}
+			?>
+			<input type="hidden" name="action" value="<?php print escape_input($POST->action); ?>">
+			<input type="hidden" name="csrf_cookie" value="<?php print $csrf; ?>">
+			<input type="text" class="description form-control input-sm" name="description" placeholder="<?php print _('Description'); ?>" value="<?php print $timeservers->description; ?>" <?php print $readonly; ?>>
+		</td>
+		<td></td>
+	</tr>
+
+	<!-- sections -->
+	<tr>
+		<td style="vertical-align: top !important"><?php print _('Sections to display timeserver set in'); ?>:</td>
+		<td style="padding-left:20px">
+		<?php
+		# select sections
+		$sections = $Sections->fetch_all_sections();
+		# reformat domains sections to array
+		$timeservers_sections = explode(";", (string) $timeservers->permissions);
+		$timeservers_sections = is_array($timeservers_sections) ? $timeservers_sections : [];
+		// loop
+		if ($sections !== false) {
+			foreach($sections as $section) {
+				if(in_array($section->id, @$timeservers_sections)) 	{ print '<div class="checkbox" style="margin:0px;"><input type="checkbox" name="section-'. $section->id .'" value="on" checked> '. $section->name .'</div>'. "\n"; }
+				else 												{ print '<div class="checkbox" style="margin:0px;"><input type="checkbox" name="section-'. $section->id .'" value="on">'. $section->name .'</span></div>'. "\n"; }
+			}
+		}
+		?>
+		</td>
+		<td></td>
+	</tr>
+	</tbody>
+
+	</table>
+	</form>
+
+	<?php
+	//print delete warning
+	if($POST->action == "delete")	{ $Result->show("warning", "<strong>"._('Warning').":</strong> "._("removing timeserver set will also remove all references from belonging subnets!"), false);}
+	?>
+</div>
+
+
+<!-- footer -->
+<div class="pFooter">
+	<div class="btn-group">
+		<button class="btn btn-sm btn-default hidePopups"><?php print _('Cancel'); ?></button>
+		<button class='btn btn-sm btn-default submit_popup <?php if($POST->action=="delete") { print "btn-danger"; } else { print "btn-success"; } ?>' data-script="app/admin/timeservers/edit-result.php" data-result_div="timeserverManagementEditResult" data-form='timeserverManagementEdit'>
+			<i class="fa <?php if($POST->action=="add") { print "fa-plus"; } elseif ($POST->action=="delete") { print "fa-trash-o"; } else { print "fa-check"; } ?>"></i> <?php print $User->get_post_action(); ?>
+		</button>
+	</div>
+	<!-- result -->
+	<div id="timeserverManagementEditResult"></div>
+</div>

--- a/public/app/admin/timeservers/index.php
+++ b/public/app/admin/timeservers/index.php
@@ -1,0 +1,94 @@
+<?php
+
+/**
+ *	Print all available timeserver sets
+ ************************************************/
+
+# verify that user is logged in
+$User->check_user_session();
+# admin check
+$User->is_admin();
+
+# fetch all timeserver sets
+$all_timeservers = $Admin->fetch_all_objects("timeservers", "name");
+?>
+
+<h4><?php print _('Manage Timeserver sets'); ?></h4>
+<hr><br>
+
+<button class='btn btn-sm btn-default open_popup' data-script='app/admin/timeservers/edit.php' data-class='700' data-action='add' style='margin-bottom:10px;'><i class='fa fa-plus'></i> <?php print _('Add timeserver set'); ?></button>
+
+<!-- timeserver sets -->
+<?php
+
+# first check if they exist!
+if($all_timeservers===false) { $Result->show("danger", _("No timeserver sets defined")."!", true);}
+else {
+	print '<table id="timeserverManagement" class="table sorted table-striped table-top table-hover table-td-top" data-cookie-id-table="admin_time">'. "\n";
+
+	# headers
+	print "<thead>";
+	print '<tr>'. "\n";
+	print '	<th>'._('Timeserver set').'</th>'. "\n";
+	print '	<th>'._('Timeservers').'</th>'. "\n";
+	print '	<th>'._('Sections').'</th>'. "\n";
+	print '	<th>'._('Description').'</th>'. "\n";
+	print '	<th></th>'. "\n";
+	print '</tr>'. "\n";
+	print "</thead>";
+
+    print "<tbody>";
+	# loop
+	foreach ($all_timeservers as $timeservers) {
+		//cast
+		$timeservers = (array) $timeservers;
+
+		unset($permitted_sections);
+		$permitted_sections = [];
+
+		// sections
+		if (!is_null($timeservers['permissions'])) {
+			$sections = array_filter(explode(";", (string) $timeservers['permissions']));
+			// some
+			if (sizeof($sections)>0) {
+				foreach($sections as $id) {
+					$sect = $Admin->fetch_object ("sections", "id", $id);
+					// exists
+					if ($sect!==false) {
+						$permitted_sections[] = "<span class='badge badge1 badge5'>".$sect->name."</span>";
+					}
+				}
+			}
+			else {
+				$permitted_sections[] = "/";
+			}
+		}
+		// none
+		else {
+			$permitted_sections[] = "/";
+		}
+
+		// merge all timeservers
+		$all_timeservers_print = explode(";", (string) $timeservers['timesrv1']);
+
+		//print details
+		print '<tr>'. "\n";
+		print '	<td class="name"><strong>'. $timeservers['name'] .'</strong></td>'. "\n";
+		print '	<td class="timesrv1">'. implode("<br>", $all_timeservers_print) .'</td>'. "\n";
+		print '	<td class="sections">'. implode("<br>", $permitted_sections).'</td>'. "\n";
+		print '	<td class="description">'. $timeservers['description'] .'</td>'. "\n";
+		print "	<td class='actions'>";
+		print "	<div class='btn-group'>";
+		print "		<button class='btn btn-xs btn-default open_popup' data-script='app/admin/timeservers/edit.php' data-class='700' data-action='edit'   data-timeserverid='$timeservers[id]'><i class='fa fa-pencil'></i></button>";
+		print "		<button class='btn btn-xs btn-default open_popup' data-script='app/admin/timeservers/edit.php' data-class='700' data-action='delete' data-timeserverid='$timeservers[id]'><i class='fa fa-times' ></i></button>";
+		print "	</div>";
+		print "	</td>";
+		print '</tr>'. "\n";
+	}
+	print "</tbody>";
+	print '</table>'. "\n";
+}
+?>
+
+<!-- edit result holder -->
+<div class="timeserverManagementEdit"></div>

--- a/public/app/subnets/addresses/mail-notify.php
+++ b/public/app/subnets/addresses/mail-notify.php
@@ -32,6 +32,7 @@ $address = (array) $Addresses->fetch_address (null, $id);
 $subnet  = (array) $Subnets->fetch_subnet (null, $address['subnetId']);
 $vlan    = (array) $Tools->fetch_object ("vlans", "vlanId", $subnet['vlanId']);
 $nameservers    = (array) $Tools->fetch_object("nameservers", "id", $subnet['nameserverId']);
+$timeservers     = (array) $Tools->fetch_object("timeservers", "id", $subnet['timeserverId']);
 
 # get all custom fields
 $custom_fields = $Tools->fetch_custom_fields ('ipaddresses');
@@ -74,6 +75,13 @@ if ( !empty( $subnet['nameserverId'] ) ) {
 	$nslist = str_replace(";", ", ", (string) $nameservers['namesrv1']);
 
 						$content[] = "&bull; "._('Nameservers').": \t $nslist ({$nameservers['name']})";
+}
+
+# Timeserver sets
+if ( !empty( $subnet['timeserverId'] ) ) {
+	$timelist = str_replace(";", ", ", (string) $timeservers['timesrv1']);
+
+						$content[] = "&bull; "._('Timeservers').": \t $timelist ({$timeservers['name']})";
 }
 
 # Switch

--- a/public/app/subnets/mail-notify-subnet.php
+++ b/public/app/subnets/mail-notify-subnet.php
@@ -31,6 +31,7 @@ $subnet  = (array) $Subnets->fetch_subnet (null, $POST->id);
 $vlan    = (array) $Tools->fetch_object ("vlans", "vlanId", $subnet['vlanId']);
 $vrf     = (array) $Tools->fetch_object ("vrf", "vrfId", $subnet['vrfId']);
 $nameservers    = (array) $Tools->fetch_object("nameservers", "id", $subnet['nameserverId']);
+$timeservers     = (array) $Tools->fetch_object("timeservers", "id", $subnet['timeserverId']);
 
 # get all custom fields
 $custom_fields = $Tools->fetch_custom_fields ('subnets');
@@ -63,6 +64,13 @@ if ( !empty( $subnet['nameserverId'] ) ) {
 	$nslist = str_replace(";", ", ", (string) $nameservers['namesrv1']);
 
 						$content[] = "&bull; "._('Nameservers').": \t $nslist ({$nameservers['name']})";
+}
+
+# Timeserver sets
+if ( !empty( $subnet['timeserverId'] ) ) {
+	$timelist = str_replace(";", ", ", (string) $timeservers['timesrv1']);
+
+						$content[] = "&bull; "._('Timeservers').": \t $timelist ({$timeservers['name']})";
 }
 
 # custom

--- a/public/app/subnets/subnet-details/subnet-details.php
+++ b/public/app/subnets/subnet-details/subnet-details.php
@@ -189,6 +189,28 @@ else {
 		</td>
 	</tr>
 
+	<!-- timeservers -->
+	<tr>
+		<th><?php print _('Timeservers'); ?></th>
+		<td>
+		<?php
+
+		// Only show timeservers if defined for subnet
+		if(!empty($subnet['timeserverId'])) {
+			# fetch timeserver details
+			$timeservers = $Tools->fetch_object("timeservers", "id", $subnet['timeserverId']);
+			print str_replace(";", ", ", (string) $timeservers->timesrv1);
+			//Print name of timeserver group
+			print ' ('.$timeservers->name.')';
+		}
+
+		else {
+			print "<span class='text-muted'>/</span>";
+		}
+		?>
+		</td>
+	</tr>
+
 	<!-- Customers -->
 	<?php if($User->get_module_permissions ("customers")>=User::ACCESS_R) { ?>
 	<tr>

--- a/public/js/magic.js
+++ b/public/js/magic.js
@@ -2467,6 +2467,32 @@ $(document).on("click", "#remove_nameserver", function() {
     hideSpinner();  return false;
 });
 
+/* ---- Timeservers ----- */
+// add new
+$(document).on("click", "#add_timeserver", function() {
+    showSpinner();
+    //get old number
+    var num = $(this).attr("data-id");
+    // append
+    $('table#timeserverManagementEdit2 tbody#timeservers').append("<tr id='timesrv-"+num+"'><td>Timeserver "+num+"</td><td><input type='text' class='rd form-control input-sm' name='timesrv-"+num+"'></input><td><button class='btn btn-sm btn-default' id='remove_timeserver' data-id='timesrv-"+num+"'><i class='fa fa-trash-o'></i></buttom></td></td></tr>");
+    // add number
+    num++;
+    $(this).attr("data-id", num);
+
+    hideSpinner();  return false;
+});
+// remove
+$(document).on("click", "#remove_timeserver", function() {
+    showSpinner();
+    //get old number
+    var id = $(this).attr("data-id");
+    // append
+    var el = document.getElementById(id);
+    el.parentNode.removeChild(el);
+
+    hideSpinner();  return false;
+});
+
 /* ---- IP requests ----- */
 //submit form
 $(document).on("click", "button.manageRequest", function() {


### PR DESCRIPTION
Add support for timeservers in the same way nameservers are implemented.

New `timeservers` table and a `timeserverId` column on subnets, with upgrade queries bumping dbversion to 47. Existing installs get a default pool.ntp.org set on upgrade, same as the Google NS default for nameservers.

Tested with PHP 8.2