### PR TITLE
Add OpenAPI documentation with Scalar UI for the REST API

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -68,6 +68,7 @@
     "driftingly/rector-laravel": "^2.3",
     "laravel/pint": "^1.29",
     "phpcompatibility/php-compatibility": "^10.0.0@dev",
-    "phpstan/phpstan": "^2.1"
+    "phpstan/phpstan": "^2.1",
+    "zircote/swagger-php": "^6.5"
   }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e7cbc2766034a362d28827815bc69ba7",
+    "content-hash": "d2be0c14817bbde4a781274af236452b",
     "packages": [
         {
             "name": "bacon/bacon-qr-code",
@@ -907,6 +907,63 @@
             "time": "2026-08-02T01:28:21+00:00"
         },
         {
+            "name": "nikic/php-parser",
+            "version": "v5.8.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nikic/PHP-Parser.git",
+                "reference": "044a6a392ff8ad0d61f14370a5fbbd0a0107152f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/044a6a392ff8ad0d61f14370a5fbbd0a0107152f",
+                "reference": "044a6a392ff8ad0d61f14370a5fbbd0a0107152f",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "ext-tokenizer": "*",
+                "php": ">=7.4"
+            },
+            "require-dev": {
+                "ircmaxell/php-yacc": "^0.0.7",
+                "phpunit/phpunit": "^9.0"
+            },
+            "bin": [
+                "bin/php-parse"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PhpParser\\": "lib/PhpParser"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Nikita Popov"
+                }
+            ],
+            "description": "A PHP parser written in PHP",
+            "keywords": [
+                "parser",
+                "php"
+            ],
+            "support": {
+                "issues": "https://github.com/nikic/PHP-Parser/issues",
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.8.0"
+            },
+            "time": "2026-07-04T14:30:18+00:00"
+        },
+        {
             "name": "phpcompatibility/php-compatibility",
             "version": "dev-develop",
             "source": {
@@ -1091,6 +1148,53 @@
             "time": "2026-07-27T10:28:41+00:00"
         },
         {
+            "name": "phpstan/phpdoc-parser",
+            "version": "2.3.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpdoc-parser.git",
+                "reference": "fb19eedd2bb67ff8cf7a5502ad329e701d6398a3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/fb19eedd2bb67ff8cf7a5502ad329e701d6398a3",
+                "reference": "fb19eedd2bb67ff8cf7a5502ad329e701d6398a3",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4 || ^8.0"
+            },
+            "require-dev": {
+                "doctrine/annotations": "^2.0",
+                "nikic/php-parser": "^5.3.0",
+                "php-parallel-lint/php-parallel-lint": "^1.2",
+                "phpstan/extension-installer": "^1.0",
+                "phpstan/phpstan": "^2.0",
+                "phpstan/phpstan-phpunit": "^2.0",
+                "phpstan/phpstan-strict-rules": "^2.0",
+                "phpunit/phpunit": "^9.6",
+                "symfony/process": "^5.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\PhpDocParser\\": [
+                        "src/"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPDoc parser with support for nullable, intersection and generic types",
+            "support": {
+                "issues": "https://github.com/phpstan/phpdoc-parser/issues",
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/2.3.3"
+            },
+            "time": "2026-07-08T07:01:06+00:00"
+        },
+        {
             "name": "phpstan/phpstan",
             "version": "2.2.7",
             "dist": {
@@ -1153,6 +1257,171 @@
                 }
             ],
             "time": "2026-07-29T17:39:32+00:00"
+        },
+        {
+            "name": "psr/container",
+            "version": "2.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/container.git",
+                "reference": "c71ecc56dfe541dbd90c5360474fbc405f8d5963"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/container/zipball/c71ecc56dfe541dbd90c5360474fbc405f8d5963",
+                "reference": "c71ecc56dfe541dbd90c5360474fbc405f8d5963",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Container\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common Container Interface (PHP FIG PSR-11)",
+            "homepage": "https://github.com/php-fig/container",
+            "keywords": [
+                "PSR-11",
+                "container",
+                "container-interface",
+                "container-interop",
+                "psr"
+            ],
+            "support": {
+                "issues": "https://github.com/php-fig/container/issues",
+                "source": "https://github.com/php-fig/container/tree/2.0.2"
+            },
+            "time": "2021-11-05T16:47:00+00:00"
+        },
+        {
+            "name": "psr/log",
+            "version": "3.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/log.git",
+                "reference": "f16e1d5863e37f8d8c2a01719f5b34baa2b714d3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/f16e1d5863e37f8d8c2a01719f5b34baa2b714d3",
+                "reference": "f16e1d5863e37f8d8c2a01719f5b34baa2b714d3",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.0.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Log\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for logging libraries",
+            "homepage": "https://github.com/php-fig/log",
+            "keywords": [
+                "log",
+                "psr",
+                "psr-3"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/log/tree/3.0.2"
+            },
+            "time": "2024-09-11T13:17:53+00:00"
+        },
+        {
+            "name": "radebatz/type-info-extras",
+            "version": "1.0.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/DerManoMann/type-info-extras.git",
+                "reference": "95a524a74a61648b44e355cb33d38db4b17ef5ce"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/DerManoMann/type-info-extras/zipball/95a524a74a61648b44e355cb33d38db4b17ef5ce",
+                "reference": "95a524a74a61648b44e355cb33d38db4b17ef5ce",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "phpstan/phpdoc-parser": "^2.0",
+                "symfony/type-info": "^7.3.8 || ^7.4.1 || ^8.0 || ^8.1-@dev"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^3.70",
+                "phpstan/phpstan": "^2.1",
+                "phpunit/phpunit": "^11.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Radebatz\\TypeInfoExtras\\": "src"
+                },
+                "exclude-from-classmap": [
+                    "/tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Martin Rademacher",
+                    "email": "mano@radebatz.org"
+                }
+            ],
+            "description": "Extras for symfony/type-info",
+            "homepage": "http://radebatz.net/mano/",
+            "keywords": [
+                "component",
+                "symfony",
+                "type-info",
+                "types"
+            ],
+            "support": {
+                "issues": "https://github.com/DerManoMann/type-info-extras/issues",
+                "source": "https://github.com/DerManoMann/type-info-extras/tree/1.0.7"
+            },
+            "time": "2026-03-06T22:40:29+00:00"
         },
         {
             "name": "rector/rector",
@@ -1294,6 +1563,995 @@
             "time": "2025-11-10T16:43:36+00:00"
         },
         {
+            "name": "symfony/console",
+            "version": "v8.1.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/console.git",
+                "reference": "68efa2ebfd9a362951eb5a8b09fd177c66ddec24"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/console/zipball/68efa2ebfd9a362951eb5a8b09fd177c66ddec24",
+                "reference": "68efa2ebfd9a362951eb5a8b09fd177c66ddec24",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.4.1",
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "symfony/polyfill-mbstring": "^1.0",
+                "symfony/polyfill-php85": "^1.32",
+                "symfony/service-contracts": "^2.5|^3",
+                "symfony/string": "^7.4.6|^8.0.6"
+            },
+            "conflict": {
+                "symfony/dependency-injection": "<8.1",
+                "symfony/event-dispatcher": "<8.1"
+            },
+            "provide": {
+                "psr/log-implementation": "1.0|2.0|3.0"
+            },
+            "require-dev": {
+                "psr/log": "^1|^2|^3",
+                "symfony/config": "^7.4|^8.0",
+                "symfony/dependency-injection": "^8.1",
+                "symfony/event-dispatcher": "^8.1",
+                "symfony/filesystem": "^7.4|^8.0",
+                "symfony/http-foundation": "^7.4|^8.0",
+                "symfony/http-kernel": "^7.4|^8.0",
+                "symfony/lock": "^7.4|^8.0",
+                "symfony/messenger": "^7.4|^8.0",
+                "symfony/mime": "^7.4|^8.0",
+                "symfony/process": "^7.4|^8.0",
+                "symfony/stopwatch": "^7.4|^8.0",
+                "symfony/uid": "^7.4|^8.0",
+                "symfony/validator": "^7.4|^8.0",
+                "symfony/var-dumper": "^7.4|^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Console\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Eases the creation of beautiful and testable command line interfaces",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "cli",
+                "command-line",
+                "console",
+                "terminal"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/console/tree/v8.1.4"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-07-31T12:43:13+00:00"
+        },
+        {
+            "name": "symfony/deprecation-contracts",
+            "version": "v3.7.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/deprecation-contracts.git",
+                "reference": "f3202fa1b5097b0af062dc978b32ecf63404e31d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/f3202fa1b5097b0af062dc978b32ecf63404e31d",
+                "reference": "f3202fa1b5097b0af062dc978b32ecf63404e31d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/contracts",
+                    "name": "symfony/contracts"
+                },
+                "branch-alias": {
+                    "dev-main": "3.7-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "function.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "A generic function and convention to trigger deprecation notices",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.7.1"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-06-05T06:23:12+00:00"
+        },
+        {
+            "name": "symfony/finder",
+            "version": "v8.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/finder.git",
+                "reference": "e2989e762c70f9490fa3a00a0ac0fae5aa97a531"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/e2989e762c70f9490fa3a00a0ac0fae5aa97a531",
+                "reference": "e2989e762c70f9490fa3a00a0ac0fae5aa97a531",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.4.1"
+            },
+            "require-dev": {
+                "symfony/filesystem": "^7.4|^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Finder\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Finds files and directories via an intuitive fluent interface",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/finder/tree/v8.1.1"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-06-27T09:05:56+00:00"
+        },
+        {
+            "name": "symfony/polyfill-ctype",
+            "version": "v1.37.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-ctype.git",
+                "reference": "141046a8f9477948ff284fa65be2095baafb94f2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/141046a8f9477948ff284fa65be2095baafb94f2",
+                "reference": "141046a8f9477948ff284fa65be2095baafb94f2",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "provide": {
+                "ext-ctype": "*"
+            },
+            "suggest": {
+                "ext-ctype": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Ctype\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Gert de Pagter",
+                    "email": "BackEndTea@gmail.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for ctype functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "ctype",
+                "polyfill",
+                "portable"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.37.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-04-10T16:19:22+00:00"
+        },
+        {
+            "name": "symfony/polyfill-intl-grapheme",
+            "version": "v1.41.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-intl-grapheme.git",
+                "reference": "bb899c1db0aa8127dc3afe8cda4a67eb24915f8d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/bb899c1db0aa8127dc3afe8cda4a67eb24915f8d",
+                "reference": "bb899c1db0aa8127dc3afe8cda4a67eb24915f8d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "suggest": {
+                "ext-intl": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Intl\\Grapheme\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for intl's grapheme_* functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "grapheme",
+                "intl",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.41.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-07-28T08:25:59+00:00"
+        },
+        {
+            "name": "symfony/polyfill-intl-normalizer",
+            "version": "v1.38.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
+                "reference": "2d446c214bdbe5b71bde5011b060a05fece3ae6b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/2d446c214bdbe5b71bde5011b060a05fece3ae6b",
+                "reference": "2d446c214bdbe5b71bde5011b060a05fece3ae6b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "suggest": {
+                "ext-intl": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Intl\\Normalizer\\": ""
+                },
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for intl's Normalizer class and related functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "intl",
+                "normalizer",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.38.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-05-25T13:48:31+00:00"
+        },
+        {
+            "name": "symfony/polyfill-mbstring",
+            "version": "v1.38.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-mbstring.git",
+                "reference": "d3d318bad5e7a1bfbd026009c8bfb8d8f99ae6b6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/d3d318bad5e7a1bfbd026009c8bfb8d8f99ae6b6",
+                "reference": "d3d318bad5e7a1bfbd026009c8bfb8d8f99ae6b6",
+                "shasum": ""
+            },
+            "require": {
+                "ext-iconv": "*",
+                "php": ">=7.2"
+            },
+            "provide": {
+                "ext-mbstring": "*"
+            },
+            "suggest": {
+                "ext-mbstring": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Mbstring\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for the Mbstring extension",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "mbstring",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.38.2"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-05-27T06:59:30+00:00"
+        },
+        {
+            "name": "symfony/polyfill-php85",
+            "version": "v1.41.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php85.git",
+                "reference": "255fab485aaa1006ed411040c42aecd7b5302d7a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php85/zipball/255fab485aaa1006ed411040c42aecd7b5302d7a",
+                "reference": "255fab485aaa1006ed411040c42aecd7b5302d7a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php85\\": ""
+                },
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 8.5+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php85/tree/v1.41.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-07-01T12:47:55+00:00"
+        },
+        {
+            "name": "symfony/service-contracts",
+            "version": "v3.7.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/service-contracts.git",
+                "reference": "c0a284bab1ed8aa0417e3d69250ab437739563a0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/c0a284bab1ed8aa0417e3d69250ab437739563a0",
+                "reference": "c0a284bab1ed8aa0417e3d69250ab437739563a0",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "psr/container": "^1.1|^2.0",
+                "symfony/deprecation-contracts": "^2.5|^3"
+            },
+            "conflict": {
+                "ext-psr": "<1.1|>=2"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/contracts",
+                    "name": "symfony/contracts"
+                },
+                "branch-alias": {
+                    "dev-main": "3.7-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Contracts\\Service\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Test/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Generic abstractions related to writing services",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "abstractions",
+                "contracts",
+                "decoupling",
+                "interfaces",
+                "interoperability",
+                "standards"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/service-contracts/tree/v3.7.1"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-06-16T09:55:08+00:00"
+        },
+        {
+            "name": "symfony/string",
+            "version": "v8.1.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/string.git",
+                "reference": "286a76b7255e5cc4bf0101a0bc5388ecf1c38ccc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/string/zipball/286a76b7255e5cc4bf0101a0bc5388ecf1c38ccc",
+                "reference": "286a76b7255e5cc4bf0101a0bc5388ecf1c38ccc",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.4.1",
+                "symfony/polyfill-ctype": "^1.8",
+                "symfony/polyfill-intl-grapheme": "^1.33",
+                "symfony/polyfill-intl-normalizer": "^1.0",
+                "symfony/polyfill-mbstring": "^1.0"
+            },
+            "conflict": {
+                "symfony/translation-contracts": "<2.5"
+            },
+            "require-dev": {
+                "symfony/emoji": "^7.4|^8.0",
+                "symfony/http-client": "^7.4|^8.0",
+                "symfony/intl": "^7.4|^8.0",
+                "symfony/translation-contracts": "^2.5|^3.0",
+                "symfony/var-exporter": "^7.4|^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "Resources/functions.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Component\\String\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides an object-oriented API to strings and deals with bytes, UTF-8 code points and grapheme clusters in a unified way",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "grapheme",
+                "i18n",
+                "string",
+                "unicode",
+                "utf-8",
+                "utf8"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/string/tree/v8.1.2"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-07-28T07:35:25+00:00"
+        },
+        {
+            "name": "symfony/type-info",
+            "version": "v8.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/type-info.git",
+                "reference": "9f24df8a79781b9b9f030fea7dfd2f3bd1e7e7e7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/type-info/zipball/9f24df8a79781b9b9f030fea7dfd2f3bd1e7e7e7",
+                "reference": "9f24df8a79781b9b9f030fea7dfd2f3bd1e7e7e7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.4.1",
+                "psr/container": "^1.1|^2.0"
+            },
+            "conflict": {
+                "phpstan/phpdoc-parser": "<1.30"
+            },
+            "require-dev": {
+                "phpstan/phpdoc-parser": "^1.30|^2.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\TypeInfo\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mathias Arlaud",
+                    "email": "mathias.arlaud@gmail.com"
+                },
+                {
+                    "name": "Baptiste LEDUC",
+                    "email": "baptiste.leduc@gmail.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Extracts PHP types information.",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "PHPStan",
+                "phpdoc",
+                "symfony",
+                "type"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/type-info/tree/v8.1.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-05-29T05:06:50+00:00"
+        },
+        {
+            "name": "symfony/yaml",
+            "version": "v8.1.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/yaml.git",
+                "reference": "faabdbe998e8c5c599dceffa27aa265b185c0736"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/faabdbe998e8c5c599dceffa27aa265b185c0736",
+                "reference": "faabdbe998e8c5c599dceffa27aa265b185c0736",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.4.1",
+                "symfony/polyfill-ctype": "^1.8"
+            },
+            "conflict": {
+                "symfony/console": "<7.4"
+            },
+            "require-dev": {
+                "symfony/console": "^7.4|^8.0",
+                "yaml/yaml-test-suite": "*"
+            },
+            "bin": [
+                "Resources/bin/yaml-lint"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Yaml\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Loads and dumps YAML files",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/yaml/tree/v8.1.2"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-07-22T15:42:13+00:00"
+        },
+        {
             "name": "webmozart/assert",
             "version": "2.4.1",
             "source": {
@@ -1358,6 +2616,95 @@
                 "source": "https://github.com/webmozarts/assert/tree/2.4.1"
             },
             "time": "2026-06-15T15:31:57+00:00"
+        },
+        {
+            "name": "zircote/swagger-php",
+            "version": "6.5.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/zircote/swagger-php.git",
+                "reference": "cec9ec9157513ba27f15513d4983acbe03ce10b8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zircote/swagger-php/zipball/cec9ec9157513ba27f15513d4983acbe03ce10b8",
+                "reference": "cec9ec9157513ba27f15513d4983acbe03ce10b8",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^4.19 || ^5.0",
+                "php": ">=8.2",
+                "phpstan/phpdoc-parser": "^2.0",
+                "psr/log": "^1.1 || ^2.0 || ^3.0",
+                "radebatz/type-info-extras": "^1.0.2",
+                "symfony/console": "^7.4 || ^8.0",
+                "symfony/deprecation-contracts": "^2 || ^3",
+                "symfony/finder": "^5.0 || ^6.0 || ^7.0 || ^8.0",
+                "symfony/yaml": "^5.4 || ^6.0 || ^7.0 || ^8.0"
+            },
+            "conflict": {
+                "symfony/process": ">=6, <6.4.14"
+            },
+            "require-dev": {
+                "doctrine/annotations": "^2.0",
+                "friendsofphp/php-cs-fixer": "^3.62",
+                "phpstan/phpstan": "^2.2",
+                "phpunit/phpunit": "^11.5 || >=12.5.22",
+                "rector/rector": "^2.3"
+            },
+            "bin": [
+                "bin/openapi"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "6.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "OpenApi\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Robert Allen",
+                    "email": "zircote@gmail.com"
+                },
+                {
+                    "name": "Bob Fanger",
+                    "email": "bfanger@gmail.com",
+                    "homepage": "https://bfanger.nl"
+                },
+                {
+                    "name": "Martin Rademacher",
+                    "email": "mano@radebatz.net",
+                    "homepage": "https://radebatz.net"
+                }
+            ],
+            "description": "Generate interactive documentation for your RESTful API using PHP attributes (preferred) or PHPDoc annotations",
+            "homepage": "https://github.com/zircote/swagger-php",
+            "keywords": [
+                "api",
+                "json",
+                "rest",
+                "service discovery"
+            ],
+            "support": {
+                "issues": "https://github.com/zircote/swagger-php/issues",
+                "source": "https://github.com/zircote/swagger-php/tree/6.5.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/zircote",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-08-05T02:31:32+00:00"
         }
     ],
     "aliases": [],

--- a/public/api/controllers/Addresses.php
+++ b/public/api/controllers/Addresses.php
@@ -1,5 +1,7 @@
 <?php
 
+use OpenApi\Attributes as OA;
+
 /**
  *	phpIPAM API class to work with Addresses
  *
@@ -55,6 +57,13 @@ class Addresses_controller extends Common_api_functions  {
 	 * @access public
 	 * @return void
 	 */
+	#[OA\Options(
+	    path: "/{app_id}/addresses/",
+	    tags: ["addresses"],
+	    summary: "Discover supported addresses routes/methods (HATEOAS)",
+	    parameters: [new OA\Parameter(ref: "#/components/parameters/app_id")],
+	    responses: [new OA\Response(response: 200, description: "OK")]
+	)]
 	#[\Override]
     public function OPTIONS () {
 		// validate
@@ -100,6 +109,199 @@ class Addresses_controller extends Common_api_functions  {
 	 * @access public
 	 * @return void
 	 */
+	#[OA\Get(
+	    path: "/{app_id}/addresses/",
+	    tags: ["addresses"],
+	    summary: "List all addresses (all subnets)",
+	    parameters: [new OA\Parameter(ref: "#/components/parameters/app_id")],
+	    responses: [
+	        new OA\Response(response: 200, description: "OK", content: new OA\JsonContent(type: "array", items: new OA\Items(ref: "#/components/schemas/Address"))),
+	        new OA\Response(response: 500, description: "Unable to read addresses", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))
+	    ]
+	)]
+	#[OA\Get(
+	    path: "/{app_id}/addresses/{id}/",
+	    tags: ["addresses"],
+	    summary: "Read a single address by id",
+	    parameters: [
+	        new OA\Parameter(ref: "#/components/parameters/app_id"),
+	        new OA\Parameter(name: "id", in: "path", required: true, schema: new OA\Schema(type: "integer"))
+	    ],
+	    responses: [
+	        new OA\Response(response: 200, description: "OK", content: new OA\JsonContent(ref: "#/components/schemas/Address")),
+	        new OA\Response(response: 404, description: "Invalid id", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))
+	    ]
+	)]
+	#[OA\Get(
+	    path: "/{app_id}/addresses/custom_fields/",
+	    tags: ["addresses"],
+	    summary: "List custom fields defined on the ipaddresses table",
+	    parameters: [new OA\Parameter(ref: "#/components/parameters/app_id")],
+	    responses: [
+	        new OA\Response(response: 200, description: "OK"),
+	        new OA\Response(response: 404, description: "No custom fields defined", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))
+	    ]
+	)]
+	#[OA\Get(
+	    path: "/{app_id}/addresses/first_free/{subnetId}/",
+	    tags: ["addresses"],
+	    summary: "Get the first free address in a subnet (does not reserve it)",
+	    parameters: [
+	        new OA\Parameter(ref: "#/components/parameters/app_id"),
+	        new OA\Parameter(name: "subnetId", in: "path", required: true, schema: new OA\Schema(type: "integer"))
+	    ],
+	    responses: [
+	        new OA\Response(response: 200, description: "OK", content: new OA\JsonContent(type: "string", example: "192.168.1.5")),
+	        new OA\Response(response: 404, description: "No free addresses found", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))
+	    ]
+	)]
+	#[OA\Get(
+	    path: "/{app_id}/addresses/{ip}/{subnetId}/",
+	    tags: ["addresses"],
+	    summary: "Read an address by IP within a given subnet",
+	    parameters: [
+	        new OA\Parameter(ref: "#/components/parameters/app_id"),
+	        new OA\Parameter(name: "ip", in: "path", required: true, schema: new OA\Schema(type: "string"), example: "192.168.1.5"),
+	        new OA\Parameter(name: "subnetId", in: "path", required: true, schema: new OA\Schema(type: "integer"))
+	    ],
+	    responses: [
+	        new OA\Response(response: 200, description: "OK", content: new OA\JsonContent(ref: "#/components/schemas/Address")),
+	        new OA\Response(response: 404, description: "No addresses found", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))
+	    ]
+	)]
+	#[OA\Get(
+	    path: "/{app_id}/addresses/tags/",
+	    tags: ["addresses"],
+	    summary: "List all IP tags",
+	    parameters: [new OA\Parameter(ref: "#/components/parameters/app_id")],
+	    responses: [
+	        new OA\Response(response: 200, description: "OK"),
+	        new OA\Response(response: 404, description: "Tag not found", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))
+	    ]
+	)]
+	#[OA\Get(
+	    path: "/{app_id}/addresses/tags/{id}/",
+	    tags: ["addresses"],
+	    summary: "Read a single IP tag by id or type",
+	    parameters: [
+	        new OA\Parameter(ref: "#/components/parameters/app_id"),
+	        new OA\Parameter(name: "id", in: "path", required: true, description: "Tag id (numeric) or type", schema: new OA\Schema(type: "string"))
+	    ],
+	    responses: [
+	        new OA\Response(response: 200, description: "OK"),
+	        new OA\Response(response: 404, description: "Tag not found", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))
+	    ]
+	)]
+	#[OA\Get(
+	    path: "/{app_id}/addresses/tags/{id}/addresses/",
+	    tags: ["addresses"],
+	    summary: "List all addresses tagged with the given tag/state, optionally filtered by subnetId",
+	    parameters: [
+	        new OA\Parameter(ref: "#/components/parameters/app_id"),
+	        new OA\Parameter(name: "id", in: "path", required: true, description: "Tag/state id", schema: new OA\Schema(type: "integer")),
+	        new OA\Parameter(name: "subnetId", in: "query", required: false, schema: new OA\Schema(type: "integer"))
+	    ],
+	    responses: [
+	        new OA\Response(response: 200, description: "OK", content: new OA\JsonContent(type: "array", items: new OA\Items(ref: "#/components/schemas/Address"))),
+	        new OA\Response(response: 404, description: "No addresses found", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))
+	    ]
+	)]
+	#[OA\Get(
+	    path: "/{app_id}/addresses/search_linked/{value}/",
+	    tags: ["addresses"],
+	    summary: "Search addresses by the custom Link addresses field value",
+	    parameters: [
+	        new OA\Parameter(ref: "#/components/parameters/app_id"),
+	        new OA\Parameter(name: "value", in: "path", required: true, schema: new OA\Schema(type: "string"))
+	    ],
+	    responses: [
+	        new OA\Response(response: 200, description: "OK", content: new OA\JsonContent(type: "array", items: new OA\Items(ref: "#/components/schemas/Address"))),
+	        new OA\Response(response: 404, description: "No addresses found", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))
+	    ]
+	)]
+	#[OA\Get(
+	    path: "/{app_id}/addresses/{id}/ping/",
+	    tags: ["addresses"],
+	    summary: "Ping an address and update its last-seen date on success",
+	    parameters: [
+	        new OA\Parameter(ref: "#/components/parameters/app_id"),
+	        new OA\Parameter(name: "id", in: "path", required: true, schema: new OA\Schema(type: "integer"))
+	    ],
+	    responses: [
+	        new OA\Response(response: 200, description: "OK", content: new OA\JsonContent(properties: [
+	            new OA\Property(property: "scan_type", type: "string"),
+	            new OA\Property(property: "exit_code", type: "integer"),
+	            new OA\Property(property: "result_code", type: "string"),
+	            new OA\Property(property: "message", type: "string", example: "Address online")
+	        ])),
+	        new OA\Response(response: 404, description: "Address does not exist", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))
+	    ]
+	)]
+	#[OA\Get(
+	    path: "/{app_id}/addresses/{id}/changelog/",
+	    tags: ["addresses"],
+	    summary: "Get the change log for an address",
+	    parameters: [
+	        new OA\Parameter(ref: "#/components/parameters/app_id"),
+	        new OA\Parameter(name: "id", in: "path", required: true, schema: new OA\Schema(type: "integer"))
+	    ],
+	    responses: [
+	        new OA\Response(response: 200, description: "OK"),
+	        new OA\Response(response: 404, description: "No changelogs found", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))
+	    ]
+	)]
+	#[OA\Get(
+	    path: "/{app_id}/addresses/search/{ip}/",
+	    tags: ["addresses"],
+	    summary: "Search addresses by exact IP (across all subnets)",
+	    parameters: [
+	        new OA\Parameter(ref: "#/components/parameters/app_id"),
+	        new OA\Parameter(name: "ip", in: "path", required: true, schema: new OA\Schema(type: "string"))
+	    ],
+	    responses: [
+	        new OA\Response(response: 200, description: "OK", content: new OA\JsonContent(type: "array", items: new OA\Items(ref: "#/components/schemas/Address"))),
+	        new OA\Response(response: 404, description: "Address not found", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))
+	    ]
+	)]
+	#[OA\Get(
+	    path: "/{app_id}/addresses/search_hostname/{hostname}/",
+	    tags: ["addresses"],
+	    summary: "Search addresses by exact hostname",
+	    parameters: [
+	        new OA\Parameter(ref: "#/components/parameters/app_id"),
+	        new OA\Parameter(name: "hostname", in: "path", required: true, schema: new OA\Schema(type: "string"))
+	    ],
+	    responses: [
+	        new OA\Response(response: 200, description: "OK", content: new OA\JsonContent(type: "array", items: new OA\Items(ref: "#/components/schemas/Address"))),
+	        new OA\Response(response: 404, description: "Hostname not found", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))
+	    ]
+	)]
+	#[OA\Get(
+	    path: "/{app_id}/addresses/search_hostbase/{hostbase}/",
+	    tags: ["addresses"],
+	    summary: "Search addresses by leading substring of hostname, sorted by name",
+	    parameters: [
+	        new OA\Parameter(ref: "#/components/parameters/app_id"),
+	        new OA\Parameter(name: "hostbase", in: "path", required: true, schema: new OA\Schema(type: "string"))
+	    ],
+	    responses: [
+	        new OA\Response(response: 200, description: "OK", content: new OA\JsonContent(type: "array", items: new OA\Items(ref: "#/components/schemas/Address"))),
+	        new OA\Response(response: 404, description: "Host name not found", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))
+	    ]
+	)]
+	#[OA\Get(
+	    path: "/{app_id}/addresses/search_mac/{mac}/",
+	    tags: ["addresses"],
+	    summary: "Search addresses by MAC address",
+	    parameters: [
+	        new OA\Parameter(ref: "#/components/parameters/app_id"),
+	        new OA\Parameter(name: "mac", in: "path", required: true, schema: new OA\Schema(type: "string"))
+	    ],
+	    responses: [
+	        new OA\Response(response: 200, description: "OK", content: new OA\JsonContent(type: "array", items: new OA\Items(ref: "#/components/schemas/Address"))),
+	        new OA\Response(response: 404, description: "Host name not found", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))
+	    ]
+	)]
 	#[\Override]
     public function GET () {
 		// all
@@ -297,6 +499,48 @@ class Addresses_controller extends Common_api_functions  {
 	 * @access public
 	 * @return void
 	 */
+	#[OA\Post(
+	    path: "/{app_id}/addresses/",
+	    tags: ["addresses"],
+	    summary: "Create a new address",
+	    parameters: [new OA\Parameter(ref: "#/components/parameters/app_id")],
+	    requestBody: new OA\RequestBody(required: true, content: new OA\JsonContent(
+	        required: ["ip_addr", "subnetId"],
+	        properties: [
+	            new OA\Property(property: "ip_addr", type: "string", example: "192.168.1.10"),
+	            new OA\Property(property: "subnetId", type: "integer", example: 3),
+	            new OA\Property(property: "hostname", type: "string"),
+	            new OA\Property(property: "description", type: "string"),
+	            new OA\Property(property: "mac", type: "string"),
+	            new OA\Property(property: "owner", type: "string"),
+	            new OA\Property(property: "state", type: "integer", description: "IP tag id, defaults to 2 (Used)")
+	        ]
+	    )),
+	    responses: [
+	        new OA\Response(response: 201, description: "Address created", content: new OA\JsonContent(ref: "#/components/schemas/SuccessResponse")),
+	        new OA\Response(response: 400, description: "Invalid parameters", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse")),
+	        new OA\Response(response: 409, description: "IP address already exists", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))
+	    ]
+	)]
+	#[OA\Post(
+	    path: "/{app_id}/addresses/first_free/{subnetId}/",
+	    tags: ["addresses"],
+	    summary: "Create an address using the first free IP in a subnet",
+	    parameters: [
+	        new OA\Parameter(ref: "#/components/parameters/app_id"),
+	        new OA\Parameter(name: "subnetId", in: "path", required: true, schema: new OA\Schema(type: "integer"))
+	    ],
+	    requestBody: new OA\RequestBody(content: new OA\JsonContent(
+	        properties: [
+	            new OA\Property(property: "hostname", type: "string"),
+	            new OA\Property(property: "description", type: "string")
+	        ]
+	    )),
+	    responses: [
+	        new OA\Response(response: 201, description: "Address created", content: new OA\JsonContent(ref: "#/components/schemas/SuccessResponse")),
+	        new OA\Response(response: 404, description: "No free addresses found", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))
+	    ]
+	)]
 	#[\Override]
     public function POST () {
 		// remap keys
@@ -362,6 +606,28 @@ class Addresses_controller extends Common_api_functions  {
 	 * @access public
 	 * @return void
 	 */
+	#[OA\Patch(
+	    path: "/{app_id}/addresses/{id}/",
+	    tags: ["addresses"],
+	    summary: "Update an address (ip/subnetId cannot be changed)",
+	    parameters: [
+	        new OA\Parameter(ref: "#/components/parameters/app_id"),
+	        new OA\Parameter(name: "id", in: "path", required: true, schema: new OA\Schema(type: "integer"))
+	    ],
+	    requestBody: new OA\RequestBody(content: new OA\JsonContent(
+	        properties: [
+	            new OA\Property(property: "hostname", type: "string"),
+	            new OA\Property(property: "description", type: "string"),
+	            new OA\Property(property: "mac", type: "string"),
+	            new OA\Property(property: "owner", type: "string"),
+	            new OA\Property(property: "state", type: "integer")
+	        ]
+	    )),
+	    responses: [
+	        new OA\Response(response: 200, description: "Address updated", content: new OA\JsonContent(ref: "#/components/schemas/SuccessResponse")),
+	        new OA\Response(response: 400, description: "IP/subnet cannot be changed, or no data provided", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))
+	    ]
+	)]
 	#[\Override]
     public function PATCH () {
 		// remap keys
@@ -424,6 +690,34 @@ class Addresses_controller extends Common_api_functions  {
 	 * @access public
 	 * @return void
 	 */
+	#[OA\Delete(
+	    path: "/{app_id}/addresses/{id}/",
+	    tags: ["addresses"],
+	    summary: "Delete an address by id",
+	    parameters: [
+	        new OA\Parameter(ref: "#/components/parameters/app_id"),
+	        new OA\Parameter(name: "id", in: "path", required: true, schema: new OA\Schema(type: "integer")),
+	        new OA\Parameter(name: "remove_dns", in: "query", required: false, description: "If set, also removes any associated PowerDNS PTR record", schema: new OA\Schema(type: "integer", enum: [0, 1]))
+	    ],
+	    responses: [
+	        new OA\Response(response: 200, description: "Address deleted", content: new OA\JsonContent(ref: "#/components/schemas/SuccessResponse")),
+	        new OA\Response(response: 500, description: "Failed to delete address", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))
+	    ]
+	)]
+	#[OA\Delete(
+	    path: "/{app_id}/addresses/{ip}/{subnetId}/",
+	    tags: ["addresses"],
+	    summary: "Delete an address by IP within a given subnet",
+	    parameters: [
+	        new OA\Parameter(ref: "#/components/parameters/app_id"),
+	        new OA\Parameter(name: "ip", in: "path", required: true, schema: new OA\Schema(type: "string")),
+	        new OA\Parameter(name: "subnetId", in: "path", required: true, schema: new OA\Schema(type: "integer"))
+	    ],
+	    responses: [
+	        new OA\Response(response: 200, description: "Address deleted", content: new OA\JsonContent(ref: "#/components/schemas/SuccessResponse")),
+	        new OA\Response(response: 404, description: "No addresses found", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))
+	    ]
+	)]
 	#[\Override]
     public function DELETE () {
     	// delete by ip

--- a/public/api/controllers/Circuits.php
+++ b/public/api/controllers/Circuits.php
@@ -1,5 +1,7 @@
 <?php
 
+use OpenApi\Attributes as OA;
+
 /**
  *	phpIPAM API class to work with Circuits and Circuit providers
  *
@@ -89,6 +91,20 @@ class Circuits_controller extends Common_api_functions {
 	 * @access public
 	 * @return void
 	 */
+	#[OA\Options(
+		path: "/{app_id}/circuits/",
+		tags: ["circuits"],
+		summary: "Discover supported circuits/providers routes/methods (HATEOAS)",
+		parameters: [new OA\Parameter(ref: "#/components/parameters/app_id")],
+		responses: [new OA\Response(response: 200, description: "OK")]
+	)]
+	#[OA\Options(
+		path: "/{app_id}/circuits/providers/",
+		tags: ["circuits"],
+		summary: "Discover supported circuit providers routes/methods (HATEOAS)",
+		parameters: [new OA\Parameter(ref: "#/components/parameters/app_id")],
+		responses: [new OA\Response(response: 200, description: "OK")]
+	)]
 	#[\Override]
     public function OPTIONS () {
 		// validate
@@ -134,6 +150,145 @@ class Circuits_controller extends Common_api_functions {
 	 * @access public
 	 * @return void|array
 	 */
+	#[OA\Get(
+		path: "/{app_id}/circuits/",
+		tags: ["circuits"],
+		summary: "List all circuits (alias: /circuits/all/)",
+		parameters: [new OA\Parameter(ref: "#/components/parameters/app_id")],
+		responses: [
+			new OA\Response(response: 200, description: "OK", content: new OA\JsonContent(type: "array", items: new OA\Items(properties: [
+				new OA\Property(property: "id", type: "string", example: "1"),
+				new OA\Property(property: "cid", type: "string"),
+				new OA\Property(property: "provider", type: "string"),
+				new OA\Property(property: "type", type: "string"),
+				new OA\Property(property: "capacity", type: "string"),
+				new OA\Property(property: "status", type: "string", enum: ["Active", "Inactive", "Reserved"]),
+				new OA\Property(property: "device1", type: "string"),
+				new OA\Property(property: "location1", type: "string"),
+				new OA\Property(property: "device2", type: "string"),
+				new OA\Property(property: "location2", type: "string"),
+				new OA\Property(property: "comment", type: "string"),
+				new OA\Property(property: "parent", type: "string"),
+				new OA\Property(property: "customer_id", type: "string"),
+				new OA\Property(property: "differentiator", type: "string")
+			]))),
+			new OA\Response(response: 404, description: "No circuits configured", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))
+		]
+	)]
+	#[OA\Get(
+		path: "/{app_id}/circuits/{id}/",
+		tags: ["circuits"],
+		summary: "Read a single circuit by id",
+		parameters: [
+			new OA\Parameter(ref: "#/components/parameters/app_id"),
+			new OA\Parameter(name: "id", in: "path", required: true, schema: new OA\Schema(type: "integer"))
+		],
+		responses: [
+			new OA\Response(response: 200, description: "OK", content: new OA\JsonContent(properties: [
+				new OA\Property(property: "id", type: "string", example: "1"),
+				new OA\Property(property: "cid", type: "string"),
+				new OA\Property(property: "provider", type: "string"),
+				new OA\Property(property: "type", type: "string"),
+				new OA\Property(property: "capacity", type: "string"),
+				new OA\Property(property: "status", type: "string", enum: ["Active", "Inactive", "Reserved"]),
+				new OA\Property(property: "device1", type: "string"),
+				new OA\Property(property: "location1", type: "string"),
+				new OA\Property(property: "device2", type: "string"),
+				new OA\Property(property: "location2", type: "string"),
+				new OA\Property(property: "comment", type: "string"),
+				new OA\Property(property: "parent", type: "string"),
+				new OA\Property(property: "customer_id", type: "string"),
+				new OA\Property(property: "differentiator", type: "string")
+			])),
+			new OA\Response(response: 400, description: "Invalid ID", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse")),
+			new OA\Response(response: 404, description: "circuit not found", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))
+		]
+	)]
+	#[OA\Get(
+		path: "/{app_id}/circuits/id/{cid}/",
+		tags: ["circuits"],
+		summary: "Read a single circuit by its Circuit ID (cid) value - alias of /circuits/circuit_id/{cid}/",
+		parameters: [
+			new OA\Parameter(ref: "#/components/parameters/app_id"),
+			new OA\Parameter(name: "cid", in: "path", required: true, description: "Circuit ID (cid) value", schema: new OA\Schema(type: "string"))
+		],
+		responses: [
+			new OA\Response(response: 200, description: "OK", content: new OA\JsonContent(properties: [
+				new OA\Property(property: "id", type: "string"),
+				new OA\Property(property: "cid", type: "string"),
+				new OA\Property(property: "provider", type: "string")
+			])),
+			new OA\Response(response: 404, description: "circuit not found", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))
+		]
+	)]
+	#[OA\Get(
+		path: "/{app_id}/circuits/circuit_id/{cid}/",
+		tags: ["circuits"],
+		summary: "Read a single circuit by its Circuit ID (cid) value - alias of /circuits/id/{cid}/",
+		parameters: [
+			new OA\Parameter(ref: "#/components/parameters/app_id"),
+			new OA\Parameter(name: "cid", in: "path", required: true, description: "Circuit ID (cid) value", schema: new OA\Schema(type: "string"))
+		],
+		responses: [
+			new OA\Response(response: 200, description: "OK", content: new OA\JsonContent(properties: [
+				new OA\Property(property: "id", type: "string"),
+				new OA\Property(property: "cid", type: "string"),
+				new OA\Property(property: "provider", type: "string")
+			])),
+			new OA\Response(response: 404, description: "circuit not found", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))
+		]
+	)]
+	#[OA\Get(
+		path: "/{app_id}/circuits/providers/",
+		tags: ["circuits"],
+		summary: "List all circuit providers (alias: /circuits/providers/all/)",
+		parameters: [new OA\Parameter(ref: "#/components/parameters/app_id")],
+		responses: [
+			new OA\Response(response: 200, description: "OK", content: new OA\JsonContent(type: "array", items: new OA\Items(properties: [
+				new OA\Property(property: "id", type: "string", example: "1"),
+				new OA\Property(property: "name", type: "string"),
+				new OA\Property(property: "description", type: "string"),
+				new OA\Property(property: "contact", type: "string")
+			]))),
+			new OA\Response(response: 404, description: "No providers configured", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))
+		]
+	)]
+	#[OA\Get(
+		path: "/{app_id}/circuits/providers/{id}/",
+		tags: ["circuits"],
+		summary: "Read a single circuit provider by id",
+		parameters: [
+			new OA\Parameter(ref: "#/components/parameters/app_id"),
+			new OA\Parameter(name: "id", in: "path", required: true, description: "Provider id", schema: new OA\Schema(type: "integer"))
+		],
+		responses: [
+			new OA\Response(response: 200, description: "OK", content: new OA\JsonContent(properties: [
+				new OA\Property(property: "id", type: "string", example: "1"),
+				new OA\Property(property: "name", type: "string"),
+				new OA\Property(property: "description", type: "string"),
+				new OA\Property(property: "contact", type: "string")
+			])),
+			new OA\Response(response: 400, description: "Invalid ID", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse")),
+			new OA\Response(response: 404, description: "provider not found", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))
+		]
+	)]
+	#[OA\Get(
+		path: "/{app_id}/circuits/providers/{id}/circuits/",
+		tags: ["circuits"],
+		summary: "List all circuits belonging to a given provider",
+		parameters: [
+			new OA\Parameter(ref: "#/components/parameters/app_id"),
+			new OA\Parameter(name: "id", in: "path", required: true, description: "Provider id", schema: new OA\Schema(type: "integer"))
+		],
+		responses: [
+			new OA\Response(response: 200, description: "OK", content: new OA\JsonContent(type: "array", items: new OA\Items(properties: [
+				new OA\Property(property: "id", type: "string"),
+				new OA\Property(property: "cid", type: "string"),
+				new OA\Property(property: "provider", type: "string")
+			]))),
+			new OA\Response(response: 404, description: "No circuits belonging to provider", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))
+		]
+	)]
 	#[\Override]
     public function GET () {
 		// all
@@ -187,6 +342,56 @@ class Circuits_controller extends Common_api_functions {
 	 * @access public
 	 * @return void
 	 */
+	#[OA\Post(
+		path: "/{app_id}/circuits/",
+		tags: ["circuits"],
+		summary: "Create a new circuit",
+		parameters: [new OA\Parameter(ref: "#/components/parameters/app_id")],
+		requestBody: new OA\RequestBody(required: true, content: new OA\JsonContent(
+			required: ["cid", "provider"],
+			properties: [
+				new OA\Property(property: "cid", type: "string", description: "Circuit ID, must be unique per differentiator"),
+				new OA\Property(property: "provider", type: "integer", description: "Existing circuit provider id"),
+				new OA\Property(property: "type", type: "string", description: "Defaults to Default if not provided"),
+				new OA\Property(property: "capacity", type: "string"),
+				new OA\Property(property: "status", type: "string", enum: ["Active", "Inactive", "Reserved"], default: "Active"),
+				new OA\Property(property: "device1", type: "integer", description: "Defaults to 0 if neither device1 nor location1 is provided"),
+				new OA\Property(property: "location1", type: "integer", description: "Defaults to 0 if neither device1 nor location1 is provided"),
+				new OA\Property(property: "device2", type: "integer", description: "Defaults to 0 if neither device2 nor location2 is provided"),
+				new OA\Property(property: "location2", type: "integer", description: "Defaults to 0 if neither device2 nor location2 is provided"),
+				new OA\Property(property: "comment", type: "string"),
+				new OA\Property(property: "parent", type: "integer"),
+				new OA\Property(property: "customer_id", type: "integer"),
+				new OA\Property(property: "differentiator", type: "string")
+			]
+		)),
+		responses: [
+			new OA\Response(response: 201, description: "circuit created", content: new OA\JsonContent(ref: "#/components/schemas/SuccessResponse")),
+			new OA\Response(response: 400, description: "Circuit ID is mandatory / Invalid circuit provider / Invalid circuit type / Invalid status / Invalid device or location", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse")),
+			new OA\Response(response: 409, description: "Circuit ID already exists / No values present", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse")),
+			new OA\Response(response: 500, description: "circuit creation failed", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))
+		]
+	)]
+	#[OA\Post(
+		path: "/{app_id}/circuits/providers/",
+		tags: ["circuits"],
+		summary: "Create a new circuit provider",
+		parameters: [new OA\Parameter(ref: "#/components/parameters/app_id")],
+		requestBody: new OA\RequestBody(required: true, content: new OA\JsonContent(
+			required: ["name"],
+			properties: [
+				new OA\Property(property: "name", type: "string"),
+				new OA\Property(property: "description", type: "string"),
+				new OA\Property(property: "contact", type: "string")
+			]
+		)),
+		responses: [
+			new OA\Response(response: 201, description: "provider created", content: new OA\JsonContent(ref: "#/components/schemas/SuccessResponse")),
+			new OA\Response(response: 404, description: "Name is mandatory", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse")),
+			new OA\Response(response: 409, description: "No values present", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse")),
+			new OA\Response(response: 500, description: "provider creation failed", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))
+		]
+	)]
 	#[\Override]
     public function POST () {
 		# remap keys
@@ -228,6 +433,62 @@ class Circuits_controller extends Common_api_functions {
 	 *
 	 * @return void|array
 	 */
+	#[OA\Patch(
+		path: "/{app_id}/circuits/{id}/",
+		tags: ["circuits"],
+		summary: "Update an existing circuit",
+		parameters: [
+			new OA\Parameter(ref: "#/components/parameters/app_id"),
+			new OA\Parameter(name: "id", in: "path", required: true, schema: new OA\Schema(type: "integer"))
+		],
+		requestBody: new OA\RequestBody(content: new OA\JsonContent(
+			properties: [
+				new OA\Property(property: "cid", type: "string"),
+				new OA\Property(property: "provider", type: "integer", description: "Existing circuit provider id"),
+				new OA\Property(property: "type", type: "string"),
+				new OA\Property(property: "capacity", type: "string"),
+				new OA\Property(property: "status", type: "string", enum: ["Active", "Inactive", "Reserved"]),
+				new OA\Property(property: "device1", type: "integer"),
+				new OA\Property(property: "location1", type: "integer"),
+				new OA\Property(property: "device2", type: "integer"),
+				new OA\Property(property: "location2", type: "integer"),
+				new OA\Property(property: "comment", type: "string"),
+				new OA\Property(property: "parent", type: "integer"),
+				new OA\Property(property: "customer_id", type: "integer"),
+				new OA\Property(property: "differentiator", type: "string")
+			]
+		)),
+		responses: [
+			new OA\Response(response: 200, description: "circuit updated", content: new OA\JsonContent(ref: "#/components/schemas/SuccessResponse")),
+			new OA\Response(response: 400, description: "circuit id is required / circuit id must be numeric / Invalid circuit provider / Invalid circuit type / Invalid status / Invalid device or location", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse")),
+			new OA\Response(response: 404, description: "Nonexisting circuit id", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse")),
+			new OA\Response(response: 409, description: "Circuit ID already exists / No values present", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse")),
+			new OA\Response(response: 500, description: "circuit edit failed", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))
+		]
+	)]
+	#[OA\Patch(
+		path: "/{app_id}/circuits/providers/{id}/",
+		tags: ["circuits"],
+		summary: "Update an existing circuit provider",
+		parameters: [
+			new OA\Parameter(ref: "#/components/parameters/app_id"),
+			new OA\Parameter(name: "id", in: "path", required: true, schema: new OA\Schema(type: "integer"))
+		],
+		requestBody: new OA\RequestBody(content: new OA\JsonContent(
+			properties: [
+				new OA\Property(property: "name", type: "string"),
+				new OA\Property(property: "description", type: "string"),
+				new OA\Property(property: "contact", type: "string")
+			]
+		)),
+		responses: [
+			new OA\Response(response: 200, description: "provider updated", content: new OA\JsonContent(ref: "#/components/schemas/SuccessResponse")),
+			new OA\Response(response: 400, description: "provider id is required / provider id must be numeric", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse")),
+			new OA\Response(response: 404, description: "Nonexisting provider id", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse")),
+			new OA\Response(response: 409, description: "No values present", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse")),
+			new OA\Response(response: 500, description: "provider edit failed", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))
+		]
+	)]
 	#[\Override]
     public function PATCH () {
 		# remap keys
@@ -265,6 +526,36 @@ class Circuits_controller extends Common_api_functions {
 	 *
 	 * @return void|array
 	 */
+	#[OA\Delete(
+		path: "/{app_id}/circuits/{id}/",
+		tags: ["circuits"],
+		summary: "Delete a circuit",
+		parameters: [
+			new OA\Parameter(ref: "#/components/parameters/app_id"),
+			new OA\Parameter(name: "id", in: "path", required: true, schema: new OA\Schema(type: "integer"))
+		],
+		responses: [
+			new OA\Response(response: 200, description: "circuit deleted", content: new OA\JsonContent(ref: "#/components/schemas/SuccessResponse")),
+			new OA\Response(response: 400, description: "circuit id is required / circuit id must be numeric", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse")),
+			new OA\Response(response: 404, description: "Nonexisting circuit id", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse")),
+			new OA\Response(response: 500, description: "circuit delete failed", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))
+		]
+	)]
+	#[OA\Delete(
+		path: "/{app_id}/circuits/providers/{id}/",
+		tags: ["circuits"],
+		summary: "Delete a circuit provider (also removes references to it from any circuits)",
+		parameters: [
+			new OA\Parameter(ref: "#/components/parameters/app_id"),
+			new OA\Parameter(name: "id", in: "path", required: true, schema: new OA\Schema(type: "integer"))
+		],
+		responses: [
+			new OA\Response(response: 200, description: "provider deleted", content: new OA\JsonContent(ref: "#/components/schemas/SuccessResponse")),
+			new OA\Response(response: 400, description: "provider id is required / provider id must be numeric", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse")),
+			new OA\Response(response: 404, description: "Nonexisting provider id", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse")),
+			new OA\Response(response: 500, description: "provider delete failed", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))
+		]
+	)]
 	#[\Override]
     public function DELETE () {
 		# verify

--- a/public/api/controllers/Devices.php
+++ b/public/api/controllers/Devices.php
@@ -1,5 +1,7 @@
 <?php
 
+use OpenApi\Attributes as OA;
+
 /**
  *	phpIPAM API class to work with devices.
  *
@@ -48,6 +50,13 @@ class Devices_controller extends Common_api_functions {
      * @access public
      * @return void
      */
+    #[OA\Options(
+        path: "/{app_id}/devices/",
+        tags: ["devices"],
+        summary: "Discover supported devices routes/methods (HATEOAS)",
+        parameters: [new OA\Parameter(ref: "#/components/parameters/app_id")],
+        responses: [new OA\Response(response: 200, description: "OK")]
+    )]
     #[\Override]
     public function OPTIONS () {
         // validate
@@ -89,6 +98,76 @@ class Devices_controller extends Common_api_functions {
      * @access public
      * @return void
      */
+    #[OA\Get(
+        path: "/{app_id}/devices/",
+        tags: ["devices"],
+        summary: "List all devices",
+        parameters: [new OA\Parameter(ref: "#/components/parameters/app_id")],
+        responses: [
+            new OA\Response(response: 200, description: "OK", content: new OA\JsonContent(type: "array", items: new OA\Items(ref: "#/components/schemas/Device"))),
+            new OA\Response(response: 404, description: "No devices configured", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))
+        ]
+    )]
+    #[OA\Get(
+        path: "/{app_id}/devices/search/{search_term}/",
+        tags: ["devices"],
+        summary: "Search devices by hostname, ip_addr, description, or custom fields (substring match)",
+        parameters: [
+            new OA\Parameter(ref: "#/components/parameters/app_id"),
+            new OA\Parameter(name: "search_term", in: "path", required: true, schema: new OA\Schema(type: "string"))
+        ],
+        responses: [
+            new OA\Response(response: 200, description: "OK", content: new OA\JsonContent(type: "array", items: new OA\Items(ref: "#/components/schemas/Device"))),
+            new OA\Response(response: 404, description: "No devices found", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))
+        ]
+    )]
+    #[OA\Get(
+        path: "/{app_id}/devices/search/",
+        tags: ["devices"],
+        summary: "Search devices without a search term (always fails)",
+        parameters: [new OA\Parameter(ref: "#/components/parameters/app_id")],
+        responses: [new OA\Response(response: 400, description: "No search term given", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))]
+    )]
+    #[OA\Get(
+        path: "/{app_id}/devices/{id}/",
+        tags: ["devices"],
+        summary: "Read a single device by id",
+        parameters: [
+            new OA\Parameter(ref: "#/components/parameters/app_id"),
+            new OA\Parameter(name: "id", in: "path", required: true, schema: new OA\Schema(type: "integer"))
+        ],
+        responses: [
+            new OA\Response(response: 200, description: "OK", content: new OA\JsonContent(ref: "#/components/schemas/Device")),
+            new OA\Response(response: 400, description: "ID must be numeric", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse")),
+            new OA\Response(response: 404, description: "Device not found", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))
+        ]
+    )]
+    #[OA\Get(
+        path: "/{app_id}/devices/{id}/addresses/",
+        tags: ["devices"],
+        summary: "List all IP addresses assigned to this device",
+        parameters: [
+            new OA\Parameter(ref: "#/components/parameters/app_id"),
+            new OA\Parameter(name: "id", in: "path", required: true, description: "Device id", schema: new OA\Schema(type: "integer"))
+        ],
+        responses: [
+            new OA\Response(response: 200, description: "OK", content: new OA\JsonContent(type: "array", items: new OA\Items(ref: "#/components/schemas/Address"))),
+            new OA\Response(response: 404, description: "No addresses found", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))
+        ]
+    )]
+    #[OA\Get(
+        path: "/{app_id}/devices/{id}/subnets/",
+        tags: ["devices"],
+        summary: "List all subnets whose gateway/device is this device",
+        parameters: [
+            new OA\Parameter(ref: "#/components/parameters/app_id"),
+            new OA\Parameter(name: "id", in: "path", required: true, description: "Device id", schema: new OA\Schema(type: "integer"))
+        ],
+        responses: [
+            new OA\Response(response: 200, description: "OK", content: new OA\JsonContent(type: "array", items: new OA\Items(ref: "#/components/schemas/Subnet"))),
+            new OA\Response(response: 404, description: "No subnets found", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))
+        ]
+    )]
     #[\Override]
     public function GET () {
         // all objects
@@ -182,6 +261,37 @@ class Devices_controller extends Common_api_functions {
      *
      * @method POST
      */
+    #[OA\Post(
+        path: "/{app_id}/devices/",
+        tags: ["devices"],
+        summary: "Create a new device",
+        parameters: [new OA\Parameter(ref: "#/components/parameters/app_id")],
+        requestBody: new OA\RequestBody(required: true, content: new OA\JsonContent(
+            required: ["hostname"],
+            properties: [
+                new OA\Property(property: "hostname", type: "string", example: "switch-01"),
+                new OA\Property(property: "ip_addr", type: "string", example: "192.168.1.1"),
+                new OA\Property(property: "type", type: "integer", description: "Device type id, see tools/deviceTypes"),
+                new OA\Property(property: "description", type: "string"),
+                new OA\Property(property: "sections", type: "string", description: "Comma/semicolon separated list of section ids; defaults to all sections if omitted"),
+                new OA\Property(property: "snmp_community", type: "string"),
+                new OA\Property(property: "snmp_version", type: "string", enum: ["0","1","2","3"], description: "0=disabled, 1=v1, 2=v2c, 3=v3"),
+                new OA\Property(property: "snmp_port", type: "integer", example: 161),
+                new OA\Property(property: "snmp_timeout", type: "integer", example: 1000),
+                new OA\Property(property: "snmp_queries", type: "string"),
+                new OA\Property(property: "snmp_v3_sec_level", type: "string", enum: ["none","noAuthNoPriv","authNoPriv","authPriv"], description: "Representative SNMPv3 field; other snmp_v3_* sub-fields (auth/priv protocol/pass, context name/engine id) are also accepted"),
+                new OA\Property(property: "rack", type: "integer"),
+                new OA\Property(property: "rack_start", type: "integer"),
+                new OA\Property(property: "rack_size", type: "integer"),
+                new OA\Property(property: "location", type: "integer")
+            ]
+        )),
+        responses: [
+            new OA\Response(response: 201, description: "Device created", content: new OA\JsonContent(ref: "#/components/schemas/SuccessResponse")),
+            new OA\Response(response: 400, description: "Hostname is mandatory / Invalid devicetype identifier / Device type does not exist", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse")),
+            new OA\Response(response: 500, description: "Device creation failed", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))
+        ]
+    )]
     #[\Override]
     public function POST () {
         # Put incoming keys in order
@@ -222,6 +332,39 @@ class Devices_controller extends Common_api_functions {
      *
      * @method PATCH
      */
+    #[OA\Patch(
+        path: "/{app_id}/devices/{id}/",
+        tags: ["devices"],
+        summary: "Update an existing device",
+        parameters: [
+            new OA\Parameter(ref: "#/components/parameters/app_id"),
+            new OA\Parameter(name: "id", in: "path", required: true, schema: new OA\Schema(type: "integer"))
+        ],
+        requestBody: new OA\RequestBody(content: new OA\JsonContent(
+            properties: [
+                new OA\Property(property: "hostname", type: "string", example: "switch-01"),
+                new OA\Property(property: "ip_addr", type: "string", example: "192.168.1.1"),
+                new OA\Property(property: "type", type: "integer", description: "Device type id, see tools/deviceTypes"),
+                new OA\Property(property: "description", type: "string"),
+                new OA\Property(property: "sections", type: "string"),
+                new OA\Property(property: "snmp_community", type: "string"),
+                new OA\Property(property: "snmp_version", type: "string", enum: ["0","1","2","3"]),
+                new OA\Property(property: "snmp_port", type: "integer"),
+                new OA\Property(property: "snmp_timeout", type: "integer"),
+                new OA\Property(property: "snmp_queries", type: "string"),
+                new OA\Property(property: "snmp_v3_sec_level", type: "string", enum: ["none","noAuthNoPriv","authNoPriv","authPriv"], description: "Representative SNMPv3 field; other snmp_v3_* sub-fields are also accepted"),
+                new OA\Property(property: "rack", type: "integer"),
+                new OA\Property(property: "rack_start", type: "integer"),
+                new OA\Property(property: "rack_size", type: "integer"),
+                new OA\Property(property: "location", type: "integer")
+            ]
+        )),
+        responses: [
+            new OA\Response(response: 200, description: "Device updated", content: new OA\JsonContent(ref: "#/components/schemas/SuccessResponse")),
+            new OA\Response(response: 400, description: "Invalid device id / Hostname is mandatory / Invalid devicetype identifier / Device type does not exist / No parameters", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse")),
+            new OA\Response(response: 500, description: "Device edit failed", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))
+        ]
+    )]
     #[\Override]
     public function PATCH (){
         # Put incoming keys back in order
@@ -256,6 +399,21 @@ class Devices_controller extends Common_api_functions {
      *
      * @method DELETE
      */
+    #[OA\Delete(
+        path: "/{app_id}/devices/{id}/",
+        tags: ["devices"],
+        summary: "Delete a device",
+        parameters: [
+            new OA\Parameter(ref: "#/components/parameters/app_id"),
+            new OA\Parameter(name: "id", in: "path", required: true, schema: new OA\Schema(type: "integer"))
+        ],
+        responses: [
+            new OA\Response(response: 200, description: "Device deleted", content: new OA\JsonContent(ref: "#/components/schemas/SuccessResponse")),
+            new OA\Response(response: 400, description: "Invalid device id", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse")),
+            new OA\Response(response: 404, description: "Device does not exist", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse")),
+            new OA\Response(response: 500, description: "Device delete failed", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))
+        ]
+    )]
     #[\Override]
     public function DELETE () {
 		# validations

--- a/public/api/controllers/L2domains.php
+++ b/public/api/controllers/L2domains.php
@@ -1,5 +1,7 @@
 <?php
 
+use OpenApi\Attributes as OA;
+
 /**
  *	phpIPAM API class to work with VLAN domains
  *
@@ -40,6 +42,13 @@ class L2domains_controller extends Common_api_functions {
 	 * @access public
 	 * @return void
 	 */
+	#[OA\Options(
+		path: "/{app_id}/l2domains/",
+		tags: ["l2domains"],
+		summary: "Discover supported l2domains routes/methods (HATEOAS)",
+		parameters: [new OA\Parameter(ref: "#/components/parameters/app_id")],
+		responses: [new OA\Response(response: 200, description: "OK")]
+	)]
 	#[\Override]
     public function OPTIONS () {
 		// validate
@@ -75,6 +84,64 @@ class L2domains_controller extends Common_api_functions {
 	 * @access public
 	 * @return void
 	 */
+	#[OA\Get(
+		path: "/{app_id}/l2domains/",
+		tags: ["l2domains"],
+		summary: "List all L2 (VLAN) domains",
+		parameters: [new OA\Parameter(ref: "#/components/parameters/app_id")],
+		responses: [
+			new OA\Response(response: 200, description: "OK", content: new OA\JsonContent(type: "array", items: new OA\Items(properties: [
+				new OA\Property(property: "id", type: "integer", example: 1),
+				new OA\Property(property: "name", type: "string", example: "default"),
+				new OA\Property(property: "description", type: "string", nullable: true, example: "default L2 domain"),
+				new OA\Property(property: "sections", type: "string", nullable: true, description: "JSON-encoded map of groupId => permission level (stored internally as 'permissions', exposed as 'sections' in read responses)")
+			]))),
+			new OA\Response(response: 404, description: "No domains configured", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))
+		]
+	)]
+	#[OA\Get(
+		path: "/{app_id}/l2domains/custom_fields/",
+		tags: ["l2domains"],
+		summary: "List custom fields defined on the vlanDomains table",
+		parameters: [new OA\Parameter(ref: "#/components/parameters/app_id")],
+		responses: [
+			new OA\Response(response: 200, description: "OK"),
+			new OA\Response(response: 404, description: "No custom fields defined", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))
+		]
+	)]
+	#[OA\Get(
+		path: "/{app_id}/l2domains/{id}/vlans/",
+		tags: ["l2domains"],
+		summary: "List all VLANs belonging to an L2 domain",
+		parameters: [
+			new OA\Parameter(ref: "#/components/parameters/app_id"),
+			new OA\Parameter(name: "id", in: "path", required: true, description: "L2 domain id", schema: new OA\Schema(type: "integer"))
+		],
+		responses: [
+			new OA\Response(response: 200, description: "OK", content: new OA\JsonContent(type: "array", items: new OA\Items(ref: "#/components/schemas/Vlan"))),
+			new OA\Response(response: 400, description: "Domain id must be numeric", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse")),
+			new OA\Response(response: 404, description: "Invalid domain id / No vlans belonging to this domain", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))
+		]
+	)]
+	#[OA\Get(
+		path: "/{app_id}/l2domains/{id}/",
+		tags: ["l2domains"],
+		summary: "Read a single L2 domain by id",
+		parameters: [
+			new OA\Parameter(ref: "#/components/parameters/app_id"),
+			new OA\Parameter(name: "id", in: "path", required: true, schema: new OA\Schema(type: "integer"))
+		],
+		responses: [
+			new OA\Response(response: 200, description: "OK", content: new OA\JsonContent(properties: [
+				new OA\Property(property: "id", type: "integer", example: 1),
+				new OA\Property(property: "name", type: "string", example: "default"),
+				new OA\Property(property: "description", type: "string", nullable: true, example: "default L2 domain"),
+				new OA\Property(property: "sections", type: "string", nullable: true, description: "JSON-encoded map of groupId => permission level (stored internally as 'permissions', exposed as 'sections' in read responses)")
+			])),
+			new OA\Response(response: 400, description: "Domain id must be numeric", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse")),
+			new OA\Response(response: 404, description: "Invalid domain id", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))
+		]
+	)]
 	#[\Override]
     public function GET () {
 		// all domains
@@ -126,6 +193,25 @@ class L2domains_controller extends Common_api_functions {
 	 * @access public
 	 * @return void
 	 */
+	#[OA\Post(
+		path: "/{app_id}/l2domains/",
+		tags: ["l2domains"],
+		summary: "Create a new L2 (VLAN) domain",
+		parameters: [new OA\Parameter(ref: "#/components/parameters/app_id")],
+		requestBody: new OA\RequestBody(required: true, content: new OA\JsonContent(
+			required: ["name"],
+			properties: [
+				new OA\Property(property: "name", type: "string", example: "Colo 1"),
+				new OA\Property(property: "description", type: "string", nullable: true),
+				new OA\Property(property: "permissions", type: "string", nullable: true, description: "JSON-encoded map of groupId => permission level")
+			]
+		)),
+		responses: [
+			new OA\Response(response: 201, description: "L2 domain created", content: new OA\JsonContent(ref: "#/components/schemas/SuccessResponse")),
+			new OA\Response(response: 400, description: "Domain name is mandatory", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse")),
+			new OA\Response(response: 500, description: "Domain creation failed", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))
+		]
+	)]
 	#[\Override]
     public function POST () {
 		# remap keys
@@ -156,6 +242,28 @@ class L2domains_controller extends Common_api_functions {
 	 * @access public
 	 * @return void
 	 */
+	#[OA\Patch(
+		path: "/{app_id}/l2domains/{id}/",
+		tags: ["l2domains"],
+		summary: "Update an existing L2 (VLAN) domain",
+		parameters: [
+			new OA\Parameter(ref: "#/components/parameters/app_id"),
+			new OA\Parameter(name: "id", in: "path", required: true, schema: new OA\Schema(type: "integer"))
+		],
+		requestBody: new OA\RequestBody(content: new OA\JsonContent(
+			properties: [
+				new OA\Property(property: "name", type: "string", example: "Colo 1"),
+				new OA\Property(property: "description", type: "string", nullable: true),
+				new OA\Property(property: "permissions", type: "string", nullable: true, description: "JSON-encoded map of groupId => permission level")
+			]
+		)),
+		responses: [
+			new OA\Response(response: 200, description: "L2 domain updated", content: new OA\JsonContent(ref: "#/components/schemas/SuccessResponse")),
+			new OA\Response(response: 400, description: "Invalid domain id / Domain name is mandatory", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse")),
+			new OA\Response(response: 404, description: "Invalid domain id", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse")),
+			new OA\Response(response: 500, description: "Domain edit failed", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))
+		]
+	)]
 	#[\Override]
     public function PATCH () {
 		# remap keys
@@ -190,6 +298,23 @@ class L2domains_controller extends Common_api_functions {
 	 * @access public
 	 * @return void
 	 */
+	#[OA\Delete(
+		path: "/{app_id}/l2domains/{id}/",
+		tags: ["l2domains"],
+		summary: "Delete an L2 (VLAN) domain (VLANs in this domain are migrated to the default domain)",
+		description: "The default domain (id=1) cannot be deleted.",
+		parameters: [
+			new OA\Parameter(ref: "#/components/parameters/app_id"),
+			new OA\Parameter(name: "id", in: "path", required: true, schema: new OA\Schema(type: "integer"))
+		],
+		responses: [
+			new OA\Response(response: 200, description: "L2 domain deleted and vlans migrated to default domain", content: new OA\JsonContent(ref: "#/components/schemas/SuccessResponse")),
+			new OA\Response(response: 400, description: "Domain id must be numeric", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse")),
+			new OA\Response(response: 404, description: "Invalid domain id", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse")),
+			new OA\Response(response: 409, description: "Default domain cannot be deleted", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse")),
+			new OA\Response(response: 500, description: "L2 domain delete failed", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))
+		]
+	)]
 	#[\Override]
     public function DELETE () {
 		# check that domain exists

--- a/public/api/controllers/Nat.php
+++ b/public/api/controllers/Nat.php
@@ -1,5 +1,7 @@
 <?php
 
+use OpenApi\Attributes as OA;
+
 /**
  *  phpIPAM API class to work with NAT
  *
@@ -111,6 +113,13 @@ class Nat_controller extends Common_api_functions {
      * @access public
      * @return void
      */
+    #[OA\Options(
+        path: "/{app_id}/nat/",
+        tags: ["nat"],
+        summary: "Discover supported NAT routes/methods (HATEOAS)",
+        parameters: [new OA\Parameter(ref: "#/components/parameters/app_id")],
+        responses: [new OA\Response(response: 200, description: "OK")]
+    )]
     #[\Override]
     public function OPTIONS () {
         // validate
@@ -140,6 +149,74 @@ class Nat_controller extends Common_api_functions {
      * @access public
      * @return void
      */
+    #[OA\Get(
+        path: "/{app_id}/nat/",
+        tags: ["nat"],
+        summary: "List all NAT entries (alias: /nat/all/)",
+        parameters: [new OA\Parameter(ref: "#/components/parameters/app_id")],
+        responses: [
+            new OA\Response(
+                response: 200,
+                description: "OK",
+                content: new OA\JsonContent(type: "array", items: new OA\Items(
+                    type: "object",
+                    properties: [
+                        new OA\Property(property: "id", type: "integer", example: 1),
+                        new OA\Property(property: "name", type: "string", nullable: true, example: "Outbound NAT"),
+                        new OA\Property(property: "type", type: "string", enum: ["source", "destination", "static"]),
+                        new OA\Property(property: "src", type: "object", description: "Map of identifier type to array of ids. Currently only 'ipaddresses' is supported.",
+                            properties: [new OA\Property(property: "ipaddresses", type: "array", items: new OA\Items(type: "integer"))]
+                        ),
+                        new OA\Property(property: "dst", type: "object", description: "Same structure as src",
+                            properties: [new OA\Property(property: "ipaddresses", type: "array", items: new OA\Items(type: "integer"))]
+                        ),
+                        new OA\Property(property: "src_port", type: "integer", nullable: true),
+                        new OA\Property(property: "dst_port", type: "integer", nullable: true),
+                        new OA\Property(property: "device", type: "integer", nullable: true, description: "Device id"),
+                        new OA\Property(property: "description", type: "string", nullable: true),
+                        new OA\Property(property: "policy", type: "string", enum: ["Yes", "No"]),
+                        new OA\Property(property: "policy_dst", type: "string", nullable: true)
+                    ]
+                ))
+            )
+        ]
+    )]
+    #[OA\Get(
+        path: "/{app_id}/nat/{id}/",
+        tags: ["nat"],
+        summary: "Read a single NAT entry by id",
+        parameters: [
+            new OA\Parameter(ref: "#/components/parameters/app_id"),
+            new OA\Parameter(name: "id", in: "path", required: true, schema: new OA\Schema(type: "integer"))
+        ],
+        responses: [
+            new OA\Response(
+                response: 200,
+                description: "OK",
+                content: new OA\JsonContent(type: "array", items: new OA\Items(
+                    type: "object",
+                    properties: [
+                        new OA\Property(property: "id", type: "integer", example: 1),
+                        new OA\Property(property: "name", type: "string", nullable: true, example: "Outbound NAT"),
+                        new OA\Property(property: "type", type: "string", enum: ["source", "destination", "static"]),
+                        new OA\Property(property: "src", type: "object", description: "Map of identifier type to array of ids. Currently only 'ipaddresses' is supported.",
+                            properties: [new OA\Property(property: "ipaddresses", type: "array", items: new OA\Items(type: "integer"))]
+                        ),
+                        new OA\Property(property: "dst", type: "object", description: "Same structure as src",
+                            properties: [new OA\Property(property: "ipaddresses", type: "array", items: new OA\Items(type: "integer"))]
+                        ),
+                        new OA\Property(property: "src_port", type: "integer", nullable: true),
+                        new OA\Property(property: "dst_port", type: "integer", nullable: true),
+                        new OA\Property(property: "device", type: "integer", nullable: true, description: "Device id"),
+                        new OA\Property(property: "description", type: "string", nullable: true),
+                        new OA\Property(property: "policy", type: "string", enum: ["Yes", "No"]),
+                        new OA\Property(property: "policy_dst", type: "string", nullable: true)
+                    ]
+                ))
+            ),
+            new OA\Response(response: 400, description: "Invalid ID format", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))
+        ]
+    )]
     #[\Override]
     public function GET () {
         # Get all NATs from DB
@@ -193,6 +270,13 @@ class Nat_controller extends Common_api_functions {
      * @access public
      * @return void
      */
+    #[OA\Head(
+        path: "/{app_id}/nat/",
+        tags: ["nat"],
+        summary: "HEAD request for NAT list/details (runs the same processing as GET, but no response body is returned)",
+        parameters: [new OA\Parameter(ref: "#/components/parameters/app_id")],
+        responses: [new OA\Response(response: 200, description: "OK (headers only, no body)")]
+    )]
     #[\Override]
     public function HEAD () {
         return $this->GET ();
@@ -204,6 +288,41 @@ class Nat_controller extends Common_api_functions {
      * @access public
      * @return void
      */
+    #[OA\Post(
+        path: "/{app_id}/nat/",
+        tags: ["nat"],
+        summary: "Create a new NAT entry",
+        parameters: [new OA\Parameter(ref: "#/components/parameters/app_id")],
+        requestBody: new OA\RequestBody(required: true, content: new OA\JsonContent(
+            required: ["name", "type"],
+            properties: [
+                new OA\Property(property: "name", type: "string", description: "NAT name (mandatory)", example: "Outbound NAT"),
+                new OA\Property(property: "type", type: "string", enum: ["source", "destination", "static"], description: "NAT type (mandatory)"),
+                new OA\Property(property: "src", type: "object", description: "Map of identifier type to array of ids. Currently only 'ipaddresses' is supported.",
+                    properties: [new OA\Property(property: "ipaddresses", type: "array", items: new OA\Items(type: "integer"), description: "Address ids")]
+                ),
+                new OA\Property(property: "dst", type: "object", description: "Same structure as src",
+                    properties: [new OA\Property(property: "ipaddresses", type: "array", items: new OA\Items(type: "integer"), description: "Address ids")]
+                ),
+                new OA\Property(property: "src_port", type: "integer", description: "Must be numeric"),
+                new OA\Property(property: "dst_port", type: "integer", description: "Must be numeric"),
+                new OA\Property(property: "device", type: "integer", description: "Device id, must reference an existing device"),
+                new OA\Property(property: "description", type: "string"),
+                new OA\Property(property: "policy", type: "string", enum: ["Yes", "No"]),
+                new OA\Property(property: "policy_dst", type: "string")
+            ]
+        )),
+        responses: [
+            new OA\Response(response: 201, description: "NAT created", content: new OA\JsonContent(ref: "#/components/schemas/SuccessResponse")),
+            new OA\Response(
+                response: 400,
+                description: "Possible causes: Missing NAT name; Missing NAT type; Invalid type; ID should not be set for creation; Invalid value for src_port/dst_port (must be numeric); Invalid src/dst format (must be an array); Invalid key identifier for src/dst; Invalid value for src/dst (must be an array or integer); Wrong format for device ID (must be numeric); Device ID not found",
+                content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse")
+            ),
+            new OA\Response(response: 404, description: "ID not found for the given src/dst identifier type", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse")),
+            new OA\Response(response: 500, description: "NAT creation failed", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))
+        ]
+    )]
     #[\Override]
     public function POST () {
         # check for valid keys
@@ -226,6 +345,43 @@ class Nat_controller extends Common_api_functions {
      * @access public
      * @return void
      */
+    #[OA\Patch(
+        path: "/{app_id}/nat/{id}/",
+        tags: ["nat"],
+        summary: "Update an existing NAT entry",
+        parameters: [
+            new OA\Parameter(ref: "#/components/parameters/app_id"),
+            new OA\Parameter(name: "id", in: "path", required: true, schema: new OA\Schema(type: "integer"))
+        ],
+        requestBody: new OA\RequestBody(content: new OA\JsonContent(
+            properties: [
+                new OA\Property(property: "name", type: "string"),
+                new OA\Property(property: "type", type: "string", enum: ["source", "destination", "static"]),
+                new OA\Property(property: "src", type: "object", description: "Map of identifier type to array of ids. Currently only 'ipaddresses' is supported.",
+                    properties: [new OA\Property(property: "ipaddresses", type: "array", items: new OA\Items(type: "integer"), description: "Address ids")]
+                ),
+                new OA\Property(property: "dst", type: "object", description: "Same structure as src",
+                    properties: [new OA\Property(property: "ipaddresses", type: "array", items: new OA\Items(type: "integer"), description: "Address ids")]
+                ),
+                new OA\Property(property: "src_port", type: "integer", description: "Must be numeric"),
+                new OA\Property(property: "dst_port", type: "integer", description: "Must be numeric"),
+                new OA\Property(property: "device", type: "integer", description: "Device id, must reference an existing device"),
+                new OA\Property(property: "description", type: "string"),
+                new OA\Property(property: "policy", type: "string", enum: ["Yes", "No"]),
+                new OA\Property(property: "policy_dst", type: "string")
+            ]
+        )),
+        responses: [
+            new OA\Response(response: 200, description: "NAT modified", content: new OA\JsonContent(ref: "#/components/schemas/SuccessResponse")),
+            new OA\Response(
+                response: 400,
+                description: "Possible causes: Invalid ID format; Invalid value for src_port/dst_port (must be numeric); Invalid src/dst format (must be an array); Invalid key identifier for src/dst; Invalid value for src/dst (must be an array or integer); Wrong format for device ID (must be numeric); Device ID not found",
+                content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse")
+            ),
+            new OA\Response(response: 404, description: "ID not found (NAT id, or src/dst identifier)", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse")),
+            new OA\Response(response: 500, description: "NAT modification failed", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))
+        ]
+    )]
     #[\Override]
     public function PATCH () {
         # check for valid keys
@@ -354,6 +510,21 @@ class Nat_controller extends Common_api_functions {
      * @access public
      * @return void
      */
+    #[OA\Delete(
+        path: "/{app_id}/nat/{id}/",
+        tags: ["nat"],
+        summary: "Delete an existing NAT entry",
+        parameters: [
+            new OA\Parameter(ref: "#/components/parameters/app_id"),
+            new OA\Parameter(name: "id", in: "path", required: true, schema: new OA\Schema(type: "integer"))
+        ],
+        responses: [
+            new OA\Response(response: 200, description: "NAT deleted", content: new OA\JsonContent(ref: "#/components/schemas/SuccessResponse")),
+            new OA\Response(response: 400, description: "Invalid ID format", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse")),
+            new OA\Response(response: 404, description: "ID not found", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse")),
+            new OA\Response(response: 500, description: "NAT delete failed", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))
+        ]
+    )]
     #[\Override]
     public function DELETE () {
         $values = $this->validate_keys();

--- a/public/api/controllers/Prefix.php
+++ b/public/api/controllers/Prefix.php
@@ -1,5 +1,7 @@
 <?php
 
+use OpenApi\Attributes as OA;
+
 /**
  *  phpIPAM API class to work with prefixes
  *
@@ -347,6 +349,13 @@ class Prefix_controller extends Common_api_functions {
      * @access public
      * @return array
      */
+    #[OA\Options(
+        path: "/{app_id}/prefix/",
+        tags: ["prefix"],
+        summary: "Discover supported prefix routes/methods (HATEOAS)",
+        parameters: [new OA\Parameter(ref: "#/components/parameters/app_id")],
+        responses: [new OA\Response(response: 200, description: "OK")]
+    )]
     #[\Override]
     public function OPTIONS () {
         // validate
@@ -378,6 +387,118 @@ class Prefix_controller extends Common_api_functions {
      * @access public
      * @return array
      */
+    #[OA\Get(
+        path: "/{app_id}/prefix/{customer_type}/",
+        tags: ["prefix"],
+        summary: "List candidate master subnets matching a customer_type custom field (any address family)",
+        description: "Searches subnets where the custom field configured as \$custom_field_name (default: custom_customer_type) equals {customer_type}, ordered by \$custom_field_orderby/\$custom_field_order_direction (default: subnet asc).",
+        parameters: [
+            new OA\Parameter(ref: "#/components/parameters/app_id"),
+            new OA\Parameter(name: "customer_type", in: "path", required: true, description: "Value of the customer_type custom field to search subnets for", schema: new OA\Schema(type: "string")),
+            new OA\Parameter(name: "usage", in: "query", required: false, description: "If set to true, append subnet usage statistics to each returned subnet", schema: new OA\Schema(type: "string", enum: ["true"]))
+        ],
+        responses: [
+            new OA\Response(response: 200, description: "OK", content: new OA\JsonContent(type: "array", items: new OA\Items(ref: "#/components/schemas/Subnet"))),
+            new OA\Response(response: 400, description: "Invalid custom field custom_customer_type (field not defined on subnets table)", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse")),
+            new OA\Response(response: 404, description: "No master subnets found", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))
+        ]
+    )]
+    #[OA\Get(
+        path: "/{app_id}/prefix/{customer_type}/{address_type}/",
+        tags: ["prefix"],
+        summary: "List candidate master subnets matching a customer_type custom field, filtered by address family",
+        parameters: [
+            new OA\Parameter(ref: "#/components/parameters/app_id"),
+            new OA\Parameter(name: "customer_type", in: "path", required: true, description: "Value of the customer_type custom field to search subnets for", schema: new OA\Schema(type: "string")),
+            new OA\Parameter(name: "address_type", in: "path", required: true, description: "IP protocol version filter", schema: new OA\Schema(type: "string", enum: ["IPv4", "IPv6", "v4", "v6", "4", "6"])),
+            new OA\Parameter(name: "usage", in: "query", required: false, description: "If set to true, append subnet usage statistics to each returned subnet", schema: new OA\Schema(type: "string", enum: ["true"]))
+        ],
+        responses: [
+            new OA\Response(response: 200, description: "OK", content: new OA\JsonContent(type: "array", items: new OA\Items(ref: "#/components/schemas/Subnet"))),
+            new OA\Response(response: 400, description: "Invalid custom field custom_customer_type, or invalid address type", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse")),
+            new OA\Response(response: 404, description: "No master subnets found", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))
+        ]
+    )]
+    #[OA\Get(
+        path: "/{app_id}/prefix/{customer_type}/{address_type}/{mask}/",
+        tags: ["prefix"],
+        summary: "Find the first available subnet of the given mask under any master subnet matching customer_type/address_type",
+        description: "Iterates matching master subnets (ordered by the configured custom field ordering) and returns the first free subnet found with the requested bitmask. Does not create it.",
+        parameters: [
+            new OA\Parameter(ref: "#/components/parameters/app_id"),
+            new OA\Parameter(name: "customer_type", in: "path", required: true, description: "Value of the customer_type custom field to search subnets for", schema: new OA\Schema(type: "string")),
+            new OA\Parameter(name: "address_type", in: "path", required: true, description: "IP protocol version filter", schema: new OA\Schema(type: "string", enum: ["IPv4", "IPv6", "v4", "v6", "4", "6"])),
+            new OA\Parameter(name: "mask", in: "path", required: true, description: "Requested subnet bitmask (8-128, IPv4 limited to <=32)", schema: new OA\Schema(type: "string"))
+        ],
+        responses: [
+            new OA\Response(response: 200, description: "OK", content: new OA\JsonContent(type: "string", description: "First available subnet found")),
+            new OA\Response(response: 400, description: "Invalid custom field, invalid address type, or invalid subnet mask", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse")),
+            new OA\Response(response: 404, description: "No subnets found", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))
+        ]
+    )]
+    #[OA\Get(
+        path: "/{app_id}/prefix/{customer_type}/address/",
+        tags: ["prefix"],
+        summary: "List candidate master subnets for address allocation matching a customer_type custom field",
+        description: "Searches subnets where the custom field configured as \$custom_field_name_addr (default: custom_customer_address_type) equals {customer_type}. Subnets that already contain slave subnets are excluded, since only leaf subnets can hold addresses.",
+        parameters: [
+            new OA\Parameter(ref: "#/components/parameters/app_id"),
+            new OA\Parameter(name: "customer_type", in: "path", required: true, description: "Value of the address custom field to search subnets for", schema: new OA\Schema(type: "string"))
+        ],
+        responses: [
+            new OA\Response(response: 200, description: "OK", content: new OA\JsonContent(type: "array", items: new OA\Items(ref: "#/components/schemas/Subnet"))),
+            new OA\Response(response: 400, description: "Invalid custom field custom_customer_address_type (field not defined on subnets table)", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse")),
+            new OA\Response(response: 404, description: "No master subnets found", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))
+        ]
+    )]
+    #[OA\Get(
+        path: "/{app_id}/prefix/{customer_type}/address/{address_type}/",
+        tags: ["prefix"],
+        summary: "List candidate master subnets for address allocation, filtered by address family",
+        parameters: [
+            new OA\Parameter(ref: "#/components/parameters/app_id"),
+            new OA\Parameter(name: "customer_type", in: "path", required: true, description: "Value of the address custom field to search subnets for", schema: new OA\Schema(type: "string")),
+            new OA\Parameter(name: "address_type", in: "path", required: true, description: "IP protocol version filter", schema: new OA\Schema(type: "string", enum: ["IPv4", "IPv6", "v4", "v6", "4", "6"]))
+        ],
+        responses: [
+            new OA\Response(response: 200, description: "OK", content: new OA\JsonContent(type: "array", items: new OA\Items(ref: "#/components/schemas/Subnet"))),
+            new OA\Response(response: 400, description: "Invalid custom field custom_customer_address_type, or invalid address type", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse")),
+            new OA\Response(response: 404, description: "No master subnets found", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))
+        ]
+    )]
+    #[OA\Get(
+        path: "/{app_id}/prefix/{customer_type}/{address_type}/address/",
+        tags: ["prefix"],
+        summary: "Find the first available address under any master subnet matching customer_type/address_type",
+        description: "Iterates matching master subnets (leaf subnets only) and returns the first free IP address found. Does not create it.",
+        parameters: [
+            new OA\Parameter(ref: "#/components/parameters/app_id"),
+            new OA\Parameter(name: "customer_type", in: "path", required: true, description: "Value of the address custom field to search subnets for", schema: new OA\Schema(type: "string")),
+            new OA\Parameter(name: "address_type", in: "path", required: true, description: "IP protocol version filter", schema: new OA\Schema(type: "string", enum: ["IPv4", "IPv6", "v4", "v6", "4", "6"]))
+        ],
+        responses: [
+            new OA\Response(response: 200, description: "OK", content: new OA\JsonContent(type: "string", example: "192.168.1.5")),
+            new OA\Response(response: 400, description: "Invalid custom field custom_customer_address_type, or invalid address type", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse")),
+            new OA\Response(response: 404, description: "No address found", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))
+        ]
+    )]
+    #[OA\Get(
+        path: "/{app_id}/prefix/external_id/{external_identifier_field}/",
+        tags: ["prefix"],
+        summary: "Find subnets and/or addresses linked by the configured external identifier field",
+        description: "Searches both subnets and ipaddresses tables for rows whose external identifier column (private property external_identifier_field, default: csid) equals the provided value. Returns whichever of subnets/addresses were found; omits the key entirely for the side with no matches.",
+        parameters: [
+            new OA\Parameter(ref: "#/components/parameters/app_id"),
+            new OA\Parameter(name: "external_identifier_field", in: "path", required: true, description: "Value to match against the csid (external identifier) column, not the field name itself", schema: new OA\Schema(type: "string"))
+        ],
+        responses: [
+            new OA\Response(response: 200, description: "OK", content: new OA\JsonContent(properties: [
+                new OA\Property(property: "subnets", type: "array", items: new OA\Items(ref: "#/components/schemas/Subnet")),
+                new OA\Property(property: "addresses", type: "array", items: new OA\Items(ref: "#/components/schemas/Address"))
+            ])),
+            new OA\Response(response: 404, description: "No objects found", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))
+        ]
+    )]
     #[\Override]
     public function GET () {
         // external identifier
@@ -469,6 +590,59 @@ class Prefix_controller extends Common_api_functions {
      * @access public
      * @return array
      */
+    #[OA\Post(
+        path: "/{app_id}/prefix/{customer_type}/{address_type}/{mask}/",
+        tags: ["prefix"],
+        summary: "Create the first available subnet of the given mask under any master subnet matching customer_type/address_type",
+        description: "Searches master subnets matching {customer_type}/{address_type}, finds the first free subnet with the requested bitmask, and creates it. sectionId, masterSubnetId and permissions are inherited automatically from the matched master subnet and must not be supplied.",
+        parameters: [
+            new OA\Parameter(ref: "#/components/parameters/app_id"),
+            new OA\Parameter(name: "customer_type", in: "path", required: true, description: "Value of the customer_type custom field to search subnets for", schema: new OA\Schema(type: "string")),
+            new OA\Parameter(name: "address_type", in: "path", required: true, description: "IP protocol version filter", schema: new OA\Schema(type: "string", enum: ["IPv4", "IPv6", "v4", "v6", "4", "6"])),
+            new OA\Parameter(name: "mask", in: "path", required: true, description: "Requested subnet bitmask (8-128, IPv4 limited to <=32)", schema: new OA\Schema(type: "string"))
+        ],
+        requestBody: new OA\RequestBody(content: new OA\JsonContent(
+            properties: [
+                new OA\Property(property: "description", type: "string", description: "Defaults to 'Prefix controller autocreated' if not provided"),
+                new OA\Property(property: "vlanId", type: "integer"),
+                new OA\Property(property: "vrfId", type: "integer")
+            ]
+        )),
+        responses: [
+            new OA\Response(response: 201, description: "Subnet created", content: new OA\JsonContent(ref: "#/components/schemas/SuccessResponse")),
+            new OA\Response(response: 400, description: "Invalid custom field, invalid address type, or invalid subnet mask", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse")),
+            new OA\Response(response: 404, description: "No subnets found", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse")),
+            new OA\Response(response: 409, description: "Subnet is not within boundaries of its master subnet, or overlaps an existing subnet", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse")),
+            new OA\Response(response: 500, description: "Failed to create subnet", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))
+        ]
+    )]
+    #[OA\Post(
+        path: "/{app_id}/prefix/{customer_type}/{address_type}/address/",
+        tags: ["prefix"],
+        summary: "Create the first available address under any master subnet matching customer_type/address_type",
+        description: "Searches leaf master subnets (no slave subnets) matching {customer_type}/{address_type}, finds the first free IP address, and creates it. ip_addr and subnetId are derived automatically and must not be supplied.",
+        parameters: [
+            new OA\Parameter(ref: "#/components/parameters/app_id"),
+            new OA\Parameter(name: "customer_type", in: "path", required: true, description: "Value of the address custom field to search subnets for", schema: new OA\Schema(type: "string")),
+            new OA\Parameter(name: "address_type", in: "path", required: true, description: "IP protocol version filter", schema: new OA\Schema(type: "string", enum: ["IPv4", "IPv6", "v4", "v6", "4", "6"]))
+        ],
+        requestBody: new OA\RequestBody(content: new OA\JsonContent(
+            properties: [
+                new OA\Property(property: "hostname", type: "string"),
+                new OA\Property(property: "description", type: "string", description: "Defaults to 'Prefix controller autocreated' if not provided"),
+                new OA\Property(property: "mac", type: "string"),
+                new OA\Property(property: "owner", type: "string"),
+                new OA\Property(property: "state", type: "integer", description: "IP tag id, defaults to 2 (Used)")
+            ]
+        )),
+        responses: [
+            new OA\Response(response: 201, description: "Address created", content: new OA\JsonContent(ref: "#/components/schemas/SuccessResponse")),
+            new OA\Response(response: 400, description: "Invalid custom field, or invalid address type", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse")),
+            new OA\Response(response: 404, description: "No addresses found", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse")),
+            new OA\Response(response: 409, description: "IP address already exists", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse")),
+            new OA\Response(response: 500, description: "Failed to create address", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))
+        ]
+    )]
     #[\Override]
     public function POST () {
         // validate parameters

--- a/public/api/controllers/Search.php
+++ b/public/api/controllers/Search.php
@@ -1,5 +1,7 @@
 <?php
 
+use OpenApi\Attributes as OA;
+
 /**
  *	phpIPAM API search class
  *
@@ -63,6 +65,13 @@ class Search_controller extends Common_api_functions {
 	 * @access public
 	 * @return void
 	 */
+	#[OA\Options(
+	    path: "/{app_id}/search/",
+	    tags: ["search"],
+	    summary: "Discover supported search routes/methods (HATEOAS)",
+	    parameters: [new OA\Parameter(ref: "#/components/parameters/app_id")],
+	    responses: [new OA\Response(response: 200, description: "OK")]
+	)]
 	#[\Override]
     public function OPTIONS () {
 		// validate
@@ -97,6 +106,43 @@ class Search_controller extends Common_api_functions {
 	 * @access public
 	 * @return void
 	 */
+	#[OA\Get(
+	    path: "/{app_id}/search/{search_string}/",
+	    tags: ["search"],
+	    summary: "Search subnets, addresses, VLANs and VRFs for a matching string or IP address",
+	    description: "Runs the search string against every object type that is enabled through the subnets/addresses/vlan/vrf query flags (subnets and addresses are searched by default, vlan and vrf are not). IP-like search strings are reformatted so that a partial address also matches. Each enabled object type gets its own key in the response data; a type with no hits reports its own \"code\":404 entry inline rather than failing the whole request. The effective flags are echoed back under \"search_filter\".",
+	    parameters: [
+	        new OA\Parameter(ref: "#/components/parameters/app_id"),
+	        new OA\Parameter(name: "search_string", in: "path", required: true, description: "Search string or (partial) IP address to search for", schema: new OA\Schema(type: "string")),
+	        new OA\Parameter(name: "subnets", in: "query", required: false, description: "Include subnets in the search (1=on, default; 0=off)", schema: new OA\Schema(type: "integer", enum: [0, 1], default: 1)),
+	        new OA\Parameter(name: "addresses", in: "query", required: false, description: "Include IP addresses in the search (1=on, default; 0=off)", schema: new OA\Schema(type: "integer", enum: [0, 1], default: 1)),
+	        new OA\Parameter(name: "vlan", in: "query", required: false, description: "Include VLANs in the search (1=on; 0=off, default)", schema: new OA\Schema(type: "integer", enum: [0, 1], default: 0)),
+	        new OA\Parameter(name: "vrf", in: "query", required: false, description: "Include VRFs in the search (1=on; 0=off, default)", schema: new OA\Schema(type: "integer", enum: [0, 1], default: 0)),
+	    ],
+	    responses: [
+	        new OA\Response(
+	            response: 200,
+	            description: "OK",
+	            content: new OA\JsonContent(
+	                properties: [
+	                    new OA\Property(property: "code", type: "integer", example: 200),
+	                    new OA\Property(
+	                        property: "data",
+	                        type: "object",
+	                        properties: [
+	                            new OA\Property(property: "subnets", type: "array", items: new OA\Items(ref: "#/components/schemas/Subnet")),
+	                            new OA\Property(property: "addresses", type: "array", items: new OA\Items(ref: "#/components/schemas/Address")),
+	                            new OA\Property(property: "vlan", type: "array", items: new OA\Items(ref: "#/components/schemas/Vlan")),
+	                            new OA\Property(property: "vrf", type: "array", items: new OA\Items(ref: "#/components/schemas/Vrf")),
+	                            new OA\Property(property: "search_filter", type: "object", description: "Effective subnets/addresses/vlan/vrf flags applied to this search", example: ["subnets" => "1", "addresses" => "1", "vlan" => "0", "vrf" => "0"]),
+	                        ]
+	                    ),
+	                ]
+	            )
+	        ),
+	        new OA\Response(response: 400, description: "Search string not provided", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse")),
+	    ]
+	)]
 	#[\Override]
     public function GET () {
 		// start search

--- a/public/api/controllers/Sections.php
+++ b/public/api/controllers/Sections.php
@@ -1,5 +1,7 @@
 <?php
 
+use OpenApi\Attributes as OA;
+
 /**
  *	phpIPAM API class to work with sections
  *
@@ -38,6 +40,13 @@ class Sections_controller extends Common_api_functions {
 	 * @access public
 	 * @return void
 	 */
+	#[OA\Options(
+		path: "/{app_id}/sections/",
+		tags: ["sections"],
+		summary: "Discover supported sections routes/methods (HATEOAS)",
+		parameters: [new OA\Parameter(ref: "#/components/parameters/app_id")],
+		responses: [new OA\Response(response: 200, description: "OK")]
+	)]
 	#[\Override]
     public function OPTIONS () {
 		// validate
@@ -76,6 +85,85 @@ class Sections_controller extends Common_api_functions {
 	 * @access public
 	 * @return void
 	 */
+	#[OA\Get(
+		path: "/{app_id}/sections/",
+		tags: ["sections"],
+		summary: "List all sections",
+		parameters: [new OA\Parameter(ref: "#/components/parameters/app_id")],
+		responses: [new OA\Response(response: 200, description: "OK, or no sections available", content: new OA\JsonContent(type: "array", items: new OA\Items(ref: "#/components/schemas/Section")))]
+	)]
+	#[OA\Get(
+		path: "/{app_id}/sections/{id}/",
+		tags: ["sections"],
+		summary: "Read a single section by numeric id",
+		parameters: [
+			new OA\Parameter(ref: "#/components/parameters/app_id"),
+			new OA\Parameter(name: "id", in: "path", required: true, description: "Section id", schema: new OA\Schema(type: "integer"))
+		],
+		responses: [
+			new OA\Response(response: 200, description: "OK", content: new OA\JsonContent(ref: "#/components/schemas/Section")),
+			new OA\Response(response: 404, description: "Section does not exist", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))
+		]
+	)]
+	#[OA\Get(
+		path: "/{app_id}/sections/{name}/",
+		tags: ["sections"],
+		summary: "Read a single section by name",
+		parameters: [
+			new OA\Parameter(ref: "#/components/parameters/app_id"),
+			new OA\Parameter(name: "name", in: "path", required: true, description: "Section name", schema: new OA\Schema(type: "string"))
+		],
+		responses: [
+			new OA\Response(response: 200, description: "OK", content: new OA\JsonContent(ref: "#/components/schemas/Section")),
+			new OA\Response(response: 404, description: "Section does not exist", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))
+		]
+	)]
+	#[OA\Get(
+		path: "/{app_id}/sections/custom_fields/",
+		tags: ["sections"],
+		summary: "Custom fields on sections (not supported)",
+		parameters: [new OA\Parameter(ref: "#/components/parameters/app_id")],
+		responses: [new OA\Response(response: 409, description: "Custom fields not supported", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))]
+	)]
+	#[OA\Get(
+		path: "/{app_id}/sections/{id}/subnets/",
+		tags: ["sections"],
+		summary: "List all subnets in a section",
+		parameters: [
+			new OA\Parameter(ref: "#/components/parameters/app_id"),
+			new OA\Parameter(name: "id", in: "path", required: true, description: "Section id", schema: new OA\Schema(type: "integer"))
+		],
+		responses: [
+			new OA\Response(response: 200, description: "OK", content: new OA\JsonContent(type: "array", items: new OA\Items(ref: "#/components/schemas/Subnet"))),
+			new OA\Response(response: 404, description: "No subnets found", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))
+		]
+	)]
+	#[OA\Get(
+		path: "/{app_id}/sections/{id}/subnets/addresses/",
+		tags: ["sections"],
+		summary: "List all subnets in a section, including their addresses",
+		parameters: [
+			new OA\Parameter(ref: "#/components/parameters/app_id"),
+			new OA\Parameter(name: "id", in: "path", required: true, description: "Section id", schema: new OA\Schema(type: "integer"))
+		],
+		responses: [
+			new OA\Response(response: 200, description: "OK", content: new OA\JsonContent(type: "array", items: new OA\Items(ref: "#/components/schemas/Subnet"))),
+			new OA\Response(response: 404, description: "No subnets found", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))
+		]
+	)]
+	#[OA\Get(
+		path: "/{app_id}/sections/{id}/changelog/",
+		tags: ["sections"],
+		summary: "Get the change log for a section",
+		parameters: [
+			new OA\Parameter(ref: "#/components/parameters/app_id"),
+			new OA\Parameter(name: "id", in: "path", required: true, description: "Section id", schema: new OA\Schema(type: "integer"))
+		],
+		responses: [
+			new OA\Response(response: 200, description: "OK"),
+			new OA\Response(response: 404, description: "No changelogs found", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))
+		]
+	)]
 	#[\Override]
     public function GET () {
 		// fetch subnets in section
@@ -167,6 +255,34 @@ class Sections_controller extends Common_api_functions {
 	 * @access public
 	 * @return void
 	 */
+	#[OA\Post(
+		path: "/{app_id}/sections/",
+		tags: ["sections"],
+		summary: "Create a new section",
+		parameters: [new OA\Parameter(ref: "#/components/parameters/app_id")],
+		requestBody: new OA\RequestBody(required: true, content: new OA\JsonContent(
+			required: ["name"],
+			properties: [
+				new OA\Property(property: "name", type: "string", description: "Minimum 3 characters", example: "Customers"),
+				new OA\Property(property: "description", type: "string"),
+				new OA\Property(property: "masterSection", type: "integer", description: "Parent section id. Only 1 level of nesting is permitted (parent must itself be a top-level section)", example: 0),
+				new OA\Property(property: "permissions", type: "string", description: "JSON-encoded map of groupId => permission level"),
+				new OA\Property(property: "strictMode", type: "boolean"),
+				new OA\Property(property: "subnetOrdering", type: "string"),
+				new OA\Property(property: "order", type: "integer"),
+				new OA\Property(property: "showSubnet", type: "boolean"),
+				new OA\Property(property: "showVLAN", type: "boolean"),
+				new OA\Property(property: "showVRF", type: "boolean"),
+				new OA\Property(property: "showSupernetOnly", type: "boolean"),
+				new OA\Property(property: "DNS", type: "string")
+			]
+		)),
+		responses: [
+			new OA\Response(response: 201, description: "Section created", content: new OA\JsonContent(ref: "#/components/schemas/SuccessResponse")),
+			new OA\Response(response: 400, description: "Name is mandatory or too short (minimum 3 characters), or invalid masterSection id, or nesting more than 1 level deep", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse")),
+			new OA\Response(response: 500, description: "Section create failed", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))
+		]
+	)]
 	#[\Override]
     public function POST () {
 		# check for valid keys
@@ -205,6 +321,37 @@ class Sections_controller extends Common_api_functions {
 	 * @access public
 	 * @return void
 	 */
+	#[OA\Patch(
+		path: "/{app_id}/sections/{id}/",
+		tags: ["sections"],
+		summary: "Update a section",
+		parameters: [
+			new OA\Parameter(ref: "#/components/parameters/app_id"),
+			new OA\Parameter(name: "id", in: "path", required: true, description: "Section id", schema: new OA\Schema(type: "integer"))
+		],
+		requestBody: new OA\RequestBody(content: new OA\JsonContent(
+			properties: [
+				new OA\Property(property: "name", type: "string", description: "Minimum 3 characters"),
+				new OA\Property(property: "description", type: "string"),
+				new OA\Property(property: "masterSection", type: "integer"),
+				new OA\Property(property: "permissions", type: "string", description: "JSON-encoded map of groupId => permission level"),
+				new OA\Property(property: "strictMode", type: "boolean"),
+				new OA\Property(property: "subnetOrdering", type: "string"),
+				new OA\Property(property: "order", type: "integer"),
+				new OA\Property(property: "showSubnet", type: "boolean"),
+				new OA\Property(property: "showVLAN", type: "boolean"),
+				new OA\Property(property: "showVRF", type: "boolean"),
+				new OA\Property(property: "showSupernetOnly", type: "boolean"),
+				new OA\Property(property: "DNS", type: "string")
+			]
+		)),
+		responses: [
+			new OA\Response(response: 200, description: "Section updated", content: new OA\JsonContent(ref: "#/components/schemas/SuccessResponse")),
+			new OA\Response(response: 400, description: "Section Id required", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse")),
+			new OA\Response(response: 404, description: "Section does not exist", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse")),
+			new OA\Response(response: 500, description: "Section update failed", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))
+		]
+	)]
 	#[\Override]
     public function PATCH () {
 		# Check for id
@@ -235,6 +382,21 @@ class Sections_controller extends Common_api_functions {
 	 * @access public
 	 * @return void
 	 */
+	#[OA\Delete(
+		path: "/{app_id}/sections/{id}/",
+		tags: ["sections"],
+		summary: "Delete a section, along with its subnets and addresses",
+		parameters: [
+			new OA\Parameter(ref: "#/components/parameters/app_id"),
+			new OA\Parameter(name: "id", in: "path", required: true, description: "Section id", schema: new OA\Schema(type: "integer"))
+		],
+		responses: [
+			new OA\Response(response: 200, description: "Section deleted", content: new OA\JsonContent(ref: "#/components/schemas/SuccessResponse")),
+			new OA\Response(response: 400, description: "Section Id required", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse")),
+			new OA\Response(response: 404, description: "Section does not exist", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse")),
+			new OA\Response(response: 500, description: "Section delete failed", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))
+		]
+	)]
 	#[\Override]
     public function DELETE () {
 		# Check for id

--- a/public/api/controllers/Subnets.php
+++ b/public/api/controllers/Subnets.php
@@ -1,5 +1,7 @@
 <?php
 
+use OpenApi\Attributes as OA;
+
 /**
  *	phpIPAM API class to work with subnets
  *
@@ -48,6 +50,13 @@ class Subnets_controller extends Common_api_functions {
 	 * @access public
 	 * @return array
 	 */
+	#[OA\Options(
+		path: "/{app_id}/subnets/",
+		tags: ["subnets"],
+		summary: "Discover supported subnets routes/methods (HATEOAS)",
+		parameters: [new OA\Parameter(ref: "#/components/parameters/app_id")],
+		responses: [new OA\Response(response: 200, description: "OK")]
+	)]
 	#[\Override]
     public function OPTIONS () {
 		// validate
@@ -81,6 +90,60 @@ class Subnets_controller extends Common_api_functions {
 	 * @access public
 	 * @return array
 	 */
+	#[OA\Post(
+		path: "/{app_id}/subnets/",
+		tags: ["subnets"],
+		summary: "Create a new subnet (or folder)",
+		description: "Set isFolder=1 to create a folder instead of a real subnet (subnet/mask are then ignored).",
+		parameters: [new OA\Parameter(ref: "#/components/parameters/app_id")],
+		requestBody: new OA\RequestBody(required: true, content: new OA\JsonContent(
+			required: ["sectionId"],
+			properties: [
+				new OA\Property(property: "subnet", type: "string", description: "Required unless isFolder=1", example: "192.168.1.0"),
+				new OA\Property(property: "mask", type: "string", description: "Required unless isFolder=1", example: "24"),
+				new OA\Property(property: "sectionId", type: "integer", example: 1),
+				new OA\Property(property: "description", type: "string"),
+				new OA\Property(property: "masterSubnetId", type: "integer", example: 0),
+				new OA\Property(property: "vlanId", type: "integer"),
+				new OA\Property(property: "vrfId", type: "integer"),
+				new OA\Property(property: "isFolder", type: "boolean", example: false),
+				new OA\Property(property: "permissions", type: "string"),
+			]
+		)),
+		responses: [
+			new OA\Response(response: 201, description: "Subnet created", content: new OA\JsonContent(ref: "#/components/schemas/SuccessResponse")),
+			new OA\Response(response: 400, description: "Invalid parameters", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse")),
+			new OA\Response(response: 409, description: "Overlapping/out of boundaries", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse")),
+		]
+	)]
+	#[OA\Post(
+		path: "/{app_id}/subnets/{id}/first_subnet/{mask}/",
+		tags: ["subnets"],
+		summary: "Create the first free subnet with the given mask under master subnet {id}",
+		parameters: [
+			new OA\Parameter(ref: "#/components/parameters/app_id"),
+			new OA\Parameter(name: "id", in: "path", required: true, description: "Master subnet id", schema: new OA\Schema(type: "integer")),
+			new OA\Parameter(name: "mask", in: "path", required: true, schema: new OA\Schema(type: "string")),
+		],
+		responses: [
+			new OA\Response(response: 201, description: "Subnet created", content: new OA\JsonContent(ref: "#/components/schemas/SuccessResponse")),
+			new OA\Response(response: 404, description: "No free subnet found", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse")),
+		]
+	)]
+	#[OA\Post(
+		path: "/{app_id}/subnets/{id}/last_subnet/{mask}/",
+		tags: ["subnets"],
+		summary: "Create the last free subnet with the given mask under master subnet {id}",
+		parameters: [
+			new OA\Parameter(ref: "#/components/parameters/app_id"),
+			new OA\Parameter(name: "id", in: "path", required: true, description: "Master subnet id", schema: new OA\Schema(type: "integer")),
+			new OA\Parameter(name: "mask", in: "path", required: true, schema: new OA\Schema(type: "string")),
+		],
+		responses: [
+			new OA\Response(response: 201, description: "Subnet created", content: new OA\JsonContent(ref: "#/components/schemas/SuccessResponse")),
+			new OA\Response(response: 404, description: "No free subnet found", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse")),
+		]
+	)]
 	#[\Override]
     public function POST () {
 		# add required parameters
@@ -162,6 +225,184 @@ class Subnets_controller extends Common_api_functions {
 	 * @access public
 	 * @return array
 	 */
+	#[OA\Get(
+		path: "/{app_id}/subnets/",
+		tags: ["subnets"],
+		summary: "List all subnets (all sections)",
+		parameters: [new OA\Parameter(ref: "#/components/parameters/app_id")],
+		responses: [
+			new OA\Response(response: 200, description: "OK", content: new OA\JsonContent(type: "array", items: new OA\Items(ref: "#/components/schemas/Subnet"))),
+			new OA\Response(response: 500, description: "Unable to read subnets", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse")),
+		]
+	)]
+	#[OA\Get(
+		path: "/{app_id}/subnets/{id}/",
+		tags: ["subnets"],
+		summary: "Read a single subnet by id",
+		parameters: [
+			new OA\Parameter(ref: "#/components/parameters/app_id"),
+			new OA\Parameter(name: "id", in: "path", required: true, schema: new OA\Schema(type: "integer")),
+		],
+		responses: [
+			new OA\Response(response: 200, description: "OK", content: new OA\JsonContent(ref: "#/components/schemas/Subnet")),
+			new OA\Response(response: 400, description: "Invalid subnet id", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse")),
+		]
+	)]
+	#[OA\Get(
+		path: "/{app_id}/subnets/custom_fields/",
+		tags: ["subnets"],
+		summary: "List custom fields defined on the subnets table",
+		parameters: [new OA\Parameter(ref: "#/components/parameters/app_id")],
+		responses: [
+			new OA\Response(response: 200, description: "OK"),
+			new OA\Response(response: 404, description: "No custom fields defined", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse")),
+		]
+	)]
+	#[OA\Get(
+		path: "/{app_id}/subnets/cidr/{subnet}/",
+		tags: ["subnets"],
+		summary: "Search subnets by CIDR network address (alias: /subnets/search/{subnet}/)",
+		parameters: [
+			new OA\Parameter(ref: "#/components/parameters/app_id"),
+			new OA\Parameter(name: "subnet", in: "path", required: true, description: "Network address (dotted/colon notation)", schema: new OA\Schema(type: "string")),
+		],
+		responses: [
+			new OA\Response(response: 200, description: "OK", content: new OA\JsonContent(type: "array", items: new OA\Items(ref: "#/components/schemas/Subnet"))),
+			new OA\Response(response: 404, description: "No subnets found", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse")),
+		]
+	)]
+	#[OA\Get(
+		path: "/{app_id}/subnets/overlapping/{subnet}/{mask}/",
+		tags: ["subnets"],
+		summary: "Search subnets overlapping a given network/mask (IPv4 & IPv6)",
+		parameters: [
+			new OA\Parameter(ref: "#/components/parameters/app_id"),
+			new OA\Parameter(name: "subnet", in: "path", required: true, schema: new OA\Schema(type: "string")),
+			new OA\Parameter(name: "mask", in: "path", required: true, schema: new OA\Schema(type: "string")),
+		],
+		responses: [
+			new OA\Response(response: 200, description: "OK", content: new OA\JsonContent(type: "array", items: new OA\Items(ref: "#/components/schemas/Subnet"))),
+			new OA\Response(response: 404, description: "No subnets found", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse")),
+		]
+	)]
+	#[OA\Get(
+		path: "/{app_id}/subnets/{id}/addresses/",
+		tags: ["subnets"],
+		summary: "List all addresses in a subnet (optionally filtered to a single {ip} via id3)",
+		parameters: [
+			new OA\Parameter(ref: "#/components/parameters/app_id"),
+			new OA\Parameter(name: "id", in: "path", required: true, schema: new OA\Schema(type: "integer")),
+		],
+		responses: [
+			new OA\Response(response: 200, description: "OK", content: new OA\JsonContent(type: "array", items: new OA\Items(ref: "#/components/schemas/Address"))),
+			new OA\Response(response: 404, description: "No addresses found", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse")),
+		]
+	)]
+	#[OA\Get(
+		path: "/{app_id}/subnets/{id}/slaves/",
+		tags: ["subnets"],
+		summary: "List immediate slave subnets",
+		parameters: [
+			new OA\Parameter(ref: "#/components/parameters/app_id"),
+			new OA\Parameter(name: "id", in: "path", required: true, schema: new OA\Schema(type: "integer")),
+		],
+		responses: [
+			new OA\Response(response: 200, description: "OK", content: new OA\JsonContent(type: "array", items: new OA\Items(ref: "#/components/schemas/Subnet"))),
+			new OA\Response(response: 404, description: "No slaves", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse")),
+		]
+	)]
+	#[OA\Get(
+		path: "/{app_id}/subnets/{id}/slaves_recursive/",
+		tags: ["subnets"],
+		summary: "List all slave subnets recursively",
+		parameters: [
+			new OA\Parameter(ref: "#/components/parameters/app_id"),
+			new OA\Parameter(name: "id", in: "path", required: true, schema: new OA\Schema(type: "integer")),
+		],
+		responses: [
+			new OA\Response(response: 200, description: "OK", content: new OA\JsonContent(type: "array", items: new OA\Items(ref: "#/components/schemas/Subnet"))),
+			new OA\Response(response: 404, description: "No slaves", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse")),
+		]
+	)]
+	#[OA\Get(
+		path: "/{app_id}/subnets/{id}/usage/",
+		tags: ["subnets"],
+		summary: "Get subnet usage statistics (free/used/offline counts, percentage)",
+		parameters: [
+			new OA\Parameter(ref: "#/components/parameters/app_id"),
+			new OA\Parameter(name: "id", in: "path", required: true, schema: new OA\Schema(type: "integer")),
+		],
+		responses: [new OA\Response(response: 200, description: "OK")]
+	)]
+	#[OA\Get(
+		path: "/{app_id}/subnets/{id}/first_free/",
+		tags: ["subnets"],
+		summary: "Get the first free address in a subnet",
+		parameters: [
+			new OA\Parameter(ref: "#/components/parameters/app_id"),
+			new OA\Parameter(name: "id", in: "path", required: true, schema: new OA\Schema(type: "integer")),
+		],
+		responses: [
+			new OA\Response(response: 200, description: "OK", content: new OA\JsonContent(type: "string", example: "192.168.1.5")),
+			new OA\Response(response: 404, description: "No free addresses found", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse")),
+			new OA\Response(response: 409, description: "Subnet contains subnets", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse")),
+		]
+	)]
+	#[OA\Get(
+		path: "/{app_id}/subnets/{id}/all_subnets/{mask}/",
+		tags: ["subnets"],
+		summary: "List all free subnets of the given mask under master subnet {id}",
+		parameters: [
+			new OA\Parameter(ref: "#/components/parameters/app_id"),
+			new OA\Parameter(name: "id", in: "path", required: true, description: "Master subnet id", schema: new OA\Schema(type: "integer")),
+			new OA\Parameter(name: "mask", in: "path", required: true, schema: new OA\Schema(type: "string")),
+		],
+		responses: [
+			new OA\Response(response: 200, description: "OK", content: new OA\JsonContent(type: "array", items: new OA\Items(type: "string"))),
+			new OA\Response(response: 404, description: "No subnets found", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse")),
+		]
+	)]
+	#[OA\Get(
+		path: "/{app_id}/subnets/{id}/first_subnet/{mask}/",
+		tags: ["subnets"],
+		summary: "Get the first free subnet of the given mask under master subnet {id} (read-only, does not create it)",
+		parameters: [
+			new OA\Parameter(ref: "#/components/parameters/app_id"),
+			new OA\Parameter(name: "id", in: "path", required: true, description: "Master subnet id", schema: new OA\Schema(type: "integer")),
+			new OA\Parameter(name: "mask", in: "path", required: true, schema: new OA\Schema(type: "string")),
+		],
+		responses: [
+			new OA\Response(response: 200, description: "OK", content: new OA\JsonContent(type: "string")),
+			new OA\Response(response: 404, description: "No subnets found", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse")),
+		]
+	)]
+	#[OA\Get(
+		path: "/{app_id}/subnets/{id}/last_subnet/{mask}/",
+		tags: ["subnets"],
+		summary: "Get the last free subnet of the given mask under master subnet {id} (read-only, does not create it)",
+		parameters: [
+			new OA\Parameter(ref: "#/components/parameters/app_id"),
+			new OA\Parameter(name: "id", in: "path", required: true, description: "Master subnet id", schema: new OA\Schema(type: "integer")),
+			new OA\Parameter(name: "mask", in: "path", required: true, schema: new OA\Schema(type: "string")),
+		],
+		responses: [
+			new OA\Response(response: 200, description: "OK", content: new OA\JsonContent(type: "string")),
+			new OA\Response(response: 404, description: "No subnets found", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse")),
+		]
+	)]
+	#[OA\Get(
+		path: "/{app_id}/subnets/{id}/changelog/",
+		tags: ["subnets"],
+		summary: "Get the change log for a subnet",
+		parameters: [
+			new OA\Parameter(ref: "#/components/parameters/app_id"),
+			new OA\Parameter(name: "id", in: "path", required: true, schema: new OA\Schema(type: "integer")),
+		],
+		responses: [
+			new OA\Response(response: 200, description: "OK"),
+			new OA\Response(response: 404, description: "No changelogs found", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse")),
+		]
+	)]
 	#[\Override]
     public function GET () {
 		// all
@@ -277,6 +518,81 @@ class Subnets_controller extends Common_api_functions {
 	 * @access public
 	 * @return array
 	 */
+	#[OA\Patch(
+		path: "/{app_id}/subnets/{id}/",
+		tags: ["subnets"],
+		summary: "Update a subnet (subnet/mask cannot be changed here, use resize)",
+		parameters: [
+			new OA\Parameter(ref: "#/components/parameters/app_id"),
+			new OA\Parameter(name: "id", in: "path", required: true, schema: new OA\Schema(type: "integer")),
+		],
+		requestBody: new OA\RequestBody(content: new OA\JsonContent(
+			properties: [
+				new OA\Property(property: "description", type: "string"),
+				new OA\Property(property: "sectionId", type: "integer"),
+				new OA\Property(property: "vlanId", type: "integer"),
+				new OA\Property(property: "vrfId", type: "integer"),
+			]
+		)),
+		responses: [
+			new OA\Response(response: 200, description: "Subnet updated", content: new OA\JsonContent(ref: "#/components/schemas/SuccessResponse")),
+			new OA\Response(response: 400, description: "Subnet/mask cannot be changed", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse")),
+		]
+	)]
+	#[OA\Patch(
+		path: "/{app_id}/subnets/{id}/resize/",
+		tags: ["subnets"],
+		summary: "Resize a subnet to a new mask",
+		parameters: [
+			new OA\Parameter(ref: "#/components/parameters/app_id"),
+			new OA\Parameter(name: "id", in: "path", required: true, schema: new OA\Schema(type: "integer")),
+		],
+		requestBody: new OA\RequestBody(required: true, content: new OA\JsonContent(required: ["mask"], properties: [
+			new OA\Property(property: "mask", type: "string", example: "25"),
+		])),
+		responses: [
+			new OA\Response(response: 200, description: "Subnet resized", content: new OA\JsonContent(ref: "#/components/schemas/SuccessResponse")),
+			new OA\Response(response: 400, description: "Subnet mask not provided", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse")),
+			new OA\Response(response: 409, description: "Resize would break nesting/overlap rules", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse")),
+		]
+	)]
+	#[OA\Patch(
+		path: "/{app_id}/subnets/{id}/split/",
+		tags: ["subnets"],
+		summary: "Split a subnet into multiple smaller subnets, moving existing addresses",
+		parameters: [
+			new OA\Parameter(ref: "#/components/parameters/app_id"),
+			new OA\Parameter(name: "id", in: "path", required: true, schema: new OA\Schema(type: "integer")),
+		],
+		requestBody: new OA\RequestBody(required: true, content: new OA\JsonContent(
+			required: ["number"],
+			properties: [
+				new OA\Property(property: "number", type: "integer", description: "Number of new subnets to split into", example: 4),
+				new OA\Property(property: "group", type: "string", enum: ["yes", "no"], default: "yes"),
+				new OA\Property(property: "prefix", type: "string", description: "Optional name prefix for created subnets"),
+				new OA\Property(property: "copy_custom", type: "string", enum: ["yes", "no"], default: "yes"),
+			]
+		)),
+		responses: [
+			new OA\Response(response: 200, description: "Subnet split", content: new OA\JsonContent(ref: "#/components/schemas/SuccessResponse")),
+			new OA\Response(response: 400, description: "Invalid number of new subnets", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse")),
+		]
+	)]
+	#[OA\Patch(
+		path: "/{app_id}/subnets/{id}/permissions/",
+		tags: ["subnets"],
+		summary: "Change subnet permissions (map of groupId/groupName to permission level)",
+		description: "0=no access, 1=read-only, 2=read-write, 3=read-write-add. Body keys are group ids or names, values are permission levels or names.",
+		parameters: [
+			new OA\Parameter(ref: "#/components/parameters/app_id"),
+			new OA\Parameter(name: "id", in: "path", required: true, schema: new OA\Schema(type: "integer")),
+		],
+		requestBody: new OA\RequestBody(required: true, content: new OA\JsonContent(type: "object", additionalProperties: true, example: ["3" => "2", "2" => "1"])),
+		responses: [
+			new OA\Response(response: 200, description: "Subnet permissions updated", content: new OA\JsonContent(ref: "#/components/schemas/SuccessResponse")),
+			new OA\Response(response: 500, description: "Invalid group/permission", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse")),
+		]
+	)]
 	#[\Override]
     public function PATCH () {
 		// Check for id
@@ -336,6 +652,39 @@ class Subnets_controller extends Common_api_functions {
 	 * @access public
 	 * @return array
 	 */
+	#[OA\Delete(
+		path: "/{app_id}/subnets/{id}/",
+		tags: ["subnets"],
+		summary: "Delete a subnet, along with its addresses",
+		parameters: [
+			new OA\Parameter(ref: "#/components/parameters/app_id"),
+			new OA\Parameter(name: "id", in: "path", required: true, schema: new OA\Schema(type: "integer")),
+		],
+		responses: [
+			new OA\Response(response: 200, description: "Subnet deleted", content: new OA\JsonContent(ref: "#/components/schemas/SuccessResponse")),
+			new OA\Response(response: 500, description: "Failed to delete subnet", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse")),
+		]
+	)]
+	#[OA\Delete(
+		path: "/{app_id}/subnets/{id}/truncate/",
+		tags: ["subnets"],
+		summary: "Delete all addresses in a subnet, keeping the subnet itself",
+		parameters: [
+			new OA\Parameter(ref: "#/components/parameters/app_id"),
+			new OA\Parameter(name: "id", in: "path", required: true, schema: new OA\Schema(type: "integer")),
+		],
+		responses: [new OA\Response(response: 200, description: "Subnet truncated", content: new OA\JsonContent(ref: "#/components/schemas/SuccessResponse"))]
+	)]
+	#[OA\Delete(
+		path: "/{app_id}/subnets/{id}/permissions/",
+		tags: ["subnets"],
+		summary: "Remove all custom permissions from a subnet",
+		parameters: [
+			new OA\Parameter(ref: "#/components/parameters/app_id"),
+			new OA\Parameter(name: "id", in: "path", required: true, schema: new OA\Schema(type: "integer")),
+		],
+		responses: [new OA\Response(response: 200, description: "Subnet permissions removed", content: new OA\JsonContent(ref: "#/components/schemas/SuccessResponse"))]
+	)]
 	#[\Override]
     public function DELETE () {
 		// Check for id

--- a/public/api/controllers/Tools.php
+++ b/public/api/controllers/Tools.php
@@ -1,5 +1,7 @@
 <?php
 
+use OpenApi\Attributes as OA;
+
 /**
  *	phpIPAM API class to work with tools
  *
@@ -140,6 +142,23 @@ class Tools_controller extends Common_api_functions {
 	 * @access public
 	 * @return void
 	 */
+	#[OA\Options(
+	    path: "/{app_id}/tools/",
+	    tags: ["tools"],
+	    summary: "Discover supported tools routes/methods (HATEOAS)",
+	    parameters: [new OA\Parameter(ref: "#/components/parameters/app_id")],
+	    responses: [new OA\Response(response: 200, description: "OK")]
+	)]
+	#[OA\Options(
+	    path: "/{app_id}/tools/{subcontroller}/",
+	    tags: ["tools"],
+	    summary: "Discover supported routes/methods for a tools subcontroller (HATEOAS)",
+	    parameters: [
+	        new OA\Parameter(ref: "#/components/parameters/app_id"),
+	        new OA\Parameter(name: "subcontroller", in: "path", required: true, description: "One of: ipTags, devices, deviceTypes, vlans, vrf, nameservers, scanAgents, locations, racks, nat, customers", schema: new OA\Schema(type: "string"))
+	    ],
+	    responses: [new OA\Response(response: 200, description: "OK")]
+	)]
 	#[\Override]
     public function OPTIONS () {
 		// validate
@@ -204,6 +223,623 @@ class Tools_controller extends Common_api_functions {
 	 * @access public
 	 * @return void
 	 */
+	#[OA\Get(
+	    path: "/{app_id}/tools/tags/",
+	    tags: ["tools"],
+	    summary: "List all IP tags",
+	    parameters: [new OA\Parameter(ref: "#/components/parameters/app_id")],
+	    responses: [
+	        new OA\Response(response: 200, description: "OK", content: new OA\JsonContent(type: "array", items: new OA\Items(
+	            type: "object",
+	            properties: [
+	                new OA\Property(property: "id", type: "integer", example: 1),
+	                new OA\Property(property: "type", type: "string", example: "Offline"),
+	                new OA\Property(property: "showtag", type: "boolean"),
+	                new OA\Property(property: "bgcolor", type: "string", example: "#f59c99"),
+	                new OA\Property(property: "fgcolor", type: "string", example: "#ffffff"),
+	                new OA\Property(property: "compress", type: "string", enum: ["No","Yes"]),
+	                new OA\Property(property: "locked", type: "string", enum: ["No","Yes"]),
+	                new OA\Property(property: "updateTag", type: "boolean")
+	            ]
+	        ))),
+	        new OA\Response(response: 404, description: "No objects found", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))
+	    ]
+	)]
+	#[OA\Get(
+	    path: "/{app_id}/tools/tags/{id}/",
+	    tags: ["tools"],
+	    summary: "Read a single IP tag by id",
+	    parameters: [
+	        new OA\Parameter(ref: "#/components/parameters/app_id"),
+	        new OA\Parameter(name: "id", in: "path", required: true, schema: new OA\Schema(type: "integer"))
+	    ],
+	    responses: [
+	        new OA\Response(response: 200, description: "OK", content: new OA\JsonContent(
+	            type: "object",
+	            properties: [
+	                new OA\Property(property: "id", type: "integer"),
+	                new OA\Property(property: "type", type: "string"),
+	                new OA\Property(property: "showtag", type: "boolean"),
+	                new OA\Property(property: "bgcolor", type: "string"),
+	                new OA\Property(property: "fgcolor", type: "string"),
+	                new OA\Property(property: "compress", type: "string", enum: ["No","Yes"]),
+	                new OA\Property(property: "locked", type: "string", enum: ["No","Yes"]),
+	                new OA\Property(property: "updateTag", type: "boolean")
+	            ]
+	        )),
+	        new OA\Response(response: 400, description: "Identifier must be numeric", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse")),
+	        new OA\Response(response: 404, description: "No objects found", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))
+	    ]
+	)]
+	#[OA\Get(
+	    path: "/{app_id}/tools/tags/{id}/addresses/",
+	    tags: ["tools"],
+	    summary: "List addresses currently marked with this IP tag",
+	    description: "Matches ipaddresses.state == {id}.",
+	    parameters: [
+	        new OA\Parameter(ref: "#/components/parameters/app_id"),
+	        new OA\Parameter(name: "id", in: "path", required: true, schema: new OA\Schema(type: "integer"))
+	    ],
+	    responses: [
+	        new OA\Response(response: 200, description: "OK", content: new OA\JsonContent(type: "array", items: new OA\Items(ref: "#/components/schemas/Address"))),
+	        new OA\Response(response: 404, description: "No objects found", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))
+	    ]
+	)]
+	#[OA\Get(
+	    path: "/{app_id}/tools/devices/",
+	    tags: ["tools"],
+	    summary: "List all devices",
+	    parameters: [new OA\Parameter(ref: "#/components/parameters/app_id")],
+	    responses: [
+	        new OA\Response(response: 200, description: "OK", content: new OA\JsonContent(type: "array", items: new OA\Items(ref: "#/components/schemas/Device"))),
+	        new OA\Response(response: 404, description: "No objects found", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))
+	    ]
+	)]
+	#[OA\Get(
+	    path: "/{app_id}/tools/devices/{id}/",
+	    tags: ["tools"],
+	    summary: "Read a single device by id",
+	    parameters: [
+	        new OA\Parameter(ref: "#/components/parameters/app_id"),
+	        new OA\Parameter(name: "id", in: "path", required: true, schema: new OA\Schema(type: "integer"))
+	    ],
+	    responses: [
+	        new OA\Response(response: 200, description: "OK", content: new OA\JsonContent(ref: "#/components/schemas/Device")),
+	        new OA\Response(response: 400, description: "Identifier must be numeric", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse")),
+	        new OA\Response(response: 404, description: "No objects found", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))
+	    ]
+	)]
+	#[OA\Get(
+	    path: "/{app_id}/tools/devices/{id}/addresses/",
+	    tags: ["tools"],
+	    summary: "List addresses whose switch is this device",
+	    description: "Matches ipaddresses.switch == {id}.",
+	    parameters: [
+	        new OA\Parameter(ref: "#/components/parameters/app_id"),
+	        new OA\Parameter(name: "id", in: "path", required: true, schema: new OA\Schema(type: "integer"))
+	    ],
+	    responses: [
+	        new OA\Response(response: 200, description: "OK", content: new OA\JsonContent(type: "array", items: new OA\Items(ref: "#/components/schemas/Address"))),
+	        new OA\Response(response: 404, description: "No objects found", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))
+	    ]
+	)]
+	#[OA\Get(
+	    path: "/{app_id}/tools/device_types/",
+	    tags: ["tools"],
+	    summary: "List all device types",
+	    parameters: [new OA\Parameter(ref: "#/components/parameters/app_id")],
+	    responses: [
+	        new OA\Response(response: 200, description: "OK", content: new OA\JsonContent(type: "array", items: new OA\Items(
+	            type: "object",
+	            properties: [
+	                new OA\Property(property: "tid", type: "integer", example: 1),
+	                new OA\Property(property: "tname", type: "string", example: "Switch"),
+	                new OA\Property(property: "tdescription", type: "string", nullable: true),
+	                new OA\Property(property: "bgcolor", type: "string", example: "#E6E6E6"),
+	                new OA\Property(property: "fgcolor", type: "string", example: "#000")
+	            ]
+	        ))),
+	        new OA\Response(response: 404, description: "No objects found", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))
+	    ]
+	)]
+	#[OA\Get(
+	    path: "/{app_id}/tools/device_types/{id}/",
+	    tags: ["tools"],
+	    summary: "Read a single device type by id",
+	    description: "{id} maps to the deviceTypes.tid field.",
+	    parameters: [
+	        new OA\Parameter(ref: "#/components/parameters/app_id"),
+	        new OA\Parameter(name: "id", in: "path", required: true, schema: new OA\Schema(type: "integer"))
+	    ],
+	    responses: [
+	        new OA\Response(response: 200, description: "OK", content: new OA\JsonContent(
+	            type: "object",
+	            properties: [
+	                new OA\Property(property: "tid", type: "integer"),
+	                new OA\Property(property: "tname", type: "string"),
+	                new OA\Property(property: "tdescription", type: "string", nullable: true),
+	                new OA\Property(property: "bgcolor", type: "string"),
+	                new OA\Property(property: "fgcolor", type: "string")
+	            ]
+	        )),
+	        new OA\Response(response: 400, description: "Identifier must be numeric", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse")),
+	        new OA\Response(response: 404, description: "No objects found", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))
+	    ]
+	)]
+	#[OA\Get(
+	    path: "/{app_id}/tools/device_types/{id}/devices/",
+	    tags: ["tools"],
+	    summary: "List devices of this device type",
+	    parameters: [
+	        new OA\Parameter(ref: "#/components/parameters/app_id"),
+	        new OA\Parameter(name: "id", in: "path", required: true, description: "Device type id (tid)", schema: new OA\Schema(type: "integer"))
+	    ],
+	    responses: [
+	        new OA\Response(response: 200, description: "OK", content: new OA\JsonContent(type: "array", items: new OA\Items(ref: "#/components/schemas/Device"))),
+	        new OA\Response(response: 404, description: "No objects found", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))
+	    ]
+	)]
+	#[OA\Get(
+	    path: "/{app_id}/tools/vlans/",
+	    tags: ["tools"],
+	    summary: "List all VLANs (read-only alias; manage VLANs via the /vlans controller)",
+	    parameters: [new OA\Parameter(ref: "#/components/parameters/app_id")],
+	    responses: [
+	        new OA\Response(response: 200, description: "OK", content: new OA\JsonContent(type: "array", items: new OA\Items(ref: "#/components/schemas/Vlan"))),
+	        new OA\Response(response: 404, description: "No objects found", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))
+	    ]
+	)]
+	#[OA\Get(
+	    path: "/{app_id}/tools/vlans/{id}/",
+	    tags: ["tools"],
+	    summary: "Read a single VLAN by id",
+	    description: "{id} maps to the vlans.vlanId field.",
+	    parameters: [
+	        new OA\Parameter(ref: "#/components/parameters/app_id"),
+	        new OA\Parameter(name: "id", in: "path", required: true, schema: new OA\Schema(type: "integer"))
+	    ],
+	    responses: [
+	        new OA\Response(response: 200, description: "OK", content: new OA\JsonContent(ref: "#/components/schemas/Vlan")),
+	        new OA\Response(response: 400, description: "Identifier must be numeric", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse")),
+	        new OA\Response(response: 404, description: "No objects found", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))
+	    ]
+	)]
+	#[OA\Get(
+	    path: "/{app_id}/tools/vlans/{id}/subnets/",
+	    tags: ["tools"],
+	    summary: "List subnets that belong to this VLAN",
+	    parameters: [
+	        new OA\Parameter(ref: "#/components/parameters/app_id"),
+	        new OA\Parameter(name: "id", in: "path", required: true, description: "VLAN id (vlanId)", schema: new OA\Schema(type: "integer"))
+	    ],
+	    responses: [
+	        new OA\Response(response: 200, description: "OK", content: new OA\JsonContent(type: "array", items: new OA\Items(ref: "#/components/schemas/Subnet"))),
+	        new OA\Response(response: 404, description: "No objects found", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))
+	    ]
+	)]
+	#[OA\Get(
+	    path: "/{app_id}/tools/vrfs/",
+	    tags: ["tools"],
+	    summary: "List all VRFs (read-only alias; manage VRFs via the /vrf controller)",
+	    parameters: [new OA\Parameter(ref: "#/components/parameters/app_id")],
+	    responses: [
+	        new OA\Response(response: 200, description: "OK", content: new OA\JsonContent(type: "array", items: new OA\Items(ref: "#/components/schemas/Vrf"))),
+	        new OA\Response(response: 404, description: "No objects found", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))
+	    ]
+	)]
+	#[OA\Get(
+	    path: "/{app_id}/tools/vrfs/{id}/",
+	    tags: ["tools"],
+	    summary: "Read a single VRF by id",
+	    description: "{id} maps to the vrf.vrfId field.",
+	    parameters: [
+	        new OA\Parameter(ref: "#/components/parameters/app_id"),
+	        new OA\Parameter(name: "id", in: "path", required: true, schema: new OA\Schema(type: "integer"))
+	    ],
+	    responses: [
+	        new OA\Response(response: 200, description: "OK", content: new OA\JsonContent(ref: "#/components/schemas/Vrf")),
+	        new OA\Response(response: 400, description: "Identifier must be numeric", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse")),
+	        new OA\Response(response: 404, description: "No objects found", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))
+	    ]
+	)]
+	#[OA\Get(
+	    path: "/{app_id}/tools/vrfs/{id}/subnets/",
+	    tags: ["tools"],
+	    summary: "List subnets that belong to this VRF",
+	    parameters: [
+	        new OA\Parameter(ref: "#/components/parameters/app_id"),
+	        new OA\Parameter(name: "id", in: "path", required: true, description: "VRF id (vrfId)", schema: new OA\Schema(type: "integer"))
+	    ],
+	    responses: [
+	        new OA\Response(response: 200, description: "OK", content: new OA\JsonContent(type: "array", items: new OA\Items(ref: "#/components/schemas/Subnet"))),
+	        new OA\Response(response: 404, description: "No objects found", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))
+	    ]
+	)]
+	#[OA\Get(
+	    path: "/{app_id}/tools/nameservers/",
+	    tags: ["tools"],
+	    summary: "List all nameserver sets",
+	    parameters: [new OA\Parameter(ref: "#/components/parameters/app_id")],
+	    responses: [
+	        new OA\Response(response: 200, description: "OK", content: new OA\JsonContent(type: "array", items: new OA\Items(
+	            type: "object",
+	            properties: [
+	                new OA\Property(property: "id", type: "integer", example: 1),
+	                new OA\Property(property: "name", type: "string", example: "Google NS"),
+	                new OA\Property(property: "namesrv1", type: "string", description: "Semicolon separated list of nameserver IPs", example: "8.8.8.8;8.8.4.4"),
+	                new OA\Property(property: "description", type: "string", nullable: true),
+	                new OA\Property(property: "permissions", type: "string", nullable: true, description: "JSON-encoded map of groupId => permission level")
+	            ]
+	        ))),
+	        new OA\Response(response: 404, description: "No objects found", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))
+	    ]
+	)]
+	#[OA\Get(
+	    path: "/{app_id}/tools/nameservers/{id}/",
+	    tags: ["tools"],
+	    summary: "Read a single nameserver set by id",
+	    parameters: [
+	        new OA\Parameter(ref: "#/components/parameters/app_id"),
+	        new OA\Parameter(name: "id", in: "path", required: true, schema: new OA\Schema(type: "integer"))
+	    ],
+	    responses: [
+	        new OA\Response(response: 200, description: "OK", content: new OA\JsonContent(
+	            type: "object",
+	            properties: [
+	                new OA\Property(property: "id", type: "integer"),
+	                new OA\Property(property: "name", type: "string"),
+	                new OA\Property(property: "namesrv1", type: "string"),
+	                new OA\Property(property: "description", type: "string", nullable: true),
+	                new OA\Property(property: "permissions", type: "string", nullable: true)
+	            ]
+	        )),
+	        new OA\Response(response: 400, description: "Identifier must be numeric", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse")),
+	        new OA\Response(response: 404, description: "No objects found", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))
+	    ]
+	)]
+	#[OA\Get(
+	    path: "/{app_id}/tools/scanagents/",
+	    tags: ["tools"],
+	    summary: "List all scan agents",
+	    parameters: [new OA\Parameter(ref: "#/components/parameters/app_id")],
+	    responses: [
+	        new OA\Response(response: 200, description: "OK", content: new OA\JsonContent(type: "array", items: new OA\Items(
+	            type: "object",
+	            properties: [
+	                new OA\Property(property: "id", type: "integer", example: 1),
+	                new OA\Property(property: "name", type: "string", example: "localhost"),
+	                new OA\Property(property: "description", type: "string", nullable: true),
+	                new OA\Property(property: "type", type: "string", enum: ["direct","api","mysql"]),
+	                new OA\Property(property: "code", type: "string", nullable: true, description: "Unique agent code used by the scanning script"),
+	                new OA\Property(property: "last_access", type: "string", format: "date-time", nullable: true)
+	            ]
+	        ))),
+	        new OA\Response(response: 404, description: "No objects found", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))
+	    ]
+	)]
+	#[OA\Get(
+	    path: "/{app_id}/tools/scanagents/{id}/",
+	    tags: ["tools"],
+	    summary: "Read a single scan agent by id",
+	    parameters: [
+	        new OA\Parameter(ref: "#/components/parameters/app_id"),
+	        new OA\Parameter(name: "id", in: "path", required: true, schema: new OA\Schema(type: "integer"))
+	    ],
+	    responses: [
+	        new OA\Response(response: 200, description: "OK", content: new OA\JsonContent(
+	            type: "object",
+	            properties: [
+	                new OA\Property(property: "id", type: "integer"),
+	                new OA\Property(property: "name", type: "string"),
+	                new OA\Property(property: "description", type: "string", nullable: true),
+	                new OA\Property(property: "type", type: "string", enum: ["direct","api","mysql"]),
+	                new OA\Property(property: "code", type: "string", nullable: true),
+	                new OA\Property(property: "last_access", type: "string", format: "date-time", nullable: true)
+	            ]
+	        )),
+	        new OA\Response(response: 400, description: "Identifier must be numeric", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse")),
+	        new OA\Response(response: 404, description: "No objects found", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))
+	    ]
+	)]
+	#[OA\Get(
+	    path: "/{app_id}/tools/locations/",
+	    tags: ["tools"],
+	    summary: "List all locations",
+	    parameters: [new OA\Parameter(ref: "#/components/parameters/app_id")],
+	    responses: [
+	        new OA\Response(response: 200, description: "OK", content: new OA\JsonContent(type: "array", items: new OA\Items(
+	            type: "object",
+	            properties: [
+	                new OA\Property(property: "id", type: "integer", example: 1),
+	                new OA\Property(property: "name", type: "string"),
+	                new OA\Property(property: "description", type: "string", nullable: true),
+	                new OA\Property(property: "address", type: "string", nullable: true),
+	                new OA\Property(property: "lat", type: "string", nullable: true),
+	                new OA\Property(property: "long", type: "string", nullable: true)
+	            ]
+	        ))),
+	        new OA\Response(response: 404, description: "No objects found", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))
+	    ]
+	)]
+	#[OA\Get(
+	    path: "/{app_id}/tools/locations/{id}/",
+	    tags: ["tools"],
+	    summary: "Read a single location by id",
+	    parameters: [
+	        new OA\Parameter(ref: "#/components/parameters/app_id"),
+	        new OA\Parameter(name: "id", in: "path", required: true, schema: new OA\Schema(type: "integer"))
+	    ],
+	    responses: [
+	        new OA\Response(response: 200, description: "OK", content: new OA\JsonContent(
+	            type: "object",
+	            properties: [
+	                new OA\Property(property: "id", type: "integer"),
+	                new OA\Property(property: "name", type: "string"),
+	                new OA\Property(property: "description", type: "string", nullable: true),
+	                new OA\Property(property: "address", type: "string", nullable: true),
+	                new OA\Property(property: "lat", type: "string", nullable: true),
+	                new OA\Property(property: "long", type: "string", nullable: true)
+	            ]
+	        )),
+	        new OA\Response(response: 400, description: "Identifier must be numeric", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse")),
+	        new OA\Response(response: 404, description: "No objects found", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))
+	    ]
+	)]
+	#[OA\Get(
+	    path: "/{app_id}/tools/locations/{id}/subnets/",
+	    tags: ["tools"],
+	    summary: "List subnets assigned to this location",
+	    parameters: [
+	        new OA\Parameter(ref: "#/components/parameters/app_id"),
+	        new OA\Parameter(name: "id", in: "path", required: true, schema: new OA\Schema(type: "integer"))
+	    ],
+	    responses: [
+	        new OA\Response(response: 200, description: "OK", content: new OA\JsonContent(type: "array", items: new OA\Items(ref: "#/components/schemas/Subnet"))),
+	        new OA\Response(response: 404, description: "No objects found", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))
+	    ]
+	)]
+	#[OA\Get(
+	    path: "/{app_id}/tools/locations/{id}/devices/",
+	    tags: ["tools"],
+	    summary: "List devices assigned to this location",
+	    parameters: [
+	        new OA\Parameter(ref: "#/components/parameters/app_id"),
+	        new OA\Parameter(name: "id", in: "path", required: true, schema: new OA\Schema(type: "integer"))
+	    ],
+	    responses: [
+	        new OA\Response(response: 200, description: "OK", content: new OA\JsonContent(type: "array", items: new OA\Items(ref: "#/components/schemas/Device"))),
+	        new OA\Response(response: 404, description: "No objects found", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))
+	    ]
+	)]
+	#[OA\Get(
+	    path: "/{app_id}/tools/locations/{id}/racks/",
+	    tags: ["tools"],
+	    summary: "List racks assigned to this location",
+	    parameters: [
+	        new OA\Parameter(ref: "#/components/parameters/app_id"),
+	        new OA\Parameter(name: "id", in: "path", required: true, schema: new OA\Schema(type: "integer"))
+	    ],
+	    responses: [
+	        new OA\Response(response: 200, description: "OK", content: new OA\JsonContent(type: "array", items: new OA\Items(
+	            type: "object",
+	            properties: [
+	                new OA\Property(property: "id", type: "integer"),
+	                new OA\Property(property: "name", type: "string"),
+	                new OA\Property(property: "size", type: "integer", nullable: true),
+	                new OA\Property(property: "location", type: "integer", nullable: true)
+	            ]
+	        ))),
+	        new OA\Response(response: 404, description: "No objects found", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))
+	    ]
+	)]
+	#[OA\Get(
+	    path: "/{app_id}/tools/locations/{id}/ipaddresses/",
+	    tags: ["tools"],
+	    summary: "List IP addresses assigned to this location",
+	    parameters: [
+	        new OA\Parameter(ref: "#/components/parameters/app_id"),
+	        new OA\Parameter(name: "id", in: "path", required: true, schema: new OA\Schema(type: "integer"))
+	    ],
+	    responses: [
+	        new OA\Response(response: 200, description: "OK", content: new OA\JsonContent(type: "array", items: new OA\Items(ref: "#/components/schemas/Address"))),
+	        new OA\Response(response: 404, description: "No objects found", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))
+	    ]
+	)]
+	#[OA\Get(
+	    path: "/{app_id}/tools/racks/",
+	    tags: ["tools"],
+	    summary: "List all racks",
+	    parameters: [new OA\Parameter(ref: "#/components/parameters/app_id")],
+	    responses: [
+	        new OA\Response(response: 200, description: "OK", content: new OA\JsonContent(type: "array", items: new OA\Items(
+	            type: "object",
+	            properties: [
+	                new OA\Property(property: "id", type: "integer", example: 1),
+	                new OA\Property(property: "name", type: "string"),
+	                new OA\Property(property: "size", type: "integer", nullable: true),
+	                new OA\Property(property: "subrack", type: "boolean"),
+	                new OA\Property(property: "location", type: "integer", nullable: true),
+	                new OA\Property(property: "row", type: "integer"),
+	                new OA\Property(property: "hasBack", type: "boolean"),
+	                new OA\Property(property: "topDown", type: "boolean"),
+	                new OA\Property(property: "description", type: "string", nullable: true),
+	                new OA\Property(property: "customer_id", type: "integer", nullable: true)
+	            ]
+	        ))),
+	        new OA\Response(response: 404, description: "No objects found", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))
+	    ]
+	)]
+	#[OA\Get(
+	    path: "/{app_id}/tools/racks/{id}/",
+	    tags: ["tools"],
+	    summary: "Read a single rack by id",
+	    parameters: [
+	        new OA\Parameter(ref: "#/components/parameters/app_id"),
+	        new OA\Parameter(name: "id", in: "path", required: true, schema: new OA\Schema(type: "integer"))
+	    ],
+	    responses: [
+	        new OA\Response(response: 200, description: "OK", content: new OA\JsonContent(
+	            type: "object",
+	            properties: [
+	                new OA\Property(property: "id", type: "integer"),
+	                new OA\Property(property: "name", type: "string"),
+	                new OA\Property(property: "size", type: "integer", nullable: true),
+	                new OA\Property(property: "subrack", type: "boolean"),
+	                new OA\Property(property: "location", type: "integer", nullable: true),
+	                new OA\Property(property: "row", type: "integer"),
+	                new OA\Property(property: "hasBack", type: "boolean"),
+	                new OA\Property(property: "topDown", type: "boolean"),
+	                new OA\Property(property: "description", type: "string", nullable: true),
+	                new OA\Property(property: "customer_id", type: "integer", nullable: true)
+	            ]
+	        )),
+	        new OA\Response(response: 400, description: "Identifier must be numeric", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse")),
+	        new OA\Response(response: 404, description: "No objects found", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))
+	    ]
+	)]
+	#[OA\Get(
+	    path: "/{app_id}/tools/racks/{id}/devices/",
+	    tags: ["tools"],
+	    summary: "List devices mounted in this rack",
+	    parameters: [
+	        new OA\Parameter(ref: "#/components/parameters/app_id"),
+	        new OA\Parameter(name: "id", in: "path", required: true, schema: new OA\Schema(type: "integer"))
+	    ],
+	    responses: [
+	        new OA\Response(response: 200, description: "OK", content: new OA\JsonContent(type: "array", items: new OA\Items(ref: "#/components/schemas/Device"))),
+	        new OA\Response(response: 404, description: "No objects found", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))
+	    ]
+	)]
+	#[OA\Get(
+	    path: "/{app_id}/tools/nat/",
+	    tags: ["tools"],
+	    summary: "List all NAT rules",
+	    parameters: [new OA\Parameter(ref: "#/components/parameters/app_id")],
+	    responses: [
+	        new OA\Response(response: 200, description: "OK", content: new OA\JsonContent(type: "array", items: new OA\Items(
+	            type: "object",
+	            properties: [
+	                new OA\Property(property: "id", type: "integer", example: 1),
+	                new OA\Property(property: "name", type: "string", nullable: true),
+	                new OA\Property(property: "type", type: "string", enum: ["source","static","destination"]),
+	                new OA\Property(property: "src", type: "string", nullable: true, description: "JSON-encoded map of object type => array of ids"),
+	                new OA\Property(property: "dst", type: "string", nullable: true, description: "JSON-encoded map of object type => array of ids"),
+	                new OA\Property(property: "src_port", type: "integer", nullable: true),
+	                new OA\Property(property: "dst_port", type: "integer", nullable: true),
+	                new OA\Property(property: "device", type: "integer", nullable: true, description: "Device id owning this NAT rule"),
+	                new OA\Property(property: "description", type: "string", nullable: true),
+	                new OA\Property(property: "policy", type: "string", enum: ["Yes","No"]),
+	                new OA\Property(property: "policy_dst", type: "string", nullable: true)
+	            ]
+	        ))),
+	        new OA\Response(response: 404, description: "No objects found", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))
+	    ]
+	)]
+	#[OA\Get(
+	    path: "/{app_id}/tools/nat/{id}/",
+	    tags: ["tools"],
+	    summary: "Read a single NAT rule by id",
+	    parameters: [
+	        new OA\Parameter(ref: "#/components/parameters/app_id"),
+	        new OA\Parameter(name: "id", in: "path", required: true, schema: new OA\Schema(type: "integer"))
+	    ],
+	    responses: [
+	        new OA\Response(response: 200, description: "OK", content: new OA\JsonContent(
+	            type: "object",
+	            properties: [
+	                new OA\Property(property: "id", type: "integer"),
+	                new OA\Property(property: "name", type: "string", nullable: true),
+	                new OA\Property(property: "type", type: "string", enum: ["source","static","destination"]),
+	                new OA\Property(property: "src", type: "string", nullable: true),
+	                new OA\Property(property: "dst", type: "string", nullable: true),
+	                new OA\Property(property: "device", type: "integer", nullable: true),
+	                new OA\Property(property: "description", type: "string", nullable: true)
+	            ]
+	        )),
+	        new OA\Response(response: 400, description: "Identifier must be numeric", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse")),
+	        new OA\Response(response: 404, description: "No objects found", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))
+	    ]
+	)]
+	#[OA\Get(
+	    path: "/{app_id}/tools/nat/{id}/objects/",
+	    tags: ["tools"],
+	    summary: "Get a NAT rule with its src/dst object id lists decoded",
+	    description: "src and dst are returned as a map of object type (e.g. subnets, ipaddresses) to an array of referenced object ids.",
+	    parameters: [
+	        new OA\Parameter(ref: "#/components/parameters/app_id"),
+	        new OA\Parameter(name: "id", in: "path", required: true, schema: new OA\Schema(type: "integer"))
+	    ],
+	    responses: [
+	        new OA\Response(response: 200, description: "OK"),
+	        new OA\Response(response: 404, description: "No objects found", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))
+	    ]
+	)]
+	#[OA\Get(
+	    path: "/{app_id}/tools/nat/{id}/objects_full/",
+	    tags: ["tools"],
+	    summary: "Get a NAT rule with its src/dst objects fully resolved",
+	    description: "Like objects/, but each referenced id is replaced with the full fetched object.",
+	    parameters: [
+	        new OA\Parameter(ref: "#/components/parameters/app_id"),
+	        new OA\Parameter(name: "id", in: "path", required: true, schema: new OA\Schema(type: "integer"))
+	    ],
+	    responses: [
+	        new OA\Response(response: 200, description: "OK"),
+	        new OA\Response(response: 404, description: "No objects found", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))
+	    ]
+	)]
+	#[OA\Get(
+	    path: "/{app_id}/tools/customers/",
+	    tags: ["tools"],
+	    summary: "List all customers",
+	    parameters: [new OA\Parameter(ref: "#/components/parameters/app_id")],
+	    responses: [
+	        new OA\Response(response: 200, description: "OK", content: new OA\JsonContent(type: "array", items: new OA\Items(
+	            type: "object",
+	            properties: [
+	                new OA\Property(property: "id", type: "integer", example: 1),
+	                new OA\Property(property: "title", type: "string"),
+	                new OA\Property(property: "address", type: "string", nullable: true),
+	                new OA\Property(property: "postcode", type: "string", nullable: true),
+	                new OA\Property(property: "city", type: "string", nullable: true),
+	                new OA\Property(property: "state", type: "string", nullable: true),
+	                new OA\Property(property: "lat", type: "string", nullable: true),
+	                new OA\Property(property: "long", type: "string", nullable: true),
+	                new OA\Property(property: "contact_person", type: "string", nullable: true),
+	                new OA\Property(property: "contact_phone", type: "string", nullable: true),
+	                new OA\Property(property: "contact_mail", type: "string", nullable: true),
+	                new OA\Property(property: "note", type: "string", nullable: true),
+	                new OA\Property(property: "status", type: "string", enum: ["Active","Reserved","Inactive"])
+	            ]
+	        ))),
+	        new OA\Response(response: 404, description: "No objects found", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))
+	    ]
+	)]
+	#[OA\Get(
+	    path: "/{app_id}/tools/customers/{id}/",
+	    tags: ["tools"],
+	    summary: "Read a single customer by id",
+	    parameters: [
+	        new OA\Parameter(ref: "#/components/parameters/app_id"),
+	        new OA\Parameter(name: "id", in: "path", required: true, schema: new OA\Schema(type: "integer"))
+	    ],
+	    responses: [
+	        new OA\Response(response: 200, description: "OK", content: new OA\JsonContent(
+	            type: "object",
+	            properties: [
+	                new OA\Property(property: "id", type: "integer"),
+	                new OA\Property(property: "title", type: "string"),
+	                new OA\Property(property: "address", type: "string", nullable: true),
+	                new OA\Property(property: "city", type: "string", nullable: true),
+	                new OA\Property(property: "contact_phone", type: "string", nullable: true),
+	                new OA\Property(property: "contact_mail", type: "string", nullable: true),
+	                new OA\Property(property: "status", type: "string", enum: ["Active","Reserved","Inactive"])
+	            ]
+	        )),
+	        new OA\Response(response: 400, description: "Identifier must be numeric", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse")),
+	        new OA\Response(response: 404, description: "No objects found", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))
+	    ]
+	)]
 	#[\Override]
     public function GET () {
 		# validate identifiers
@@ -340,6 +976,235 @@ class Tools_controller extends Common_api_functions {
 	 * @access public
 	 * @return void
 	 */
+	#[OA\Post(
+	    path: "/{app_id}/tools/tags/",
+	    tags: ["tools"],
+	    summary: "Create a new IP tag",
+	    parameters: [new OA\Parameter(ref: "#/components/parameters/app_id")],
+	    requestBody: new OA\RequestBody(required: true, content: new OA\JsonContent(
+	        required: ["type"],
+	        properties: [
+	            new OA\Property(property: "type", type: "string", example: "Maintenance"),
+	            new OA\Property(property: "showtag", type: "boolean", default: true),
+	            new OA\Property(property: "bgcolor", type: "string", example: "#000"),
+	            new OA\Property(property: "fgcolor", type: "string", example: "#fff"),
+	            new OA\Property(property: "compress", type: "string", enum: ["No","Yes"], default: "No"),
+	            new OA\Property(property: "locked", type: "string", enum: ["No","Yes"], default: "No"),
+	            new OA\Property(property: "updateTag", type: "boolean", default: false)
+	        ]
+	    )),
+	    responses: [
+	        new OA\Response(response: 201, description: "Tag created", content: new OA\JsonContent(ref: "#/components/schemas/SuccessResponse")),
+	        new OA\Response(response: 400, description: "No parameters", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse")),
+	        new OA\Response(response: 500, description: "Object creation failed", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))
+	    ]
+	)]
+	#[OA\Post(
+	    path: "/{app_id}/tools/devices/",
+	    tags: ["tools"],
+	    summary: "Create a new device",
+	    parameters: [new OA\Parameter(ref: "#/components/parameters/app_id")],
+	    requestBody: new OA\RequestBody(required: true, content: new OA\JsonContent(
+	        required: ["hostname"],
+	        properties: [
+	            new OA\Property(property: "hostname", type: "string"),
+	            new OA\Property(property: "ip_addr", type: "string", nullable: true),
+	            new OA\Property(property: "type", type: "integer", description: "Device type id (deviceTypes.tid)"),
+	            new OA\Property(property: "description", type: "string", nullable: true),
+	            new OA\Property(property: "sections", type: "string", nullable: true, description: "Semicolon separated list of section ids"),
+	            new OA\Property(property: "snmp_community", type: "string", nullable: true),
+	            new OA\Property(property: "snmp_version", type: "string", enum: ["0","1","2","3"]),
+	            new OA\Property(property: "snmp_port", type: "integer", nullable: true),
+	            new OA\Property(property: "snmp_timeout", type: "integer", nullable: true),
+	            new OA\Property(property: "snmp_queries", type: "string", nullable: true),
+	            new OA\Property(property: "rack", type: "integer", nullable: true),
+	            new OA\Property(property: "rack_start", type: "integer", nullable: true),
+	            new OA\Property(property: "rack_size", type: "integer", nullable: true),
+	            new OA\Property(property: "location", type: "integer", nullable: true),
+	            new OA\Property(property: "address", type: "string", nullable: true, description: "If lat/long are not set, resolved to coordinates via Nominatim"),
+	            new OA\Property(property: "lat", type: "string", nullable: true),
+	            new OA\Property(property: "long", type: "string", nullable: true)
+	        ]
+	    )),
+	    responses: [
+	        new OA\Response(response: 201, description: "Device created", content: new OA\JsonContent(ref: "#/components/schemas/SuccessResponse")),
+	        new OA\Response(response: 400, description: "No parameters, invalid device type or invalid ip_addr", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse")),
+	        new OA\Response(response: 500, description: "Object creation failed", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))
+	    ]
+	)]
+	#[OA\Post(
+	    path: "/{app_id}/tools/device_types/",
+	    tags: ["tools"],
+	    summary: "Create a new device type",
+	    parameters: [new OA\Parameter(ref: "#/components/parameters/app_id")],
+	    requestBody: new OA\RequestBody(required: true, content: new OA\JsonContent(
+	        required: ["tname"],
+	        properties: [
+	            new OA\Property(property: "tname", type: "string", example: "Custom type"),
+	            new OA\Property(property: "tdescription", type: "string", nullable: true),
+	            new OA\Property(property: "bgcolor", type: "string", example: "#E6E6E6"),
+	            new OA\Property(property: "fgcolor", type: "string", example: "#000")
+	        ]
+	    )),
+	    responses: [
+	        new OA\Response(response: 201, description: "Device type created", content: new OA\JsonContent(ref: "#/components/schemas/SuccessResponse")),
+	        new OA\Response(response: 400, description: "No parameters", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse")),
+	        new OA\Response(response: 500, description: "Object creation failed", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))
+	    ]
+	)]
+	#[OA\Post(
+	    path: "/{app_id}/tools/vlans/",
+	    tags: ["tools"],
+	    summary: "Not supported here - VLANs must be created via the /vlans controller",
+	    parameters: [new OA\Parameter(ref: "#/components/parameters/app_id")],
+	    responses: [new OA\Response(response: 400, description: "Please use vlans controller", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))]
+	)]
+	#[OA\Post(
+	    path: "/{app_id}/tools/vrfs/",
+	    tags: ["tools"],
+	    summary: "Not supported here - VRFs must be created via the /vrf controller",
+	    parameters: [new OA\Parameter(ref: "#/components/parameters/app_id")],
+	    responses: [new OA\Response(response: 400, description: "Please use vrf controller", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))]
+	)]
+	#[OA\Post(
+	    path: "/{app_id}/tools/nameservers/",
+	    tags: ["tools"],
+	    summary: "Create a new nameserver set",
+	    parameters: [new OA\Parameter(ref: "#/components/parameters/app_id")],
+	    requestBody: new OA\RequestBody(required: true, content: new OA\JsonContent(
+	        required: ["name","namesrv1"],
+	        properties: [
+	            new OA\Property(property: "name", type: "string", example: "Google NS"),
+	            new OA\Property(property: "namesrv1", type: "string", description: "Semicolon separated list of nameserver IPs", example: "8.8.8.8;8.8.4.4"),
+	            new OA\Property(property: "description", type: "string", nullable: true),
+	            new OA\Property(property: "permissions", type: "string", nullable: true, description: "JSON-encoded map of groupId => permission level")
+	        ]
+	    )),
+	    responses: [
+	        new OA\Response(response: 201, description: "Nameserver set created", content: new OA\JsonContent(ref: "#/components/schemas/SuccessResponse")),
+	        new OA\Response(response: 400, description: "No parameters", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse")),
+	        new OA\Response(response: 500, description: "Object creation failed", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))
+	    ]
+	)]
+	#[OA\Post(
+	    path: "/{app_id}/tools/scanagents/",
+	    tags: ["tools"],
+	    summary: "Create a new scan agent",
+	    parameters: [new OA\Parameter(ref: "#/components/parameters/app_id")],
+	    requestBody: new OA\RequestBody(required: true, content: new OA\JsonContent(
+	        required: ["name"],
+	        properties: [
+	            new OA\Property(property: "name", type: "string"),
+	            new OA\Property(property: "description", type: "string", nullable: true),
+	            new OA\Property(property: "type", type: "string", enum: ["direct","api","mysql"]),
+	            new OA\Property(property: "code", type: "string", nullable: true, description: "Unique agent code used by the scanning script")
+	        ]
+	    )),
+	    responses: [
+	        new OA\Response(response: 201, description: "Scan agent created", content: new OA\JsonContent(ref: "#/components/schemas/SuccessResponse")),
+	        new OA\Response(response: 400, description: "No parameters", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse")),
+	        new OA\Response(response: 500, description: "Object creation failed", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))
+	    ]
+	)]
+	#[OA\Post(
+	    path: "/{app_id}/tools/locations/",
+	    tags: ["tools"],
+	    summary: "Create a new location",
+	    parameters: [new OA\Parameter(ref: "#/components/parameters/app_id")],
+	    requestBody: new OA\RequestBody(required: true, content: new OA\JsonContent(
+	        required: ["name"],
+	        properties: [
+	            new OA\Property(property: "name", type: "string"),
+	            new OA\Property(property: "description", type: "string", nullable: true),
+	            new OA\Property(property: "address", type: "string", nullable: true, description: "If lat/long are not set, resolved to coordinates via Nominatim"),
+	            new OA\Property(property: "lat", type: "string", nullable: true),
+	            new OA\Property(property: "long", type: "string", nullable: true)
+	        ]
+	    )),
+	    responses: [
+	        new OA\Response(response: 201, description: "Location created", content: new OA\JsonContent(ref: "#/components/schemas/SuccessResponse")),
+	        new OA\Response(response: 400, description: "No parameters", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse")),
+	        new OA\Response(response: 500, description: "Object creation failed", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))
+	    ]
+	)]
+	#[OA\Post(
+	    path: "/{app_id}/tools/racks/",
+	    tags: ["tools"],
+	    summary: "Create a new rack",
+	    parameters: [new OA\Parameter(ref: "#/components/parameters/app_id")],
+	    requestBody: new OA\RequestBody(required: true, content: new OA\JsonContent(
+	        required: ["name"],
+	        properties: [
+	            new OA\Property(property: "name", type: "string"),
+	            new OA\Property(property: "size", type: "integer", nullable: true, description: "Number of U's"),
+	            new OA\Property(property: "subrack", type: "boolean", default: false),
+	            new OA\Property(property: "location", type: "integer", nullable: true),
+	            new OA\Property(property: "row", type: "integer", default: 1),
+	            new OA\Property(property: "hasBack", type: "boolean", default: false),
+	            new OA\Property(property: "topDown", type: "boolean", default: false),
+	            new OA\Property(property: "description", type: "string", nullable: true),
+	            new OA\Property(property: "customer_id", type: "integer", nullable: true)
+	        ]
+	    )),
+	    responses: [
+	        new OA\Response(response: 201, description: "Rack created", content: new OA\JsonContent(ref: "#/components/schemas/SuccessResponse")),
+	        new OA\Response(response: 400, description: "No parameters", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse")),
+	        new OA\Response(response: 500, description: "Object creation failed", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))
+	    ]
+	)]
+	#[OA\Post(
+	    path: "/{app_id}/tools/nat/",
+	    tags: ["tools"],
+	    summary: "Create a new NAT rule",
+	    parameters: [new OA\Parameter(ref: "#/components/parameters/app_id")],
+	    requestBody: new OA\RequestBody(required: true, content: new OA\JsonContent(
+	        properties: [
+	            new OA\Property(property: "name", type: "string", nullable: true),
+	            new OA\Property(property: "type", type: "string", enum: ["source","static","destination"], default: "source"),
+	            new OA\Property(property: "src", type: "string", nullable: true, description: "JSON-encoded map of object type => array of ids"),
+	            new OA\Property(property: "dst", type: "string", nullable: true, description: "JSON-encoded map of object type => array of ids"),
+	            new OA\Property(property: "src_port", type: "integer", nullable: true),
+	            new OA\Property(property: "dst_port", type: "integer", nullable: true),
+	            new OA\Property(property: "device", type: "integer", nullable: true, description: "Device id owning this NAT rule"),
+	            new OA\Property(property: "description", type: "string", nullable: true),
+	            new OA\Property(property: "policy", type: "string", enum: ["Yes","No"], default: "No"),
+	            new OA\Property(property: "policy_dst", type: "string", nullable: true)
+	        ]
+	    )),
+	    responses: [
+	        new OA\Response(response: 201, description: "NAT rule created", content: new OA\JsonContent(ref: "#/components/schemas/SuccessResponse")),
+	        new OA\Response(response: 400, description: "No parameters", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse")),
+	        new OA\Response(response: 500, description: "Object creation failed", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))
+	    ]
+	)]
+	#[OA\Post(
+	    path: "/{app_id}/tools/customers/",
+	    tags: ["tools"],
+	    summary: "Create a new customer",
+	    parameters: [new OA\Parameter(ref: "#/components/parameters/app_id")],
+	    requestBody: new OA\RequestBody(required: true, content: new OA\JsonContent(
+	        required: ["title"],
+	        properties: [
+	            new OA\Property(property: "title", type: "string"),
+	            new OA\Property(property: "address", type: "string", nullable: true),
+	            new OA\Property(property: "postcode", type: "string", nullable: true),
+	            new OA\Property(property: "city", type: "string", nullable: true),
+	            new OA\Property(property: "state", type: "string", nullable: true),
+	            new OA\Property(property: "lat", type: "string", nullable: true),
+	            new OA\Property(property: "long", type: "string", nullable: true),
+	            new OA\Property(property: "contact_person", type: "string", nullable: true),
+	            new OA\Property(property: "contact_phone", type: "string", nullable: true),
+	            new OA\Property(property: "contact_mail", type: "string", nullable: true),
+	            new OA\Property(property: "note", type: "string", nullable: true),
+	            new OA\Property(property: "status", type: "string", enum: ["Active","Reserved","Inactive"], default: "Active")
+	        ]
+	    )),
+	    responses: [
+	        new OA\Response(response: 201, description: "Customer created", content: new OA\JsonContent(ref: "#/components/schemas/SuccessResponse")),
+	        new OA\Response(response: 400, description: "No parameters", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse")),
+	        new OA\Response(response: 500, description: "Object creation failed", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))
+	    ]
+	)]
 	#[\Override]
     public function POST () {
 		# rewrite tool controller _params
@@ -377,6 +1242,257 @@ class Tools_controller extends Common_api_functions {
 	 * @access public
 	 * @return void
 	 */
+	#[OA\Patch(
+	    path: "/{app_id}/tools/tags/{id}/",
+	    tags: ["tools"],
+	    summary: "Update an IP tag",
+	    parameters: [
+	        new OA\Parameter(ref: "#/components/parameters/app_id"),
+	        new OA\Parameter(name: "id", in: "path", required: true, schema: new OA\Schema(type: "integer"))
+	    ],
+	    requestBody: new OA\RequestBody(content: new OA\JsonContent(
+	        properties: [
+	            new OA\Property(property: "type", type: "string"),
+	            new OA\Property(property: "showtag", type: "boolean"),
+	            new OA\Property(property: "bgcolor", type: "string"),
+	            new OA\Property(property: "fgcolor", type: "string"),
+	            new OA\Property(property: "compress", type: "string", enum: ["No","Yes"]),
+	            new OA\Property(property: "locked", type: "string", enum: ["No","Yes"]),
+	            new OA\Property(property: "updateTag", type: "boolean")
+	        ]
+	    )),
+	    responses: [
+	        new OA\Response(response: 200, description: "Tag updated", content: new OA\JsonContent(ref: "#/components/schemas/SuccessResponse")),
+	        new OA\Response(response: 400, description: "No parameters or invalid identifier", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse")),
+	        new OA\Response(response: 500, description: "Object edit failed", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))
+	    ]
+	)]
+	#[OA\Patch(
+	    path: "/{app_id}/tools/devices/{id}/",
+	    tags: ["tools"],
+	    summary: "Update a device",
+	    parameters: [
+	        new OA\Parameter(ref: "#/components/parameters/app_id"),
+	        new OA\Parameter(name: "id", in: "path", required: true, schema: new OA\Schema(type: "integer"))
+	    ],
+	    requestBody: new OA\RequestBody(content: new OA\JsonContent(
+	        properties: [
+	            new OA\Property(property: "hostname", type: "string"),
+	            new OA\Property(property: "ip_addr", type: "string", nullable: true),
+	            new OA\Property(property: "type", type: "integer", description: "Device type id (deviceTypes.tid)"),
+	            new OA\Property(property: "description", type: "string", nullable: true),
+	            new OA\Property(property: "sections", type: "string", nullable: true),
+	            new OA\Property(property: "snmp_community", type: "string", nullable: true),
+	            new OA\Property(property: "rack", type: "integer", nullable: true),
+	            new OA\Property(property: "rack_start", type: "integer", nullable: true),
+	            new OA\Property(property: "rack_size", type: "integer", nullable: true),
+	            new OA\Property(property: "location", type: "integer", nullable: true),
+	            new OA\Property(property: "address", type: "string", nullable: true),
+	            new OA\Property(property: "lat", type: "string", nullable: true),
+	            new OA\Property(property: "long", type: "string", nullable: true)
+	        ]
+	    )),
+	    responses: [
+	        new OA\Response(response: 200, description: "Device updated", content: new OA\JsonContent(ref: "#/components/schemas/SuccessResponse")),
+	        new OA\Response(response: 400, description: "No parameters, invalid device type, invalid ip_addr or invalid identifier", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse")),
+	        new OA\Response(response: 500, description: "Object edit failed", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))
+	    ]
+	)]
+	#[OA\Patch(
+	    path: "/{app_id}/tools/device_types/{id}/",
+	    tags: ["tools"],
+	    summary: "Update a device type",
+	    description: "{id} maps to the deviceTypes.tid field.",
+	    parameters: [
+	        new OA\Parameter(ref: "#/components/parameters/app_id"),
+	        new OA\Parameter(name: "id", in: "path", required: true, schema: new OA\Schema(type: "integer"))
+	    ],
+	    requestBody: new OA\RequestBody(content: new OA\JsonContent(
+	        properties: [
+	            new OA\Property(property: "tname", type: "string"),
+	            new OA\Property(property: "tdescription", type: "string", nullable: true),
+	            new OA\Property(property: "bgcolor", type: "string"),
+	            new OA\Property(property: "fgcolor", type: "string")
+	        ]
+	    )),
+	    responses: [
+	        new OA\Response(response: 200, description: "Device type updated", content: new OA\JsonContent(ref: "#/components/schemas/SuccessResponse")),
+	        new OA\Response(response: 400, description: "No parameters or invalid identifier", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse")),
+	        new OA\Response(response: 500, description: "Object edit failed", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))
+	    ]
+	)]
+	#[OA\Patch(
+	    path: "/{app_id}/tools/vlans/{id}/",
+	    tags: ["tools"],
+	    summary: "Not supported here - VLANs must be updated via the /vlans controller",
+	    parameters: [
+	        new OA\Parameter(ref: "#/components/parameters/app_id"),
+	        new OA\Parameter(name: "id", in: "path", required: true, schema: new OA\Schema(type: "integer"))
+	    ],
+	    responses: [new OA\Response(response: 400, description: "Please use vlans controller", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))]
+	)]
+	#[OA\Patch(
+	    path: "/{app_id}/tools/vrfs/{id}/",
+	    tags: ["tools"],
+	    summary: "Not supported here - VRFs must be updated via the /vrf controller",
+	    parameters: [
+	        new OA\Parameter(ref: "#/components/parameters/app_id"),
+	        new OA\Parameter(name: "id", in: "path", required: true, schema: new OA\Schema(type: "integer"))
+	    ],
+	    responses: [new OA\Response(response: 400, description: "Please use vrf controller", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))]
+	)]
+	#[OA\Patch(
+	    path: "/{app_id}/tools/nameservers/{id}/",
+	    tags: ["tools"],
+	    summary: "Update a nameserver set",
+	    parameters: [
+	        new OA\Parameter(ref: "#/components/parameters/app_id"),
+	        new OA\Parameter(name: "id", in: "path", required: true, schema: new OA\Schema(type: "integer"))
+	    ],
+	    requestBody: new OA\RequestBody(content: new OA\JsonContent(
+	        properties: [
+	            new OA\Property(property: "name", type: "string"),
+	            new OA\Property(property: "namesrv1", type: "string"),
+	            new OA\Property(property: "description", type: "string", nullable: true),
+	            new OA\Property(property: "permissions", type: "string", nullable: true)
+	        ]
+	    )),
+	    responses: [
+	        new OA\Response(response: 200, description: "Nameserver set updated", content: new OA\JsonContent(ref: "#/components/schemas/SuccessResponse")),
+	        new OA\Response(response: 400, description: "No parameters or invalid identifier", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse")),
+	        new OA\Response(response: 500, description: "Object edit failed", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))
+	    ]
+	)]
+	#[OA\Patch(
+	    path: "/{app_id}/tools/scanagents/{id}/",
+	    tags: ["tools"],
+	    summary: "Update a scan agent",
+	    parameters: [
+	        new OA\Parameter(ref: "#/components/parameters/app_id"),
+	        new OA\Parameter(name: "id", in: "path", required: true, schema: new OA\Schema(type: "integer"))
+	    ],
+	    requestBody: new OA\RequestBody(content: new OA\JsonContent(
+	        properties: [
+	            new OA\Property(property: "name", type: "string"),
+	            new OA\Property(property: "description", type: "string", nullable: true),
+	            new OA\Property(property: "type", type: "string", enum: ["direct","api","mysql"]),
+	            new OA\Property(property: "code", type: "string", nullable: true)
+	        ]
+	    )),
+	    responses: [
+	        new OA\Response(response: 200, description: "Scan agent updated", content: new OA\JsonContent(ref: "#/components/schemas/SuccessResponse")),
+	        new OA\Response(response: 400, description: "No parameters or invalid identifier", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse")),
+	        new OA\Response(response: 500, description: "Object edit failed", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))
+	    ]
+	)]
+	#[OA\Patch(
+	    path: "/{app_id}/tools/locations/{id}/",
+	    tags: ["tools"],
+	    summary: "Update a location",
+	    parameters: [
+	        new OA\Parameter(ref: "#/components/parameters/app_id"),
+	        new OA\Parameter(name: "id", in: "path", required: true, schema: new OA\Schema(type: "integer"))
+	    ],
+	    requestBody: new OA\RequestBody(content: new OA\JsonContent(
+	        properties: [
+	            new OA\Property(property: "name", type: "string"),
+	            new OA\Property(property: "description", type: "string", nullable: true),
+	            new OA\Property(property: "address", type: "string", nullable: true),
+	            new OA\Property(property: "lat", type: "string", nullable: true),
+	            new OA\Property(property: "long", type: "string", nullable: true)
+	        ]
+	    )),
+	    responses: [
+	        new OA\Response(response: 200, description: "Location updated", content: new OA\JsonContent(ref: "#/components/schemas/SuccessResponse")),
+	        new OA\Response(response: 400, description: "No parameters or invalid identifier", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse")),
+	        new OA\Response(response: 500, description: "Object edit failed", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))
+	    ]
+	)]
+	#[OA\Patch(
+	    path: "/{app_id}/tools/racks/{id}/",
+	    tags: ["tools"],
+	    summary: "Update a rack",
+	    parameters: [
+	        new OA\Parameter(ref: "#/components/parameters/app_id"),
+	        new OA\Parameter(name: "id", in: "path", required: true, schema: new OA\Schema(type: "integer"))
+	    ],
+	    requestBody: new OA\RequestBody(content: new OA\JsonContent(
+	        properties: [
+	            new OA\Property(property: "name", type: "string"),
+	            new OA\Property(property: "size", type: "integer", nullable: true),
+	            new OA\Property(property: "subrack", type: "boolean"),
+	            new OA\Property(property: "location", type: "integer", nullable: true),
+	            new OA\Property(property: "row", type: "integer"),
+	            new OA\Property(property: "hasBack", type: "boolean"),
+	            new OA\Property(property: "topDown", type: "boolean"),
+	            new OA\Property(property: "description", type: "string", nullable: true),
+	            new OA\Property(property: "customer_id", type: "integer", nullable: true)
+	        ]
+	    )),
+	    responses: [
+	        new OA\Response(response: 200, description: "Rack updated", content: new OA\JsonContent(ref: "#/components/schemas/SuccessResponse")),
+	        new OA\Response(response: 400, description: "No parameters or invalid identifier", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse")),
+	        new OA\Response(response: 500, description: "Object edit failed", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))
+	    ]
+	)]
+	#[OA\Patch(
+	    path: "/{app_id}/tools/nat/{id}/",
+	    tags: ["tools"],
+	    summary: "Update a NAT rule",
+	    parameters: [
+	        new OA\Parameter(ref: "#/components/parameters/app_id"),
+	        new OA\Parameter(name: "id", in: "path", required: true, schema: new OA\Schema(type: "integer"))
+	    ],
+	    requestBody: new OA\RequestBody(content: new OA\JsonContent(
+	        properties: [
+	            new OA\Property(property: "name", type: "string", nullable: true),
+	            new OA\Property(property: "type", type: "string", enum: ["source","static","destination"]),
+	            new OA\Property(property: "src", type: "string", nullable: true),
+	            new OA\Property(property: "dst", type: "string", nullable: true),
+	            new OA\Property(property: "src_port", type: "integer", nullable: true),
+	            new OA\Property(property: "dst_port", type: "integer", nullable: true),
+	            new OA\Property(property: "device", type: "integer", nullable: true),
+	            new OA\Property(property: "description", type: "string", nullable: true),
+	            new OA\Property(property: "policy", type: "string", enum: ["Yes","No"]),
+	            new OA\Property(property: "policy_dst", type: "string", nullable: true)
+	        ]
+	    )),
+	    responses: [
+	        new OA\Response(response: 200, description: "NAT rule updated", content: new OA\JsonContent(ref: "#/components/schemas/SuccessResponse")),
+	        new OA\Response(response: 400, description: "No parameters or invalid identifier", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse")),
+	        new OA\Response(response: 500, description: "Object edit failed", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))
+	    ]
+	)]
+	#[OA\Patch(
+	    path: "/{app_id}/tools/customers/{id}/",
+	    tags: ["tools"],
+	    summary: "Update a customer",
+	    parameters: [
+	        new OA\Parameter(ref: "#/components/parameters/app_id"),
+	        new OA\Parameter(name: "id", in: "path", required: true, schema: new OA\Schema(type: "integer"))
+	    ],
+	    requestBody: new OA\RequestBody(content: new OA\JsonContent(
+	        properties: [
+	            new OA\Property(property: "title", type: "string"),
+	            new OA\Property(property: "address", type: "string", nullable: true),
+	            new OA\Property(property: "postcode", type: "string", nullable: true),
+	            new OA\Property(property: "city", type: "string", nullable: true),
+	            new OA\Property(property: "state", type: "string", nullable: true),
+	            new OA\Property(property: "lat", type: "string", nullable: true),
+	            new OA\Property(property: "long", type: "string", nullable: true),
+	            new OA\Property(property: "contact_person", type: "string", nullable: true),
+	            new OA\Property(property: "contact_phone", type: "string", nullable: true),
+	            new OA\Property(property: "contact_mail", type: "string", nullable: true),
+	            new OA\Property(property: "note", type: "string", nullable: true),
+	            new OA\Property(property: "status", type: "string", enum: ["Active","Reserved","Inactive"])
+	        ]
+	    )),
+	    responses: [
+	        new OA\Response(response: 200, description: "Customer updated", content: new OA\JsonContent(ref: "#/components/schemas/SuccessResponse")),
+	        new OA\Response(response: 400, description: "No parameters or invalid identifier", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse")),
+	        new OA\Response(response: 500, description: "Object edit failed", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))
+	    ]
+	)]
 	#[\Override]
     public function PATCH () {
 		# rewrite tool controller _params
@@ -417,6 +1533,155 @@ class Tools_controller extends Common_api_functions {
 	 * @access public
 	 * @return void
 	 */
+	#[OA\Delete(
+	    path: "/{app_id}/tools/tags/{id}/",
+	    tags: ["tools"],
+	    summary: "Delete an IP tag",
+	    description: "Also clears ipaddresses.state references to this tag.",
+	    parameters: [
+	        new OA\Parameter(ref: "#/components/parameters/app_id"),
+	        new OA\Parameter(name: "id", in: "path", required: true, schema: new OA\Schema(type: "integer"))
+	    ],
+	    responses: [
+	        new OA\Response(response: 200, description: "Tag deleted", content: new OA\JsonContent(ref: "#/components/schemas/SuccessResponse")),
+	        new OA\Response(response: 400, description: "Invalid identifier", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse")),
+	        new OA\Response(response: 500, description: "Object delete failed", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))
+	    ]
+	)]
+	#[OA\Delete(
+	    path: "/{app_id}/tools/devices/{id}/",
+	    tags: ["tools"],
+	    summary: "Delete a device",
+	    description: "Also clears ipaddresses.switch references to this device.",
+	    parameters: [
+	        new OA\Parameter(ref: "#/components/parameters/app_id"),
+	        new OA\Parameter(name: "id", in: "path", required: true, schema: new OA\Schema(type: "integer"))
+	    ],
+	    responses: [
+	        new OA\Response(response: 200, description: "Device deleted", content: new OA\JsonContent(ref: "#/components/schemas/SuccessResponse")),
+	        new OA\Response(response: 400, description: "Invalid identifier", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse")),
+	        new OA\Response(response: 500, description: "Object delete failed", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))
+	    ]
+	)]
+	#[OA\Delete(
+	    path: "/{app_id}/tools/device_types/{id}/",
+	    tags: ["tools"],
+	    summary: "Delete a device type",
+	    description: "{id} maps to the deviceTypes.tid field.",
+	    parameters: [
+	        new OA\Parameter(ref: "#/components/parameters/app_id"),
+	        new OA\Parameter(name: "id", in: "path", required: true, schema: new OA\Schema(type: "integer"))
+	    ],
+	    responses: [
+	        new OA\Response(response: 200, description: "Device type deleted", content: new OA\JsonContent(ref: "#/components/schemas/SuccessResponse")),
+	        new OA\Response(response: 400, description: "Invalid identifier", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse")),
+	        new OA\Response(response: 500, description: "Object delete failed", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))
+	    ]
+	)]
+	#[OA\Delete(
+	    path: "/{app_id}/tools/vlans/{id}/",
+	    tags: ["tools"],
+	    summary: "Not supported here - VLANs must be deleted via the /vlans controller",
+	    parameters: [
+	        new OA\Parameter(ref: "#/components/parameters/app_id"),
+	        new OA\Parameter(name: "id", in: "path", required: true, schema: new OA\Schema(type: "integer"))
+	    ],
+	    responses: [new OA\Response(response: 400, description: "Please use vlans controller", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))]
+	)]
+	#[OA\Delete(
+	    path: "/{app_id}/tools/vrfs/{id}/",
+	    tags: ["tools"],
+	    summary: "Not supported here - VRFs must be deleted via the /vrf controller",
+	    parameters: [
+	        new OA\Parameter(ref: "#/components/parameters/app_id"),
+	        new OA\Parameter(name: "id", in: "path", required: true, schema: new OA\Schema(type: "integer"))
+	    ],
+	    responses: [new OA\Response(response: 400, description: "Please use vrf controller", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))]
+	)]
+	#[OA\Delete(
+	    path: "/{app_id}/tools/nameservers/{id}/",
+	    tags: ["tools"],
+	    summary: "Delete a nameserver set",
+	    parameters: [
+	        new OA\Parameter(ref: "#/components/parameters/app_id"),
+	        new OA\Parameter(name: "id", in: "path", required: true, schema: new OA\Schema(type: "integer"))
+	    ],
+	    responses: [
+	        new OA\Response(response: 200, description: "Nameserver set deleted", content: new OA\JsonContent(ref: "#/components/schemas/SuccessResponse")),
+	        new OA\Response(response: 400, description: "Invalid identifier", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse")),
+	        new OA\Response(response: 500, description: "Object delete failed", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))
+	    ]
+	)]
+	#[OA\Delete(
+	    path: "/{app_id}/tools/scanagents/{id}/",
+	    tags: ["tools"],
+	    summary: "Delete a scan agent",
+	    parameters: [
+	        new OA\Parameter(ref: "#/components/parameters/app_id"),
+	        new OA\Parameter(name: "id", in: "path", required: true, schema: new OA\Schema(type: "integer"))
+	    ],
+	    responses: [
+	        new OA\Response(response: 200, description: "Scan agent deleted", content: new OA\JsonContent(ref: "#/components/schemas/SuccessResponse")),
+	        new OA\Response(response: 400, description: "Invalid identifier", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse")),
+	        new OA\Response(response: 500, description: "Object delete failed", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))
+	    ]
+	)]
+	#[OA\Delete(
+	    path: "/{app_id}/tools/locations/{id}/",
+	    tags: ["tools"],
+	    summary: "Delete a location",
+	    parameters: [
+	        new OA\Parameter(ref: "#/components/parameters/app_id"),
+	        new OA\Parameter(name: "id", in: "path", required: true, schema: new OA\Schema(type: "integer"))
+	    ],
+	    responses: [
+	        new OA\Response(response: 200, description: "Location deleted", content: new OA\JsonContent(ref: "#/components/schemas/SuccessResponse")),
+	        new OA\Response(response: 400, description: "Invalid identifier", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse")),
+	        new OA\Response(response: 500, description: "Object delete failed", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))
+	    ]
+	)]
+	#[OA\Delete(
+	    path: "/{app_id}/tools/racks/{id}/",
+	    tags: ["tools"],
+	    summary: "Delete a rack",
+	    parameters: [
+	        new OA\Parameter(ref: "#/components/parameters/app_id"),
+	        new OA\Parameter(name: "id", in: "path", required: true, schema: new OA\Schema(type: "integer"))
+	    ],
+	    responses: [
+	        new OA\Response(response: 200, description: "Rack deleted", content: new OA\JsonContent(ref: "#/components/schemas/SuccessResponse")),
+	        new OA\Response(response: 400, description: "Invalid identifier", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse")),
+	        new OA\Response(response: 500, description: "Object delete failed", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))
+	    ]
+	)]
+	#[OA\Delete(
+	    path: "/{app_id}/tools/nat/{id}/",
+	    tags: ["tools"],
+	    summary: "Delete a NAT rule",
+	    parameters: [
+	        new OA\Parameter(ref: "#/components/parameters/app_id"),
+	        new OA\Parameter(name: "id", in: "path", required: true, schema: new OA\Schema(type: "integer"))
+	    ],
+	    responses: [
+	        new OA\Response(response: 200, description: "NAT rule deleted", content: new OA\JsonContent(ref: "#/components/schemas/SuccessResponse")),
+	        new OA\Response(response: 400, description: "Invalid identifier", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse")),
+	        new OA\Response(response: 500, description: "Object delete failed", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))
+	    ]
+	)]
+	#[OA\Delete(
+	    path: "/{app_id}/tools/customers/{id}/",
+	    tags: ["tools"],
+	    summary: "Delete a customer",
+	    parameters: [
+	        new OA\Parameter(ref: "#/components/parameters/app_id"),
+	        new OA\Parameter(name: "id", in: "path", required: true, schema: new OA\Schema(type: "integer"))
+	    ],
+	    responses: [
+	        new OA\Response(response: 200, description: "Customer deleted", content: new OA\JsonContent(ref: "#/components/schemas/SuccessResponse")),
+	        new OA\Response(response: 400, description: "Invalid identifier", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse")),
+	        new OA\Response(response: 500, description: "Object delete failed", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))
+	    ]
+	)]
 	#[\Override]
     public function DELETE () {
 		# rewrite tool controller _params

--- a/public/api/controllers/User.php
+++ b/public/api/controllers/User.php
@@ -1,5 +1,7 @@
 <?php
 
+use OpenApi\Attributes as OA;
+
 /**
  *	phpIPAM API class to authenticate users
  *
@@ -100,6 +102,13 @@ class User_controller extends Common_api_functions {
 	 * @access public
 	 * @return void
 	 */
+	#[OA\Options(
+		path: "/{app_id}/user/",
+		tags: ["user"],
+		summary: "Discover supported user routes/methods (HATEOAS)",
+		parameters: [new OA\Parameter(ref: "#/components/parameters/app_id")],
+		responses: [new OA\Response(response: 200, description: "OK")]
+	)]
 	#[\Override]
     public function OPTIONS () {
 		// validate
@@ -133,6 +142,36 @@ class User_controller extends Common_api_functions {
 	 *		- /all/							// returns all phpipam users
 	 *		- /admins/						// returns ipam admins
 	 */
+	#[OA\Get(
+		path: "/{app_id}/user/",
+		tags: ["user"],
+		summary: "Get current token expiration date",
+		parameters: [new OA\Parameter(ref: "#/components/parameters/app_id")],
+		responses: [
+			new OA\Response(response: 200, description: "OK", content: new OA\JsonContent(properties: [new OA\Property(property: "expires", type: "string", format: "date-time")])),
+			new OA\Response(response: 401, description: "Invalid/missing token", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))
+		]
+	)]
+	#[OA\Get(
+		path: "/{app_id}/user/all/",
+		tags: ["user"],
+		summary: "List all phpIPAM users (requires RWA app permission)",
+		parameters: [new OA\Parameter(ref: "#/components/parameters/app_id")],
+		responses: [
+			new OA\Response(response: 200, description: "OK"),
+			new OA\Response(response: 503, description: "Invalid app permissions", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))
+		]
+	)]
+	#[OA\Get(
+		path: "/{app_id}/user/admins/",
+		tags: ["user"],
+		summary: "List phpIPAM administrator users (requires RWA app permission)",
+		parameters: [new OA\Parameter(ref: "#/components/parameters/app_id")],
+		responses: [
+			new OA\Response(response: 200, description: "OK"),
+			new OA\Response(response: 503, description: "Invalid app permissions", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))
+		]
+	)]
 	#[\Override]
     public function GET () {
 		// token_expires
@@ -180,6 +219,23 @@ class User_controller extends Common_api_functions {
 	 * @access public
 	 * @return void
 	 */
+	#[OA\Post(
+		path: "/{app_id}/user/",
+		tags: ["user"],
+		summary: "Log in and obtain a phpipam-token (ssl_token security model)",
+		description: "Send HTTP Basic Authentication credentials (a phpIPAM user/password with API permission on this app). If a still-valid token already exists for the user it is extended, otherwise a new one is generated. No phpipam-token header is required or used for this call.",
+		security: [["basicAuth" => []]],
+		parameters: [new OA\Parameter(ref: "#/components/parameters/app_id")],
+		responses: [
+			new OA\Response(response: 200, description: "OK", content: new OA\JsonContent(properties: [
+				new OA\Property(property: "token", type: "string"),
+				new OA\Property(property: "expires", type: "string", format: "date-time")
+			])),
+			new OA\Response(response: 400, description: "Missing username/password", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse")),
+			new OA\Response(response: 403, description: "Invalid credentials", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse")),
+			new OA\Response(response: 500, description: "IP blocked after excessive login failures", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))
+		]
+	)]
 	#[\Override]
     public function POST () {
 		// block IP
@@ -198,6 +254,17 @@ class User_controller extends Common_api_functions {
 	 * @access public
 	 * @return void
 	 */
+	#[OA\Patch(
+		path: "/{app_id}/user/",
+		tags: ["user"],
+		summary: "Extend the validity of the current token (ssl_token security model)",
+		parameters: [new OA\Parameter(ref: "#/components/parameters/app_id")],
+		responses: [
+			new OA\Response(response: 200, description: "OK", content: new OA\JsonContent(properties: [new OA\Property(property: "expires", type: "string", format: "date-time")])),
+			new OA\Response(response: 401, description: "Invalid/missing token", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse")),
+			new OA\Response(response: 409, description: "Authentication not needed (ssl_code apps have no per-session token)", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))
+		]
+	)]
 	#[\Override]
     public function PATCH () {
 		// block IP
@@ -221,6 +288,17 @@ class User_controller extends Common_api_functions {
 	 * @access public
 	 * @return void
 	 */
+	#[OA\Delete(
+		path: "/{app_id}/user/",
+		tags: ["user"],
+		summary: "Revoke the current token (ssl_token security model)",
+		parameters: [new OA\Parameter(ref: "#/components/parameters/app_id")],
+		responses: [
+			new OA\Response(response: 200, description: "Token removed", content: new OA\JsonContent(ref: "#/components/schemas/SuccessResponse")),
+			new OA\Response(response: 401, description: "Invalid/missing token", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse")),
+			new OA\Response(response: 409, description: "Authentication not needed (ssl_code apps have no per-session token)", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))
+		]
+	)]
 	#[\Override]
     public function DELETE () {
 		// block IP

--- a/public/api/controllers/Vlans.php
+++ b/public/api/controllers/Vlans.php
@@ -1,5 +1,7 @@
 <?php
 
+use OpenApi\Attributes as OA;
+
 /**
  *	phpIPAM API class to work with VLANS
  *
@@ -49,6 +51,13 @@ class Vlans_controller extends Common_api_functions {
 	 * @access public
 	 * @return void
 	 */
+	#[OA\Options(
+		path: "/{app_id}/vlans/",
+		tags: ["vlans"],
+		summary: "Discover supported vlans routes/methods (HATEOAS)",
+		parameters: [new OA\Parameter(ref: "#/components/parameters/app_id")],
+		responses: [new OA\Response(response: 200, description: "OK")]
+	)]
 	#[\Override]
     public function OPTIONS () {
 		// validate
@@ -85,6 +94,79 @@ class Vlans_controller extends Common_api_functions {
 	 * @access public
 	 * @return void
 	 */
+	#[OA\Get(
+		path: "/{app_id}/vlans/",
+		tags: ["vlans"],
+		summary: "List all VLANs (alias: /vlans/all/)",
+		parameters: [new OA\Parameter(ref: "#/components/parameters/app_id")],
+		responses: [
+			new OA\Response(response: 200, description: "OK", content: new OA\JsonContent(type: "array", items: new OA\Items(ref: "#/components/schemas/Vlan"))),
+			new OA\Response(response: 404, description: "No vlans configured", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))
+		]
+	)]
+	#[OA\Get(
+		path: "/{app_id}/vlans/{id}/",
+		tags: ["vlans"],
+		summary: "Read a single VLAN by id",
+		parameters: [
+			new OA\Parameter(ref: "#/components/parameters/app_id"),
+			new OA\Parameter(name: "id", in: "path", required: true, schema: new OA\Schema(type: "integer"))
+		],
+		responses: [
+			new OA\Response(response: 200, description: "OK", content: new OA\JsonContent(ref: "#/components/schemas/Vlan")),
+			new OA\Response(response: 404, description: "Vlan not found", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))
+		]
+	)]
+	#[OA\Get(
+		path: "/{app_id}/vlans/custom_fields/",
+		tags: ["vlans"],
+		summary: "List custom fields defined on the vlans table",
+		parameters: [new OA\Parameter(ref: "#/components/parameters/app_id")],
+		responses: [
+			new OA\Response(response: 200, description: "OK"),
+			new OA\Response(response: 404, description: "No custom fields defined", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))
+		]
+	)]
+	#[OA\Get(
+		path: "/{app_id}/vlans/search/{number}/",
+		tags: ["vlans"],
+		summary: "Search VLANs by VLAN number",
+		parameters: [
+			new OA\Parameter(ref: "#/components/parameters/app_id"),
+			new OA\Parameter(name: "number", in: "path", required: true, description: "VLAN number to search for", schema: new OA\Schema(type: "integer"))
+		],
+		responses: [
+			new OA\Response(response: 200, description: "OK", content: new OA\JsonContent(type: "array", items: new OA\Items(ref: "#/components/schemas/Vlan"))),
+			new OA\Response(response: 404, description: "Vlans not found", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))
+		]
+	)]
+	#[OA\Get(
+		path: "/{app_id}/vlans/{id}/subnets/",
+		tags: ["vlans"],
+		summary: "List all subnets belonging to a VLAN",
+		parameters: [
+			new OA\Parameter(ref: "#/components/parameters/app_id"),
+			new OA\Parameter(name: "id", in: "path", required: true, description: "Vlan id", schema: new OA\Schema(type: "integer"))
+		],
+		responses: [
+			new OA\Response(response: 200, description: "OK", content: new OA\JsonContent(type: "array", items: new OA\Items(ref: "#/components/schemas/Subnet"))),
+			new OA\Response(response: 404, description: "Invalid Vlan id / No subnets found", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))
+		]
+	)]
+	#[OA\Get(
+		path: "/{app_id}/vlans/{id}/subnets/{sectionId}/",
+		tags: ["vlans"],
+		summary: "List subnets belonging to a VLAN, filtered to a single section",
+		parameters: [
+			new OA\Parameter(ref: "#/components/parameters/app_id"),
+			new OA\Parameter(name: "id", in: "path", required: true, description: "Vlan id", schema: new OA\Schema(type: "integer")),
+			new OA\Parameter(name: "sectionId", in: "path", required: true, schema: new OA\Schema(type: "integer"))
+		],
+		responses: [
+			new OA\Response(response: 200, description: "OK", content: new OA\JsonContent(type: "array", items: new OA\Items(ref: "#/components/schemas/Subnet"))),
+			new OA\Response(response: 404, description: "Invalid Vlan id / No subnets found", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))
+		]
+	)]
 	#[\Override]
     public function GET () {
 		// all
@@ -161,6 +243,28 @@ class Vlans_controller extends Common_api_functions {
 	 * @access public
 	 * @return void
 	 */
+	#[OA\Post(
+		path: "/{app_id}/vlans/",
+		tags: ["vlans"],
+		summary: "Create a new VLAN",
+		parameters: [new OA\Parameter(ref: "#/components/parameters/app_id")],
+		requestBody: new OA\RequestBody(required: true, content: new OA\JsonContent(
+			required: ["name", "number"],
+			properties: [
+				new OA\Property(property: "domainId", type: "integer", description: "L2 domain id, defaults to 1", example: 1),
+				new OA\Property(property: "name", type: "string"),
+				new OA\Property(property: "number", type: "integer"),
+				new OA\Property(property: "description", type: "string"),
+				new OA\Property(property: "customer_id", type: "integer")
+			]
+		)),
+		responses: [
+			new OA\Response(response: 201, description: "Vlan created", content: new OA\JsonContent(ref: "#/components/schemas/SuccessResponse")),
+			new OA\Response(response: 400, description: "Invalid domain id / Vlan name is required / Vlan number must be number / Vlan number cannot be negative", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse")),
+			new OA\Response(response: 409, description: "Vlan already exists / Highest possible VLAN number exceeded", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse")),
+			new OA\Response(response: 500, description: "Vlan creation failed / Highest possible VLAN number exceeded", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))
+		]
+	)]
 	#[\Override]
     public function POST () {
 		# check for valid keys
@@ -191,6 +295,31 @@ class Vlans_controller extends Common_api_functions {
 	 * @access public
 	 * @return void
 	 */
+	#[OA\Patch(
+		path: "/{app_id}/vlans/{id}/",
+		tags: ["vlans"],
+		summary: "Update an existing VLAN",
+		parameters: [
+			new OA\Parameter(ref: "#/components/parameters/app_id"),
+			new OA\Parameter(name: "id", in: "path", required: true, schema: new OA\Schema(type: "integer"))
+		],
+		requestBody: new OA\RequestBody(content: new OA\JsonContent(
+			properties: [
+				new OA\Property(property: "domainId", type: "integer"),
+				new OA\Property(property: "name", type: "string"),
+				new OA\Property(property: "number", type: "integer"),
+				new OA\Property(property: "description", type: "string"),
+				new OA\Property(property: "customer_id", type: "integer")
+			]
+		)),
+		responses: [
+			new OA\Response(response: 200, description: "Vlan updated", content: new OA\JsonContent(ref: "#/components/schemas/SuccessResponse")),
+			new OA\Response(response: 400, description: "Vlan Id is required / Vlan Id must be numeric", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse")),
+			new OA\Response(response: 404, description: "Invalid Vlan id", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse")),
+			new OA\Response(response: 409, description: "Highest possible VLAN number exceeded", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse")),
+			new OA\Response(response: 500, description: "Vlan edit failed / Highest possible VLAN number exceeded", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))
+		]
+	)]
 	#[\Override]
     public function PATCH () {
 		# verify
@@ -226,6 +355,21 @@ class Vlans_controller extends Common_api_functions {
 	 * @access public
 	 * @return void
 	 */
+	#[OA\Delete(
+		path: "/{app_id}/vlans/{id}/",
+		tags: ["vlans"],
+		summary: "Delete a VLAN, removing references from any subnets that use it",
+		parameters: [
+			new OA\Parameter(ref: "#/components/parameters/app_id"),
+			new OA\Parameter(name: "id", in: "path", required: true, schema: new OA\Schema(type: "integer"))
+		],
+		responses: [
+			new OA\Response(response: 200, description: "Vlan deleted", content: new OA\JsonContent(ref: "#/components/schemas/SuccessResponse")),
+			new OA\Response(response: 400, description: "Vlan Id is required / Vlan Id must be numeric", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse")),
+			new OA\Response(response: 404, description: "Invalid Vlan id", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse")),
+			new OA\Response(response: 500, description: "Vlan delete failed", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))
+		]
+	)]
 	#[\Override]
     public function DELETE () {
 		# verify

--- a/public/api/controllers/Vrfs.php
+++ b/public/api/controllers/Vrfs.php
@@ -1,5 +1,7 @@
 <?php
 
+use OpenApi\Attributes as OA;
+
 /**
  *	phpIPAM API class to work with vrfs
  *
@@ -40,6 +42,13 @@ class Vrfs_controller extends Common_api_functions {
 	 * @access public
 	 * @return void
 	 */
+	#[OA\Options(
+		path: "/{app_id}/vrfs/",
+		tags: ["vrfs"],
+		summary: "Discover supported vrfs routes/methods (HATEOAS)",
+		parameters: [new OA\Parameter(ref: "#/components/parameters/app_id")],
+		responses: [new OA\Response(response: 200, description: "OK")]
+	)]
 	#[\Override]
     public function OPTIONS () {
 		// validate
@@ -76,6 +85,54 @@ class Vrfs_controller extends Common_api_functions {
 	 * @access public
 	 * @return void
 	 */
+	#[OA\Get(
+		path: "/{app_id}/vrfs/",
+		tags: ["vrfs"],
+		summary: "List all VRFs (alias: /vrfs/all/)",
+		parameters: [new OA\Parameter(ref: "#/components/parameters/app_id")],
+		responses: [
+			new OA\Response(response: 200, description: "OK", content: new OA\JsonContent(type: "array", items: new OA\Items(ref: "#/components/schemas/Vrf"))),
+			new OA\Response(response: 404, description: "No vrfs configured", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))
+		]
+	)]
+	#[OA\Get(
+		path: "/{app_id}/vrfs/custom_fields/",
+		tags: ["vrfs"],
+		summary: "List custom fields defined on the vrf table",
+		parameters: [new OA\Parameter(ref: "#/components/parameters/app_id")],
+		responses: [
+			new OA\Response(response: 200, description: "OK"),
+			new OA\Response(response: 404, description: "No custom fields defined", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))
+		]
+	)]
+	#[OA\Get(
+		path: "/{app_id}/vrfs/{id}/",
+		tags: ["vrfs"],
+		summary: "Read a single VRF by id",
+		parameters: [
+			new OA\Parameter(ref: "#/components/parameters/app_id"),
+			new OA\Parameter(name: "id", in: "path", required: true, schema: new OA\Schema(type: "integer"))
+		],
+		responses: [
+			new OA\Response(response: 200, description: "OK", content: new OA\JsonContent(ref: "#/components/schemas/Vrf")),
+			new OA\Response(response: 400, description: "Vrf Id is required / must be numeric / Invalid VRF id", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse")),
+			new OA\Response(response: 404, description: "VRF not found", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))
+		]
+	)]
+	#[OA\Get(
+		path: "/{app_id}/vrfs/{id}/subnets/",
+		tags: ["vrfs"],
+		summary: "List all subnets belonging to a VRF",
+		parameters: [
+			new OA\Parameter(ref: "#/components/parameters/app_id"),
+			new OA\Parameter(name: "id", in: "path", required: true, description: "VRF id", schema: new OA\Schema(type: "integer"))
+		],
+		responses: [
+			new OA\Response(response: 200, description: "OK", content: new OA\JsonContent(type: "array", items: new OA\Items(ref: "#/components/schemas/Subnet"))),
+			new OA\Response(response: 400, description: "Vrf Id is required / must be numeric / Invalid VRF id", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse")),
+			new OA\Response(response: 404, description: "No subnets belonging to this vrf", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))
+		]
+	)]
 	#[\Override]
     public function GET () {
 		// all
@@ -143,6 +200,28 @@ class Vrfs_controller extends Common_api_functions {
 	 * @access public
 	 * @return void
 	 */
+	#[OA\Post(
+		path: "/{app_id}/vrfs/",
+		tags: ["vrfs"],
+		summary: "Create a new VRF",
+		parameters: [new OA\Parameter(ref: "#/components/parameters/app_id")],
+		requestBody: new OA\RequestBody(required: true, content: new OA\JsonContent(
+			required: ["name"],
+			properties: [
+				new OA\Property(property: "name", type: "string", example: "Customer-A"),
+				new OA\Property(property: "rd", type: "string", description: "Route distinguisher"),
+				new OA\Property(property: "description", type: "string"),
+				new OA\Property(property: "sections", type: "string", description: "Comma-separated list of section ids this VRF is restricted to"),
+				new OA\Property(property: "customer_id", type: "integer")
+			]
+		)),
+		responses: [
+			new OA\Response(response: 201, description: "VRF created", content: new OA\JsonContent(ref: "#/components/schemas/SuccessResponse")),
+			new OA\Response(response: 400, description: "VRF name is required", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse")),
+			new OA\Response(response: 409, description: "VRF with that name already exists", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse")),
+			new OA\Response(response: 500, description: "VRF creation failed", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))
+		]
+	)]
 	#[\Override]
     public function POST () {
 		# check for valid keys
@@ -170,6 +249,30 @@ class Vrfs_controller extends Common_api_functions {
 	 * @access public
 	 * @return void
 	 */
+	#[OA\Patch(
+		path: "/{app_id}/vrfs/{id}/",
+		tags: ["vrfs"],
+		summary: "Update an existing VRF",
+		parameters: [
+			new OA\Parameter(ref: "#/components/parameters/app_id"),
+			new OA\Parameter(name: "id", in: "path", required: true, schema: new OA\Schema(type: "integer"))
+		],
+		requestBody: new OA\RequestBody(content: new OA\JsonContent(
+			properties: [
+				new OA\Property(property: "name", type: "string", example: "Customer-A"),
+				new OA\Property(property: "rd", type: "string", description: "Route distinguisher"),
+				new OA\Property(property: "description", type: "string"),
+				new OA\Property(property: "sections", type: "string", description: "Comma-separated list of section ids this VRF is restricted to"),
+				new OA\Property(property: "customer_id", type: "integer")
+			]
+		)),
+		responses: [
+			new OA\Response(response: 200, description: "VRF updated", content: new OA\JsonContent(ref: "#/components/schemas/SuccessResponse")),
+			new OA\Response(response: 400, description: "Vrf Id is required / must be numeric / Invalid VRF id", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse")),
+			new OA\Response(response: 409, description: "VRF with that name already exists", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse")),
+			new OA\Response(response: 500, description: "Vrf edit failed", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))
+		]
+	)]
 	#[\Override]
     public function PATCH () {
 		# verify
@@ -204,6 +307,20 @@ class Vrfs_controller extends Common_api_functions {
 	 * @access public
 	 * @return void
 	 */
+	#[OA\Delete(
+		path: "/{app_id}/vrfs/{id}/",
+		tags: ["vrfs"],
+		summary: "Delete a VRF, removing all references from subnets that used it",
+		parameters: [
+			new OA\Parameter(ref: "#/components/parameters/app_id"),
+			new OA\Parameter(name: "id", in: "path", required: true, schema: new OA\Schema(type: "integer"))
+		],
+		responses: [
+			new OA\Response(response: 200, description: "VRF deleted", content: new OA\JsonContent(ref: "#/components/schemas/SuccessResponse")),
+			new OA\Response(response: 400, description: "Vrf Id is required / must be numeric / Invalid VRF id", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse")),
+			new OA\Response(response: 500, description: "Vrf delete failed", content: new OA\JsonContent(ref: "#/components/schemas/ErrorResponse"))
+		]
+	)]
 	#[\Override]
     public function DELETE () {
 		# check that vrf exists

--- a/public/api/docs/generator/annotations/AppIdParameter.php
+++ b/public/api/docs/generator/annotations/AppIdParameter.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * The "app_id" path parameter shared by every route, kept in its own class
+ * (and file) on purpose: mixing a scalar `schema: new OA\Schema(...)` with
+ * the reusable Schema components in OpenApiSpec.php breaks their generation
+ * — see the note there.
+ */
+
+use OpenApi\Attributes as OA;
+
+#[OA\Parameter(
+    parameter: 'app_id',
+    name: 'app_id',
+    description: 'API application identifier, created under Administration > API. Selects which application (and therefore which security model and permission set) handles the request.',
+    in: 'path',
+    required: true,
+    schema: new OA\Schema(type: 'string', example: 'myapp')
+)]
+class AppIdParameter
+{
+}

--- a/public/api/docs/generator/annotations/OpenApiSpec.php
+++ b/public/api/docs/generator/annotations/OpenApiSpec.php
@@ -1,0 +1,205 @@
+<?php
+/**
+ * Global OpenAPI attributes for the phpIPAM REST API.
+ *
+ * This file is NOT executed by the application. It is only read by the
+ * swagger-php attribute scanner (public/api/docs/generator/generate.php) to
+ * build public/api/openapi.yaml. It exists purely as a container for
+ * #[OA\...] attributes that don't belong to any single controller (info,
+ * servers, security schemes, shared schemas).
+ *
+ * The shared "app_id" path parameter lives in AppIdParameter.php in this
+ * same directory, in its own class: co-locating it here (with its inline
+ * `schema: new OA\Schema(...)`) breaks the reusable Schema components below
+ * — a scalar (non-array) nested annotation object sharing this class's
+ * scan context corrupts sibling top-level components during generation.
+ */
+
+use OpenApi\Attributes as OA;
+
+#[OA\OpenApi(
+    security: [['ssl_token' => []], ['ssl_code' => []], ['crypt' => []]]
+)]
+#[OA\Info(
+    title: 'phpIPAM API',
+    version: '1.8',
+    description: 'REST API exposed by phpIPAM to manage sections, subnets, addresses, VLANs, VRFs, devices, circuits, NAT mappings and more. All routes are prefixed with /api/{app_id}/, where {app_id} is the API application name created in phpIPAM administration (Administration > API). Every application is bound to one of three security models (see the security schemes below): ssl_token, ssl_code, or crypt. Responses are always JSON objects of the form: code (HTTP status), success (boolean), data and message.',
+    contact: new OA\Contact(name: 'phpIPAM', url: 'https://phpipam.net')
+)]
+#[OA\Server(
+    url: '/api',
+    description: 'phpIPAM API root (path relative to the phpIPAM base install URL)'
+)]
+#[OA\SecurityScheme(
+    securityScheme: 'ssl_token',
+    type: 'apiKey',
+    in: 'header',
+    name: 'phpipam-token',
+    description: "Token-based authentication (app security = 'ssl_token', HTTPS required). Obtain a token by sending POST /api/{app_id}/user/ with HTTP Basic Authentication (a phpIPAM user/password with API permission on the app). The response contains data.token and data.expires. Send that token on every subsequent request in the phpipam-token header (an alias token header is also accepted). Refresh the expiration with PATCH /api/{app_id}/user/ and revoke it with DELETE /api/{app_id}/user/, both sent with the same header."
+)]
+#[OA\SecurityScheme(
+    securityScheme: 'ssl_code',
+    type: 'apiKey',
+    in: 'header',
+    name: 'phpipam-token',
+    description: "Static application-code authentication (app security = 'ssl_code', HTTPS required). No login step: the app's static app_code (set in Administration > API) is sent as-is in the phpipam-token header on every request. There is no token lifecycle — user/ GET is allowed, but POST/PATCH/DELETE on user/ are rejected with 409 since no per-session token exists."
+)]
+#[OA\SecurityScheme(
+    securityScheme: 'crypt',
+    type: 'apiKey',
+    in: 'query',
+    name: 'enc_request',
+    description: "Encrypted-body authentication (app security = 'crypt'). No phpipam-token header is used; instead the entire request payload (normally sent as JSON body or query string) is AES-encrypted (see Config api_crypt_encryption_library, default openssl-128-cbc) with the app's app_code as the password, base64-encoded, and sent as a single enc_request value (query string or POST body). The server decrypts it with the same app_code before processing the request as if the plaintext had been sent directly. Possessing a valid app_code is itself the authentication — there is no separate token."
+)]
+#[OA\SecurityScheme(
+    securityScheme: 'basicAuth',
+    type: 'http',
+    scheme: 'basic',
+    description: 'HTTP Basic Authentication, used once to log in via POST /user/ and obtain a phpipam-token (ssl_token security model only). Not used on any other route.'
+)]
+#[OA\Schema(
+    schema: 'ErrorResponse',
+    type: 'object',
+    properties: [
+        new OA\Property(property: 'code', type: 'integer', example: 400, description: 'HTTP status code, repeated in the body'),
+        new OA\Property(property: 'success', type: 'boolean', example: false),
+        new OA\Property(property: 'message', type: 'string', example: 'Missing parameters'),
+    ]
+)]
+#[OA\Schema(
+    schema: 'SuccessResponse',
+    type: 'object',
+    properties: [
+        new OA\Property(property: 'code', type: 'integer', example: 200),
+        new OA\Property(property: 'success', type: 'boolean', example: true),
+        new OA\Property(property: 'message', type: 'string', nullable: true, example: 'Subnet updated'),
+        new OA\Property(property: 'data', nullable: true, description: 'Payload, shape depends on the endpoint'),
+    ]
+)]
+#[OA\Schema(
+    schema: 'Section',
+    type: 'object',
+    properties: [
+        new OA\Property(property: 'id', type: 'integer', example: 1),
+        new OA\Property(property: 'name', type: 'string', example: 'Customers'),
+        new OA\Property(property: 'description', type: 'string', nullable: true),
+        new OA\Property(property: 'masterSection', type: 'integer', example: 0, description: 'Parent section id, 0 for a top-level section'),
+        new OA\Property(property: 'permissions', type: 'string', nullable: true, description: 'JSON-encoded map of groupId => permission level'),
+        new OA\Property(property: 'strictMode', type: 'boolean'),
+        new OA\Property(property: 'subnetOrdering', type: 'string', nullable: true),
+        new OA\Property(property: 'order', type: 'integer', nullable: true),
+        new OA\Property(property: 'showSubnet', type: 'boolean'),
+        new OA\Property(property: 'showVLAN', type: 'boolean'),
+        new OA\Property(property: 'showVRF', type: 'boolean'),
+        new OA\Property(property: 'showSupernetOnly', type: 'boolean'),
+        new OA\Property(property: 'DNS', type: 'string', nullable: true),
+    ]
+)]
+#[OA\Schema(
+    schema: 'Subnet',
+    type: 'object',
+    properties: [
+        new OA\Property(property: 'id', type: 'integer', example: 3),
+        new OA\Property(property: 'subnet', type: 'string', description: 'Network address, stored as decimal string (IPv4 or IPv6)', example: '168427776'),
+        new OA\Property(property: 'mask', type: 'string', example: '24'),
+        new OA\Property(property: 'sectionId', type: 'integer', example: 1),
+        new OA\Property(property: 'description', type: 'string', nullable: true),
+        new OA\Property(property: 'linked_subnet', type: 'integer', nullable: true),
+        new OA\Property(property: 'firewallAddressObject', type: 'string', nullable: true),
+        new OA\Property(property: 'vrfId', type: 'integer', nullable: true),
+        new OA\Property(property: 'masterSubnetId', type: 'integer', example: 0, description: '0 for a top-level subnet'),
+        new OA\Property(property: 'allowRequests', type: 'boolean'),
+        new OA\Property(property: 'vlanId', type: 'integer', nullable: true),
+        new OA\Property(property: 'showName', type: 'boolean'),
+        new OA\Property(property: 'device', type: 'integer', nullable: true),
+        new OA\Property(property: 'permissions', type: 'string', nullable: true, description: 'JSON-encoded map of groupId => permission level'),
+        new OA\Property(property: 'pingSubnet', type: 'boolean'),
+        new OA\Property(property: 'discoverSubnet', type: 'boolean'),
+        new OA\Property(property: 'resolveDNS', type: 'boolean'),
+        new OA\Property(property: 'DNSrecursive', type: 'boolean'),
+        new OA\Property(property: 'DNSrecords', type: 'boolean'),
+        new OA\Property(property: 'nameserverId', type: 'integer', nullable: true),
+        new OA\Property(property: 'scanAgent', type: 'integer', nullable: true),
+        new OA\Property(property: 'isFolder', type: 'boolean'),
+        new OA\Property(property: 'isFull', type: 'boolean'),
+        new OA\Property(property: 'isPool', type: 'boolean'),
+        new OA\Property(property: 'state', type: 'integer', nullable: true),
+        new OA\Property(property: 'threshold', type: 'integer', nullable: true),
+        new OA\Property(property: 'location', type: 'integer', nullable: true),
+        new OA\Property(property: 'editDate', type: 'string', format: 'date-time', nullable: true),
+    ]
+)]
+#[OA\Schema(
+    schema: 'Address',
+    type: 'object',
+    properties: [
+        new OA\Property(property: 'id', type: 'integer', example: 1),
+        new OA\Property(property: 'subnetId', type: 'integer', example: 3),
+        new OA\Property(property: 'ip_addr', type: 'string', description: 'Stored as decimal string; dotted/colon notation is used on input/output at the API boundary', example: '168427779'),
+        new OA\Property(property: 'is_gateway', type: 'boolean'),
+        new OA\Property(property: 'description', type: 'string', nullable: true),
+        new OA\Property(property: 'hostname', type: 'string', nullable: true),
+        new OA\Property(property: 'mac', type: 'string', nullable: true),
+        new OA\Property(property: 'owner', type: 'string', nullable: true),
+        new OA\Property(property: 'state', type: 'integer', nullable: true, description: 'Address status/tag id (Used, Offline, Reserved, DHCP...)'),
+        new OA\Property(property: 'switch', type: 'integer', nullable: true),
+        new OA\Property(property: 'location', type: 'integer', nullable: true),
+        new OA\Property(property: 'port', type: 'string', nullable: true),
+        new OA\Property(property: 'note', type: 'string', nullable: true),
+        new OA\Property(property: 'lastSeen', type: 'string', format: 'date-time', nullable: true),
+        new OA\Property(property: 'excludePing', type: 'boolean'),
+        new OA\Property(property: 'PTRignore', type: 'boolean'),
+        new OA\Property(property: 'PTR', type: 'integer', nullable: true),
+        new OA\Property(property: 'firewallAddressObject', type: 'string', nullable: true),
+        new OA\Property(property: 'editDate', type: 'string', format: 'date-time', nullable: true),
+    ]
+)]
+#[OA\Schema(
+    schema: 'Vlan',
+    type: 'object',
+    properties: [
+        new OA\Property(property: 'vlanId', type: 'integer', example: 1),
+        new OA\Property(property: 'domainId', type: 'integer', example: 1, description: 'L2 domain id (see l2domains controller)'),
+        new OA\Property(property: 'name', type: 'string', example: 'Servers DMZ'),
+        new OA\Property(property: 'number', type: 'integer', example: 4001),
+        new OA\Property(property: 'description', type: 'string', nullable: true),
+        new OA\Property(property: 'editDate', type: 'string', format: 'date-time', nullable: true),
+    ]
+)]
+#[OA\Schema(
+    schema: 'Vrf',
+    type: 'object',
+    properties: [
+        new OA\Property(property: 'vrfId', type: 'integer', example: 1),
+        new OA\Property(property: 'name', type: 'string', example: 'Customer-A'),
+        new OA\Property(property: 'rd', type: 'string', nullable: true, description: 'Route distinguisher'),
+        new OA\Property(property: 'description', type: 'string', nullable: true),
+        new OA\Property(property: 'sections', type: 'string', nullable: true, description: 'Comma-separated list of section ids this VRF is restricted to'),
+        new OA\Property(property: 'editDate', type: 'string', format: 'date-time', nullable: true),
+    ]
+)]
+#[OA\Schema(
+    schema: 'Device',
+    type: 'object',
+    properties: [
+        new OA\Property(property: 'id', type: 'integer', example: 1),
+        new OA\Property(property: 'hostname', type: 'string', nullable: true),
+        new OA\Property(property: 'ip_addr', type: 'string', nullable: true),
+        new OA\Property(property: 'type', type: 'integer', description: 'Device type id, see tools/deviceTypes'),
+        new OA\Property(property: 'description', type: 'string', nullable: true),
+        new OA\Property(property: 'sections', type: 'string', nullable: true, description: 'Comma-separated list of section ids'),
+        new OA\Property(property: 'snmp_community', type: 'string', nullable: true),
+        new OA\Property(property: 'snmp_version', type: 'string', nullable: true, enum: ['0', '1', '2', '3']),
+        new OA\Property(property: 'snmp_port', type: 'integer', nullable: true),
+        new OA\Property(property: 'snmp_timeout', type: 'integer', nullable: true),
+        new OA\Property(property: 'snmp_queries', type: 'string', nullable: true),
+        new OA\Property(property: 'rack', type: 'integer', nullable: true),
+        new OA\Property(property: 'rack_start', type: 'integer', nullable: true),
+        new OA\Property(property: 'rack_size', type: 'integer', nullable: true),
+        new OA\Property(property: 'location', type: 'integer', nullable: true),
+        new OA\Property(property: 'editDate', type: 'string', format: 'date-time', nullable: true),
+    ]
+)]
+class OpenApiSpec
+{
+}

--- a/public/api/docs/generator/generate.php
+++ b/public/api/docs/generator/generate.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * Regenerates public/api/openapi.yaml from the #[OA\...] attributes found on
+ * public/api/controllers/*.php and public/api/docs/generator/annotations/*.php.
+ *
+ * Dev/build-time only script, never executed by the running application.
+ * swagger-php's generator uses PHP Reflection, so the target classes must be
+ * loaded (require'd) before scanning — they are never instantiated here.
+ *
+ * Usage:
+ *   composer install
+ *   php public/api/docs/generator/generate.php
+ */
+
+$root = dirname(__DIR__, 4);
+
+$autoload = $root.'/vendor/autoload.php';
+if (!is_file($autoload)) {
+    fwrite(STDERR, "Composer dependencies are not installed.\nRun: composer install\n");
+    exit(1);
+}
+require $autoload;
+
+require $root.'/functions/version.php';
+
+// Load the class hierarchy the controllers depend on, without running the
+// app bootstrap (no config, no DB, no session).
+require $root.'/functions/classes/class.Params.php';
+require $root.'/functions/classes/class.Result.php';
+require $root.'/public/api/controllers/Common.php';
+
+$controllerFiles = [
+    'Sections.php',
+    'Subnets.php',
+    'Addresses.php',
+    'Vlans.php',
+    'Vrfs.php',
+    'L2domains.php',
+    'Devices.php',
+    'Circuits.php',
+    'Nat.php',
+    'Prefix.php',
+    'Tools.php',
+    'Search.php',
+    'User.php',
+];
+
+$sources = [];
+foreach (['OpenApiSpec.php', 'AppIdParameter.php'] as $file) {
+    $path = __DIR__.'/annotations/'.$file;
+    require $path;
+    $sources[] = $path;
+}
+foreach ($controllerFiles as $file) {
+    $path = $root.'/public/api/controllers/'.$file;
+    require $path;
+    $sources[] = $path;
+}
+
+$openapi = (new \OpenApi\Generator())->generate($sources);
+
+if ($openapi === null) {
+    fwrite(STDERR, "No OpenAPI annotations found, aborting.\n");
+    exit(1);
+}
+
+$openapi->info->version = VERSION_VISIBLE;
+
+$outputFile = $root.'/public/api/openapi.yaml';
+file_put_contents($outputFile, $openapi->toYaml());
+
+echo "Generated $outputFile\n";

--- a/public/api/docs/index.html
+++ b/public/api/docs/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+<head>
+	<meta charset="utf-8" />
+	<title>phpIPAM API reference</title>
+	<meta name="viewport" content="width=device-width, initial-scale=1" />
+</head>
+<body>
+	<script id="api-reference" data-url="../openapi.yaml"></script>
+	<script src="https://cdn.jsdelivr.net/npm/@scalar/api-reference"></script>
+</body>
+</html>

--- a/public/api/openapi.yaml
+++ b/public/api/openapi.yaml
@@ -1,0 +1,7735 @@
+openapi: 3.0.0
+info:
+  title: 'phpIPAM API'
+  description: 'REST API exposed by phpIPAM to manage sections, subnets, addresses, VLANs, VRFs, devices, circuits, NAT mappings and more. All routes are prefixed with /api/{app_id}/, where {app_id} is the API application name created in phpIPAM administration (Administration > API). Every application is bound to one of three security models (see the security schemes below): ssl_token, ssl_code, or crypt. Responses are always JSON objects of the form: code (HTTP status), success (boolean), data and message.'
+  contact:
+    name: phpIPAM
+    url: 'https://phpipam.net'
+  version: 1.9.0
+servers:
+  -
+    url: /api
+    description: 'phpIPAM API root (path relative to the phpIPAM base install URL)'
+paths:
+  '/{app_id}/sections/':
+    get:
+      tags:
+        - sections
+      summary: 'List all sections'
+      description: "GET sections functions\n\n\tID can be:\n     - /                     // returns all sections\n\t\t- /{id}/                // returns section details\n\t\t- /{id}/subnets/\t\t// returns all subnets in this section\n\t\t- /{id}/subnets/addresses/ // returns all subnets in this section + addresses\n\t\t- /{name}/subnets/\t\t// returns all subnets in this named section\n\t\t- /{name}/ \t\t\t\t// section name\n\n\tIf no ID is provided all sections are returned"
+      operationId: f59e1f9eebe3988827b0758a176ea2c6
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+      responses:
+        '200':
+          description: 'OK, or no sections available'
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Section'
+    post:
+      tags:
+        - sections
+      summary: 'Create a new section'
+      description: 'Creates new section'
+      operationId: 3022d33b52efecdb29b29b5f5e7f9103
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              required:
+                - name
+              properties:
+                name:
+                  description: 'Minimum 3 characters'
+                  type: string
+                  example: Customers
+                description:
+                  type: string
+                masterSection:
+                  description: 'Parent section id. Only 1 level of nesting is permitted (parent must itself be a top-level section)'
+                  type: integer
+                  example: 0
+                permissions:
+                  description: 'JSON-encoded map of groupId => permission level'
+                  type: string
+                strictMode:
+                  type: boolean
+                subnetOrdering:
+                  type: string
+                order:
+                  type: integer
+                showSubnet:
+                  type: boolean
+                showVLAN:
+                  type: boolean
+                showVRF:
+                  type: boolean
+                showSupernetOnly:
+                  type: boolean
+                DNS:
+                  type: string
+              type: object
+      responses:
+        '201':
+          description: 'Section created'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse'
+        '400':
+          description: 'Name is mandatory or too short (minimum 3 characters), or invalid masterSection id, or nesting more than 1 level deep'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: 'Section create failed'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+    options:
+      tags:
+        - sections
+      summary: 'Discover supported sections routes/methods (HATEOAS)'
+      description: 'Returns json encoded options and version'
+      operationId: a640dca5317e8e5f913da378def0a6fc
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+      responses:
+        '200':
+          description: OK
+  '/{app_id}/sections/{id}/':
+    get:
+      tags:
+        - sections
+      summary: 'Read a single section by numeric id'
+      operationId: aa3962efda3cbe4963f64d57dce911a2
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+        -
+          name: id
+          in: path
+          description: 'Section id'
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Section'
+        '404':
+          description: 'Section does not exist'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+    delete:
+      tags:
+        - sections
+      summary: 'Delete a section, along with its subnets and addresses'
+      description: 'Deletes existing section along with subnets and addresses'
+      operationId: ee9fb2ee4354081e5310f16f14114604
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+        -
+          name: id
+          in: path
+          description: 'Section id'
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: 'Section deleted'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse'
+        '400':
+          description: 'Section Id required'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: 'Section does not exist'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: 'Section delete failed'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+    patch:
+      tags:
+        - sections
+      summary: 'Update a section'
+      description: 'Updates existing section'
+      operationId: 375cb2cca8048e0eb6675dc049143853
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+        -
+          name: id
+          in: path
+          description: 'Section id'
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                name:
+                  description: 'Minimum 3 characters'
+                  type: string
+                description:
+                  type: string
+                masterSection:
+                  type: integer
+                permissions:
+                  description: 'JSON-encoded map of groupId => permission level'
+                  type: string
+                strictMode:
+                  type: boolean
+                subnetOrdering:
+                  type: string
+                order:
+                  type: integer
+                showSubnet:
+                  type: boolean
+                showVLAN:
+                  type: boolean
+                showVRF:
+                  type: boolean
+                showSupernetOnly:
+                  type: boolean
+                DNS:
+                  type: string
+              type: object
+      responses:
+        '200':
+          description: 'Section updated'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse'
+        '400':
+          description: 'Section Id required'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: 'Section does not exist'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: 'Section update failed'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  '/{app_id}/sections/{name}/':
+    get:
+      tags:
+        - sections
+      summary: 'Read a single section by name'
+      operationId: 257e9d495bca97a4bd136a9e475d17d5
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+        -
+          name: name
+          in: path
+          description: 'Section name'
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Section'
+        '404':
+          description: 'Section does not exist'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  '/{app_id}/sections/custom_fields/':
+    get:
+      tags:
+        - sections
+      summary: 'Custom fields on sections (not supported)'
+      operationId: 3cc311be443dc590b254dd1a8818a9a8
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+      responses:
+        '409':
+          description: 'Custom fields not supported'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  '/{app_id}/sections/{id}/subnets/':
+    get:
+      tags:
+        - sections
+      summary: 'List all subnets in a section'
+      operationId: 871a0163cbcedb6a638168182cc001f7
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+        -
+          name: id
+          in: path
+          description: 'Section id'
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Subnet'
+        '404':
+          description: 'No subnets found'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  '/{app_id}/sections/{id}/subnets/addresses/':
+    get:
+      tags:
+        - sections
+      summary: 'List all subnets in a section, including their addresses'
+      operationId: 67f24846f56fcac6c3de79243af1c0f6
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+        -
+          name: id
+          in: path
+          description: 'Section id'
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Subnet'
+        '404':
+          description: 'No subnets found'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  '/{app_id}/sections/{id}/changelog/':
+    get:
+      tags:
+        - sections
+      summary: 'Get the change log for a section'
+      operationId: b491ea23a0e9c20113500b11bd2a1ed4
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+        -
+          name: id
+          in: path
+          description: 'Section id'
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: OK
+        '404':
+          description: 'No changelogs found'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  '/{app_id}/subnets/':
+    get:
+      tags:
+        - subnets
+      summary: 'List all subnets (all sections)'
+      description: "Reads subnet functions\n\n\tIdentifier can be:\n\t\t- /\t\t\t\t\t\t\t\t// returns all subnets in all sections\n\t\t- /{id}/\n\t\t- /custom_fields/\t\t\t\t// returns custom fields\n\t\t- /cidr/{subnet}/\t\t\t\t// subnets in CIDR format\n\t\t- /search/{subnet}/\t\t\t\t// subnets in CIDR format (same as above)\n\t\t- /overlaping/{subnet}/\t\t\t// returns all overlapping subnets\n\t\t- /{id}/usage/\t\t\t\t    // returns subnet usage\n\t\t- /{id}/slaves/ \t\t\t    // returns all immediate slave subnets\n\t\t- /{id}/slaves_recursive/ \t    // returns all slave subnets recursively\n\t\t- /{id}/addresses/\t\t\t    // returns all IP addresses in subnet\n     - /{id}/addresses/{ip}/         // returns IP address from subnet\n\t\t- /{id}/first_free/\t\t\t    // returns first free address in subnet\n     - /{id}/first_subnet/{mask}/    // returns first available subnets with specified mask\n     - /{id}/last_subnet/{mask}/     // returns last available subnets with specified mask\n     - /{id}/all_subnets/{mask}/     // returns all available subnets with specified mask\n     - /{id}/changelog/     \t\t\t// returns changelog\n\t\t- /all/\t\t\t\t\t\t\t// returns all subnets in all sections"
+      operationId: 402ea3eebcdf31a563a0296133a672b7
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Subnet'
+        '500':
+          description: 'Unable to read subnets'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+    post:
+      tags:
+        - subnets
+      summary: 'Create a new subnet (or folder)'
+      description: 'Set isFolder=1 to create a folder instead of a real subnet (subnet/mask are then ignored).'
+      operationId: 5f7c363127a056d6a16cb745295f1889
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              required:
+                - sectionId
+              properties:
+                subnet:
+                  description: 'Required unless isFolder=1'
+                  type: string
+                  example: 192.168.1.0
+                mask:
+                  description: 'Required unless isFolder=1'
+                  type: string
+                  example: '24'
+                sectionId:
+                  type: integer
+                  example: 1
+                description:
+                  type: string
+                masterSubnetId:
+                  type: integer
+                  example: 0
+                vlanId:
+                  type: integer
+                vrfId:
+                  type: integer
+                isFolder:
+                  type: boolean
+                  example: false
+                permissions:
+                  type: string
+              type: object
+      responses:
+        '201':
+          description: 'Subnet created'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse'
+        '400':
+          description: 'Invalid parameters'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '409':
+          description: 'Overlapping/out of boundaries'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+    options:
+      tags:
+        - subnets
+      summary: 'Discover supported subnets routes/methods (HATEOAS)'
+      description: 'Returns json encoded options'
+      operationId: a990e5c78709222279eb728798cd6181
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+      responses:
+        '200':
+          description: OK
+  '/{app_id}/subnets/{id}/first_subnet/{mask}/':
+    get:
+      tags:
+        - subnets
+      summary: 'Get the first free subnet of the given mask under master subnet {id} (read-only, does not create it)'
+      operationId: ff6f7793ada93ff061b24d4fee1da400
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+        -
+          name: id
+          in: path
+          description: 'Master subnet id'
+          required: true
+          schema:
+            type: integer
+        -
+          name: mask
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: string
+        '404':
+          description: 'No subnets found'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+    post:
+      tags:
+        - subnets
+      summary: 'Create the first free subnet with the given mask under master subnet {id}'
+      operationId: 5f956475e9ccd7d119606f6e983fd3db
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+        -
+          name: id
+          in: path
+          description: 'Master subnet id'
+          required: true
+          schema:
+            type: integer
+        -
+          name: mask
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '201':
+          description: 'Subnet created'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse'
+        '404':
+          description: 'No free subnet found'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  '/{app_id}/subnets/{id}/last_subnet/{mask}/':
+    get:
+      tags:
+        - subnets
+      summary: 'Get the last free subnet of the given mask under master subnet {id} (read-only, does not create it)'
+      operationId: 4e062aa8d06173aa41aa0b4d543ac1a2
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+        -
+          name: id
+          in: path
+          description: 'Master subnet id'
+          required: true
+          schema:
+            type: integer
+        -
+          name: mask
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: string
+        '404':
+          description: 'No subnets found'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+    post:
+      tags:
+        - subnets
+      summary: 'Create the last free subnet with the given mask under master subnet {id}'
+      operationId: 59662010d93efec5651be8014dee75ab
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+        -
+          name: id
+          in: path
+          description: 'Master subnet id'
+          required: true
+          schema:
+            type: integer
+        -
+          name: mask
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '201':
+          description: 'Subnet created'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse'
+        '404':
+          description: 'No free subnet found'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  '/{app_id}/subnets/{id}/':
+    get:
+      tags:
+        - subnets
+      summary: 'Read a single subnet by id'
+      operationId: 18640a08dfe716e2b26c29e43de2f822
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Subnet'
+        '400':
+          description: 'Invalid subnet id'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+    delete:
+      tags:
+        - subnets
+      summary: 'Delete a subnet, along with its addresses'
+      description: "Deletes existing subnet along with and addresses\n\n\trequired params : id\n\n\tif id2 is present than execute:\n\t\t- {id}/truncate/\n\t\t- {id}/permissions/"
+      operationId: 786caf69659ae12f05b1897d2c35728e
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: 'Subnet deleted'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse'
+        '500':
+          description: 'Failed to delete subnet'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+    patch:
+      tags:
+        - subnets
+      summary: 'Update a subnet (subnet/mask cannot be changed here, use resize)'
+      description: "Updates existing subnet\n\n\trequired params : id\n\tforbidden params : subnet, mask\n\n\tif id2 is present than execute:\n\t\t- {id}/resize/\n\t\t- {id}/split/\n     - {id}/permissions/               // changes permissions (?3=2&41=1 || ?groupname1=3&groupname2=1) 0=na, 1=ro, 2=rw, 3=rwa"
+      operationId: 0970f8622caf2f70a81a0a5b06d371a0
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                description:
+                  type: string
+                sectionId:
+                  type: integer
+                vlanId:
+                  type: integer
+                vrfId:
+                  type: integer
+              type: object
+      responses:
+        '200':
+          description: 'Subnet updated'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse'
+        '400':
+          description: 'Subnet/mask cannot be changed'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  '/{app_id}/subnets/custom_fields/':
+    get:
+      tags:
+        - subnets
+      summary: 'List custom fields defined on the subnets table'
+      operationId: 407245a62daccb32acaf61706deb71e2
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+      responses:
+        '200':
+          description: OK
+        '404':
+          description: 'No custom fields defined'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  '/{app_id}/subnets/cidr/{subnet}/':
+    get:
+      tags:
+        - subnets
+      summary: 'Search subnets by CIDR network address (alias: /subnets/search/{subnet}/)'
+      operationId: 22ce097908d6afaded921078b3d6453c
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+        -
+          name: subnet
+          in: path
+          description: 'Network address (dotted/colon notation)'
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Subnet'
+        '404':
+          description: 'No subnets found'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  '/{app_id}/subnets/overlapping/{subnet}/{mask}/':
+    get:
+      tags:
+        - subnets
+      summary: 'Search subnets overlapping a given network/mask (IPv4 & IPv6)'
+      operationId: d5136981341d396e4e6798b716f112fc
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+        -
+          name: subnet
+          in: path
+          required: true
+          schema:
+            type: string
+        -
+          name: mask
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Subnet'
+        '404':
+          description: 'No subnets found'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  '/{app_id}/subnets/{id}/addresses/':
+    get:
+      tags:
+        - subnets
+      summary: 'List all addresses in a subnet (optionally filtered to a single {ip} via id3)'
+      operationId: 3e6bdade1df9dd855bedcab817d47d8e
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Address'
+        '404':
+          description: 'No addresses found'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  '/{app_id}/subnets/{id}/slaves/':
+    get:
+      tags:
+        - subnets
+      summary: 'List immediate slave subnets'
+      operationId: 4c6086b6af7b41291e575ac819674c71
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Subnet'
+        '404':
+          description: 'No slaves'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  '/{app_id}/subnets/{id}/slaves_recursive/':
+    get:
+      tags:
+        - subnets
+      summary: 'List all slave subnets recursively'
+      operationId: eda4b4afad20d36673f7b93e8cf3a7a4
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Subnet'
+        '404':
+          description: 'No slaves'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  '/{app_id}/subnets/{id}/usage/':
+    get:
+      tags:
+        - subnets
+      summary: 'Get subnet usage statistics (free/used/offline counts, percentage)'
+      operationId: 456db27dc932e06c360182875e13cdc1
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: OK
+  '/{app_id}/subnets/{id}/first_free/':
+    get:
+      tags:
+        - subnets
+      summary: 'Get the first free address in a subnet'
+      operationId: 31f4c2bbca83be074d4308677d4869e2
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: string
+              example: 192.168.1.5
+        '404':
+          description: 'No free addresses found'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '409':
+          description: 'Subnet contains subnets'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  '/{app_id}/subnets/{id}/all_subnets/{mask}/':
+    get:
+      tags:
+        - subnets
+      summary: 'List all free subnets of the given mask under master subnet {id}'
+      operationId: 26e1c6824e9b62987efa0733051e3766
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+        -
+          name: id
+          in: path
+          description: 'Master subnet id'
+          required: true
+          schema:
+            type: integer
+        -
+          name: mask
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: string
+        '404':
+          description: 'No subnets found'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  '/{app_id}/subnets/{id}/changelog/':
+    get:
+      tags:
+        - subnets
+      summary: 'Get the change log for a subnet'
+      operationId: 635f2c84aa494398fa476692f54ed3fc
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: OK
+        '404':
+          description: 'No changelogs found'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  '/{app_id}/subnets/{id}/resize/':
+    patch:
+      tags:
+        - subnets
+      summary: 'Resize a subnet to a new mask'
+      operationId: d9bd1b33bc8a6b7c3c337db88d9b78c9
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              required:
+                - mask
+              properties:
+                mask:
+                  type: string
+                  example: '25'
+              type: object
+      responses:
+        '200':
+          description: 'Subnet resized'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse'
+        '400':
+          description: 'Subnet mask not provided'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '409':
+          description: 'Resize would break nesting/overlap rules'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  '/{app_id}/subnets/{id}/split/':
+    patch:
+      tags:
+        - subnets
+      summary: 'Split a subnet into multiple smaller subnets, moving existing addresses'
+      operationId: a67378a09361dc45d5536876c56e035d
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              required:
+                - number
+              properties:
+                number:
+                  description: 'Number of new subnets to split into'
+                  type: integer
+                  example: 4
+                group:
+                  type: string
+                  default: 'yes'
+                  enum: ['yes', 'no']
+                prefix:
+                  description: 'Optional name prefix for created subnets'
+                  type: string
+                copy_custom:
+                  type: string
+                  default: 'yes'
+                  enum: ['yes', 'no']
+              type: object
+      responses:
+        '200':
+          description: 'Subnet split'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse'
+        '400':
+          description: 'Invalid number of new subnets'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  '/{app_id}/subnets/{id}/permissions/':
+    delete:
+      tags:
+        - subnets
+      summary: 'Remove all custom permissions from a subnet'
+      operationId: 295069877908d908e8e6ad541a743477
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: 'Subnet permissions removed'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse'
+    patch:
+      tags:
+        - subnets
+      summary: 'Change subnet permissions (map of groupId/groupName to permission level)'
+      description: '0=no access, 1=read-only, 2=read-write, 3=read-write-add. Body keys are group ids or names, values are permission levels or names.'
+      operationId: f5fb1a2e0e0aa99c238f0412e7af17ed
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties: true
+            example:
+              '3': '2'
+              '2': '1'
+      responses:
+        '200':
+          description: 'Subnet permissions updated'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse'
+        '500':
+          description: 'Invalid group/permission'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  '/{app_id}/subnets/{id}/truncate/':
+    delete:
+      tags:
+        - subnets
+      summary: 'Delete all addresses in a subnet, keeping the subnet itself'
+      operationId: 503d62c2954195e0572880151650b016
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: 'Subnet truncated'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse'
+  '/{app_id}/addresses/':
+    get:
+      tags:
+        - addresses
+      summary: 'List all addresses (all subnets)'
+      description: "Read address functions\n\n\tidentifiers can be:\n\t\t- /\t\t\t\t\t\t\t\t             // returns all addresses in all sections\n\t\t- /addresses/{id}/\n\t\t- /addresses/{id}/ping/\t\t\t\t\t     // pings address\n     - /addresses/{ip}/{subnetId}/                // Returns address from subnet\n\t\t- /addresses/search/{ip_address}/\t\t\t // searches for addresses in database, returns multiple if found\n\t\t- /addresses/search_hostname/{hostname}/     // searches for addresses in database by hostname, returns multiple if found\n\t\t- /addresses/search_linked/{value}/          // searches in database for addresses linked by customer defined \"Link addresses\" field, returns multiple if found\n\t\t- /addresses/search_hostbase/{hostbase}/     // searches for addresses by leading substring (base) of hostname, returns ordered multiple\n\t\t- /addresses/search_mac/{mac}/   \t\t     // searches for addresses by mac, returns ordered multiple\n     - /addresses/first_free/{subnetId}/          // returns first available address (subnetId can be provided with parameters)\n\t\t- /addresses/custom_fields/                  // custom fields\n\t\t- /addresses/tags/\t\t\t\t\t\t     // all tags\n\t\t- /addresses/tags/{id}/\t\t\t\t\t     // specific tag\n\t\t- /addresses/tags/{id}/addresses/\t\t\t // returns all addresses that are tagged with this tag ***if subnetId is provided it will be filtered to specific subnet\n\t\t- /all/\t\t\t\t\t\t\t             // returns all addresses in all sections"
+      operationId: a8f4987d72f314ff324b6efcf0fb4c30
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Address'
+        '500':
+          description: 'Unable to read addresses'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+    post:
+      tags:
+        - addresses
+      summary: 'Create a new address'
+      description: "Creates new address\n\n  /addresses/                            // create ip_addr in subnet (required parameters: ip, subnetId)\n  /addresses/first_free/{subnetId}/      // will search for first free address in subnet, creating ip_addr"
+      operationId: e6c497ac81c3f677db2d950f466e663f
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              required:
+                - ip_addr
+                - subnetId
+              properties:
+                ip_addr:
+                  type: string
+                  example: 192.168.1.10
+                subnetId:
+                  type: integer
+                  example: 3
+                hostname:
+                  type: string
+                description:
+                  type: string
+                mac:
+                  type: string
+                owner:
+                  type: string
+                state:
+                  description: 'IP tag id, defaults to 2 (Used)'
+                  type: integer
+              type: object
+      responses:
+        '201':
+          description: 'Address created'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse'
+        '400':
+          description: 'Invalid parameters'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '409':
+          description: 'IP address already exists'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+    options:
+      tags:
+        - addresses
+      summary: 'Discover supported addresses routes/methods (HATEOAS)'
+      description: 'Returns json encoded options'
+      operationId: 0b347b0ab1231fd5d4ea2d2460ec0ffd
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+      responses:
+        '200':
+          description: OK
+  '/{app_id}/addresses/{id}/':
+    get:
+      tags:
+        - addresses
+      summary: 'Read a single address by id'
+      operationId: 93f7597f749a63ae106478e357907f68
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Address'
+        '404':
+          description: 'Invalid id'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+    delete:
+      tags:
+        - addresses
+      summary: 'Delete an address by id'
+      description: "Deletes existing address\n\n\trequired parameters: id\n\n\tidentifiers can be:\n\n     /addresses/{id}                            // Returns address by id\n     /addresses/{ip}/{subnetId}/                // Deletes address from subnet by ip"
+      operationId: 266db92e1ed3a1e5a641b0f7d839414e
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+        -
+          name: remove_dns
+          in: query
+          description: 'If set, also removes any associated PowerDNS PTR record'
+          required: false
+          schema:
+            type: integer
+            enum:
+              - 0
+              - 1
+      responses:
+        '200':
+          description: 'Address deleted'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse'
+        '500':
+          description: 'Failed to delete address'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+    patch:
+      tags:
+        - addresses
+      summary: 'Update an address (ip/subnetId cannot be changed)'
+      description: "Updates existing address\n\n\tforbidden parameters: ip, subnetId"
+      operationId: 5d8834747adff72ff78228723ff104c4
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                hostname:
+                  type: string
+                description:
+                  type: string
+                mac:
+                  type: string
+                owner:
+                  type: string
+                state:
+                  type: integer
+              type: object
+      responses:
+        '200':
+          description: 'Address updated'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse'
+        '400':
+          description: 'IP/subnet cannot be changed, or no data provided'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  '/{app_id}/addresses/custom_fields/':
+    get:
+      tags:
+        - addresses
+      summary: 'List custom fields defined on the ipaddresses table'
+      operationId: 07e4bfd51971d677d37e83e2ef0cd93a
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+      responses:
+        '200':
+          description: OK
+        '404':
+          description: 'No custom fields defined'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  '/{app_id}/addresses/first_free/{subnetId}/':
+    get:
+      tags:
+        - addresses
+      summary: 'Get the first free address in a subnet (does not reserve it)'
+      operationId: f0b12e438390a5c108fd04fb18376529
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+        -
+          name: subnetId
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: string
+              example: 192.168.1.5
+        '404':
+          description: 'No free addresses found'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+    post:
+      tags:
+        - addresses
+      summary: 'Create an address using the first free IP in a subnet'
+      operationId: de49ffc03c905464f8709461c5a45792
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+        -
+          name: subnetId
+          in: path
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                hostname:
+                  type: string
+                description:
+                  type: string
+              type: object
+      responses:
+        '201':
+          description: 'Address created'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse'
+        '404':
+          description: 'No free addresses found'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  '/{app_id}/addresses/{ip}/{subnetId}/':
+    get:
+      tags:
+        - addresses
+      summary: 'Read an address by IP within a given subnet'
+      operationId: b0d0213dda137a04c05483c621c7af70
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+        -
+          name: ip
+          in: path
+          required: true
+          schema:
+            type: string
+          example: 192.168.1.5
+        -
+          name: subnetId
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Address'
+        '404':
+          description: 'No addresses found'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+    delete:
+      tags:
+        - addresses
+      summary: 'Delete an address by IP within a given subnet'
+      operationId: a3e0ceb71e43b8dbd58355ea4f93e4d4
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+        -
+          name: ip
+          in: path
+          required: true
+          schema:
+            type: string
+        -
+          name: subnetId
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: 'Address deleted'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse'
+        '404':
+          description: 'No addresses found'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  '/{app_id}/addresses/tags/':
+    get:
+      tags:
+        - addresses
+      summary: 'List all IP tags'
+      operationId: 5f3a12556d93ba09a3a4a75628ff6838
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+      responses:
+        '200':
+          description: OK
+        '404':
+          description: 'Tag not found'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  '/{app_id}/addresses/tags/{id}/':
+    get:
+      tags:
+        - addresses
+      summary: 'Read a single IP tag by id or type'
+      operationId: c40ffe11c09ec57644f8bec6343a9ffc
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+        -
+          name: id
+          in: path
+          description: 'Tag id (numeric) or type'
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
+        '404':
+          description: 'Tag not found'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  '/{app_id}/addresses/tags/{id}/addresses/':
+    get:
+      tags:
+        - addresses
+      summary: 'List all addresses tagged with the given tag/state, optionally filtered by subnetId'
+      operationId: f671ecb1c72d518218033ef92986913f
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+        -
+          name: id
+          in: path
+          description: 'Tag/state id'
+          required: true
+          schema:
+            type: integer
+        -
+          name: subnetId
+          in: query
+          required: false
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Address'
+        '404':
+          description: 'No addresses found'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  '/{app_id}/addresses/search_linked/{value}/':
+    get:
+      tags:
+        - addresses
+      summary: 'Search addresses by the custom Link addresses field value'
+      operationId: f8c3dab7b49f3c8caf25a01100f8ba74
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+        -
+          name: value
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Address'
+        '404':
+          description: 'No addresses found'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  '/{app_id}/addresses/{id}/ping/':
+    get:
+      tags:
+        - addresses
+      summary: 'Ping an address and update its last-seen date on success'
+      operationId: 01e2cd97965fea530ef25ec2736615d3
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                properties:
+                  scan_type: { type: string }
+                  exit_code: { type: integer }
+                  result_code: { type: string }
+                  message: { type: string, example: 'Address online' }
+                type: object
+        '404':
+          description: 'Address does not exist'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  '/{app_id}/addresses/{id}/changelog/':
+    get:
+      tags:
+        - addresses
+      summary: 'Get the change log for an address'
+      operationId: 9beb8efe2fadded6e7aeadf28f0ef138
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: OK
+        '404':
+          description: 'No changelogs found'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  '/{app_id}/addresses/search/{ip}/':
+    get:
+      tags:
+        - addresses
+      summary: 'Search addresses by exact IP (across all subnets)'
+      operationId: 73175d8a340a108479b86f616bb930fb
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+        -
+          name: ip
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Address'
+        '404':
+          description: 'Address not found'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  '/{app_id}/addresses/search_hostname/{hostname}/':
+    get:
+      tags:
+        - addresses
+      summary: 'Search addresses by exact hostname'
+      operationId: a41b3e66f0b556b7e4fbbc83da1b4efb
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+        -
+          name: hostname
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Address'
+        '404':
+          description: 'Hostname not found'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  '/{app_id}/addresses/search_hostbase/{hostbase}/':
+    get:
+      tags:
+        - addresses
+      summary: 'Search addresses by leading substring of hostname, sorted by name'
+      operationId: 25375096965576a30cef7820682485f1
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+        -
+          name: hostbase
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Address'
+        '404':
+          description: 'Host name not found'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  '/{app_id}/addresses/search_mac/{mac}/':
+    get:
+      tags:
+        - addresses
+      summary: 'Search addresses by MAC address'
+      operationId: bbb97f116932a56be0ff3b267e4dbb1f
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+        -
+          name: mac
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Address'
+        '404':
+          description: 'Host name not found'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  '/{app_id}/vlans/':
+    get:
+      tags:
+        - vlans
+      summary: 'List all VLANs (alias: /vlans/all/)'
+      description: "Read vlan/domain functions\n\nparameters:\n     - /                             returns all vlans\n\t\t- /{id}/                        returns vlan details\n\t\t- /{id}/subnets/\t\t\t\treturns subnets belonging to this VLAN\n\t\t- /{id}/subnets/{sectionId}/\treturns subnets belonging to this VLAN inside one section\n\t\t- /custom_fields/\t\t\t    returns custom fields\n\t\t- /search/{number}/\t\t\t    returns all vlans with specified number\n     - /all/                         returns all vlans"
+      operationId: 648d93d19cbec83c73f02bf51fb0085e
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Vlan'
+        '404':
+          description: 'No vlans configured'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+    post:
+      tags:
+        - vlans
+      summary: 'Create a new VLAN'
+      description: 'Creates new vlan'
+      operationId: 04b38b712cd4513cda9313fc7f3f9774
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              required:
+                - name
+                - number
+              properties:
+                domainId:
+                  description: 'L2 domain id, defaults to 1'
+                  type: integer
+                  example: 1
+                name:
+                  type: string
+                number:
+                  type: integer
+                description:
+                  type: string
+                customer_id:
+                  type: integer
+              type: object
+      responses:
+        '201':
+          description: 'Vlan created'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse'
+        '400':
+          description: 'Invalid domain id / Vlan name is required / Vlan number must be number / Vlan number cannot be negative'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '409':
+          description: 'Vlan already exists / Highest possible VLAN number exceeded'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: 'Vlan creation failed / Highest possible VLAN number exceeded'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+    options:
+      tags:
+        - vlans
+      summary: 'Discover supported vlans routes/methods (HATEOAS)'
+      description: 'Returns json encoded options'
+      operationId: 3f29b62f58f8ea7f5f9c8e9a734d7bd0
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+      responses:
+        '200':
+          description: OK
+  '/{app_id}/vlans/{id}/':
+    get:
+      tags:
+        - vlans
+      summary: 'Read a single VLAN by id'
+      operationId: e0f884190b2e47c34bcd9bf253e8b3ce
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Vlan'
+        '404':
+          description: 'Vlan not found'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+    delete:
+      tags:
+        - vlans
+      summary: 'Delete a VLAN, removing references from any subnets that use it'
+      description: 'Deletes existing vlan'
+      operationId: 7e8606134454326b2dcabf24aa668908
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: 'Vlan deleted'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse'
+        '400':
+          description: 'Vlan Id is required / Vlan Id must be numeric'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: 'Invalid Vlan id'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: 'Vlan delete failed'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+    patch:
+      tags:
+        - vlans
+      summary: 'Update an existing VLAN'
+      description: 'Updates existing vlan/domain'
+      operationId: 5b12d6be9c47cc52abe6adf98480ab2c
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                domainId:
+                  type: integer
+                name:
+                  type: string
+                number:
+                  type: integer
+                description:
+                  type: string
+                customer_id:
+                  type: integer
+              type: object
+      responses:
+        '200':
+          description: 'Vlan updated'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse'
+        '400':
+          description: 'Vlan Id is required / Vlan Id must be numeric'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: 'Invalid Vlan id'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '409':
+          description: 'Highest possible VLAN number exceeded'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: 'Vlan edit failed / Highest possible VLAN number exceeded'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  '/{app_id}/vlans/custom_fields/':
+    get:
+      tags:
+        - vlans
+      summary: 'List custom fields defined on the vlans table'
+      operationId: 95566012c5b6d21d05350291c5011d73
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+      responses:
+        '200':
+          description: OK
+        '404':
+          description: 'No custom fields defined'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  '/{app_id}/vlans/search/{number}/':
+    get:
+      tags:
+        - vlans
+      summary: 'Search VLANs by VLAN number'
+      operationId: 8f58a02436d262b55134ea07411e68d0
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+        -
+          name: number
+          in: path
+          description: 'VLAN number to search for'
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Vlan'
+        '404':
+          description: 'Vlans not found'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  '/{app_id}/vlans/{id}/subnets/':
+    get:
+      tags:
+        - vlans
+      summary: 'List all subnets belonging to a VLAN'
+      operationId: c7784708947ec1c91a1580b19c046996
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+        -
+          name: id
+          in: path
+          description: 'Vlan id'
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Subnet'
+        '404':
+          description: 'Invalid Vlan id / No subnets found'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  '/{app_id}/vlans/{id}/subnets/{sectionId}/':
+    get:
+      tags:
+        - vlans
+      summary: 'List subnets belonging to a VLAN, filtered to a single section'
+      operationId: 7f98e8a6307f0fbd17123ecb64a17e8e
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+        -
+          name: id
+          in: path
+          description: 'Vlan id'
+          required: true
+          schema:
+            type: integer
+        -
+          name: sectionId
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Subnet'
+        '404':
+          description: 'Invalid Vlan id / No subnets found'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  '/{app_id}/vrfs/':
+    get:
+      tags:
+        - vrfs
+      summary: 'List all VRFs (alias: /vrfs/all/)'
+      description: "Read vrf\n\n\tidentifiers:\n\t\t- /\t\t\t\t        // returns all VRFs\n\t\t- /custom_fields/\t\t// returns all VRF custom fields\n\t\t- /{id}/\t\t\t\t// returns VRF by id\n\t\t- /{id}/subnets/\t\t// subnets inside vrf\n\t\t- /all/\t\t\t        // returns all VRFs"
+      operationId: 6190eed8afe50929f26667869eaf045a
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Vrf'
+        '404':
+          description: 'No vrfs configured'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+    post:
+      tags:
+        - vrfs
+      summary: 'Create a new VRF'
+      description: 'Creates new VRF'
+      operationId: 8ee6456aae0110f6d0f7e391b9802cbb
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              required:
+                - name
+              properties:
+                name:
+                  type: string
+                  example: Customer-A
+                rd:
+                  description: 'Route distinguisher'
+                  type: string
+                description:
+                  type: string
+                sections:
+                  description: 'Comma-separated list of section ids this VRF is restricted to'
+                  type: string
+                customer_id:
+                  type: integer
+              type: object
+      responses:
+        '201':
+          description: 'VRF created'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse'
+        '400':
+          description: 'VRF name is required'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '409':
+          description: 'VRF with that name already exists'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: 'VRF creation failed'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+    options:
+      tags:
+        - vrfs
+      summary: 'Discover supported vrfs routes/methods (HATEOAS)'
+      description: 'Returns json encoded options'
+      operationId: 9c281b45ce0f159914271dcf911ea40b
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+      responses:
+        '200':
+          description: OK
+  '/{app_id}/vrfs/custom_fields/':
+    get:
+      tags:
+        - vrfs
+      summary: 'List custom fields defined on the vrf table'
+      operationId: c494824ad5a773efa7e5415d84a2b3f7
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+      responses:
+        '200':
+          description: OK
+        '404':
+          description: 'No custom fields defined'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  '/{app_id}/vrfs/{id}/':
+    get:
+      tags:
+        - vrfs
+      summary: 'Read a single VRF by id'
+      operationId: 14f44110e6237bb2d4c965ef2c259888
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Vrf'
+        '400':
+          description: 'Vrf Id is required / must be numeric / Invalid VRF id'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: 'VRF not found'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+    delete:
+      tags:
+        - vrfs
+      summary: 'Delete a VRF, removing all references from subnets that used it'
+      description: 'Deletes existing vrf'
+      operationId: 39801f7087c13d9524f21a567d8e5d85
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: 'VRF deleted'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse'
+        '400':
+          description: 'Vrf Id is required / must be numeric / Invalid VRF id'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: 'Vrf delete failed'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+    patch:
+      tags:
+        - vrfs
+      summary: 'Update an existing VRF'
+      description: 'Updates existing vrf'
+      operationId: 45f2bb947a65b7c57fbc65cde876b7d0
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                name:
+                  type: string
+                  example: Customer-A
+                rd:
+                  description: 'Route distinguisher'
+                  type: string
+                description:
+                  type: string
+                sections:
+                  description: 'Comma-separated list of section ids this VRF is restricted to'
+                  type: string
+                customer_id:
+                  type: integer
+              type: object
+      responses:
+        '200':
+          description: 'VRF updated'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse'
+        '400':
+          description: 'Vrf Id is required / must be numeric / Invalid VRF id'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '409':
+          description: 'VRF with that name already exists'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: 'Vrf edit failed'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  '/{app_id}/vrfs/{id}/subnets/':
+    get:
+      tags:
+        - vrfs
+      summary: 'List all subnets belonging to a VRF'
+      operationId: 9d6ba691b256696b59a0aee928609dd0
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+        -
+          name: id
+          in: path
+          description: 'VRF id'
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Subnet'
+        '400':
+          description: 'Vrf Id is required / must be numeric / Invalid VRF id'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: 'No subnets belonging to this vrf'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  '/{app_id}/l2domains/':
+    get:
+      tags:
+        - l2domains
+      summary: 'List all L2 (VLAN) domains'
+      description: "Read domain functions\n\n\tidentifier can be:\n\t\t- / \t\t\t\t// will return all domains\n\t\t- /{id}/\n\t\t- /{id}/vlans/\n\t\t- /custom_fields/\n\t\t- /all/\t\t\t\t// will return all domains"
+      operationId: 79bfcaf488969e8429c9b994efbaeddc
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  properties: { id: { type: integer, example: 1 }, name: { type: string, example: default }, description: { type: string, example: 'default L2 domain', nullable: true }, sections: { description: "JSON-encoded map of groupId => permission level (stored internally as 'permissions', exposed as 'sections' in read responses)", type: string, nullable: true } }
+                  type: object
+        '404':
+          description: 'No domains configured'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+    post:
+      tags:
+        - l2domains
+      summary: 'Create a new L2 (VLAN) domain'
+      description: 'Creates new domain'
+      operationId: c16dc2d43e4715a597321c1a2ff5a431
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              required:
+                - name
+              properties:
+                name:
+                  type: string
+                  example: 'Colo 1'
+                description:
+                  type: string
+                  nullable: true
+                permissions:
+                  description: 'JSON-encoded map of groupId => permission level'
+                  type: string
+                  nullable: true
+              type: object
+      responses:
+        '201':
+          description: 'L2 domain created'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse'
+        '400':
+          description: 'Domain name is mandatory'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: 'Domain creation failed'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+    options:
+      tags:
+        - l2domains
+      summary: 'Discover supported l2domains routes/methods (HATEOAS)'
+      description: 'Returns json encoded options'
+      operationId: 8f5ab370f8e7b201bdaf5955bcce02b9
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+      responses:
+        '200':
+          description: OK
+  '/{app_id}/l2domains/custom_fields/':
+    get:
+      tags:
+        - l2domains
+      summary: 'List custom fields defined on the vlanDomains table'
+      operationId: 26172a74e2bc51077f2438b78f5a2a3d
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+      responses:
+        '200':
+          description: OK
+        '404':
+          description: 'No custom fields defined'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  '/{app_id}/l2domains/{id}/vlans/':
+    get:
+      tags:
+        - l2domains
+      summary: 'List all VLANs belonging to an L2 domain'
+      operationId: d3c111a38654679cbad1661fc78c58ba
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+        -
+          name: id
+          in: path
+          description: 'L2 domain id'
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Vlan'
+        '400':
+          description: 'Domain id must be numeric'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: 'Invalid domain id / No vlans belonging to this domain'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  '/{app_id}/l2domains/{id}/':
+    get:
+      tags:
+        - l2domains
+      summary: 'Read a single L2 domain by id'
+      operationId: f5c2946a5361ab15eefa85d2ea39de59
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                properties:
+                  id: { type: integer, example: 1 }
+                  name: { type: string, example: default }
+                  description: { type: string, example: 'default L2 domain', nullable: true }
+                  sections: { description: "JSON-encoded map of groupId => permission level (stored internally as 'permissions', exposed as 'sections' in read responses)", type: string, nullable: true }
+                type: object
+        '400':
+          description: 'Domain id must be numeric'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: 'Invalid domain id'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+    delete:
+      tags:
+        - l2domains
+      summary: 'Delete an L2 (VLAN) domain (VLANs in this domain are migrated to the default domain)'
+      description: 'The default domain (id=1) cannot be deleted.'
+      operationId: f337ae88d5b4373e79bd75de9bd79e43
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: 'L2 domain deleted and vlans migrated to default domain'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse'
+        '400':
+          description: 'Domain id must be numeric'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: 'Invalid domain id'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '409':
+          description: 'Default domain cannot be deleted'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: 'L2 domain delete failed'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+    patch:
+      tags:
+        - l2domains
+      summary: 'Update an existing L2 (VLAN) domain'
+      description: 'Updates existing domain'
+      operationId: eac648f64b3a7dda780508c2d4567aae
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                name:
+                  type: string
+                  example: 'Colo 1'
+                description:
+                  type: string
+                  nullable: true
+                permissions:
+                  description: 'JSON-encoded map of groupId => permission level'
+                  type: string
+                  nullable: true
+              type: object
+      responses:
+        '200':
+          description: 'L2 domain updated'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse'
+        '400':
+          description: 'Invalid domain id / Domain name is mandatory'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: 'Invalid domain id'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: 'Domain edit failed'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  '/{app_id}/devices/':
+    get:
+      tags:
+        - devices
+      summary: 'List all devices'
+      description: "GET devices functions\n\n ID can be:\n     - /                     // returns all devices\n     - /{id}/                // returns device details\n     - /{id}/{subnets}/      // returns all subnets attached to device\n     - /{id}/{addresses}/    // returns all IP addresses attached to device\n     - /search/{search_q}/   // searches for devices\n     - /all/                 // returns all devices"
+      operationId: 475625808c40b18df71f4574339d486f
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Device'
+        '404':
+          description: 'No devices configured'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+    post:
+      tags:
+        - devices
+      summary: 'Create a new device'
+      description: "Creates new device\n\n/devices/"
+      operationId: 5c252818cefef3cfafe11bec3cc3e428
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              required:
+                - hostname
+              properties:
+                hostname:
+                  type: string
+                  example: switch-01
+                ip_addr:
+                  type: string
+                  example: 192.168.1.1
+                type:
+                  description: 'Device type id, see tools/deviceTypes'
+                  type: integer
+                description:
+                  type: string
+                sections:
+                  description: 'Comma/semicolon separated list of section ids; defaults to all sections if omitted'
+                  type: string
+                snmp_community:
+                  type: string
+                snmp_version:
+                  description: '0=disabled, 1=v1, 2=v2c, 3=v3'
+                  type: string
+                  enum: ['0', '1', '2', '3']
+                snmp_port:
+                  type: integer
+                  example: 161
+                snmp_timeout:
+                  type: integer
+                  example: 1000
+                snmp_queries:
+                  type: string
+                snmp_v3_sec_level:
+                  description: 'Representative SNMPv3 field; other snmp_v3_* sub-fields (auth/priv protocol/pass, context name/engine id) are also accepted'
+                  type: string
+                  enum: [none, noAuthNoPriv, authNoPriv, authPriv]
+                rack:
+                  type: integer
+                rack_start:
+                  type: integer
+                rack_size:
+                  type: integer
+                location:
+                  type: integer
+              type: object
+      responses:
+        '201':
+          description: 'Device created'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse'
+        '400':
+          description: 'Hostname is mandatory / Invalid devicetype identifier / Device type does not exist'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: 'Device creation failed'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+    options:
+      tags:
+        - devices
+      summary: 'Discover supported devices routes/methods (HATEOAS)'
+      description: 'Returns json encoded options and version'
+      operationId: 86edee6acde2f60c71ef7c1c1ef0248e
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+      responses:
+        '200':
+          description: OK
+  '/{app_id}/devices/search/{search_term}/':
+    get:
+      tags:
+        - devices
+      summary: 'Search devices by hostname, ip_addr, description, or custom fields (substring match)'
+      operationId: 06a94413cfdbfb77cc34cbeb55604641
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+        -
+          name: search_term
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Device'
+        '404':
+          description: 'No devices found'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  '/{app_id}/devices/search/':
+    get:
+      tags:
+        - devices
+      summary: 'Search devices without a search term (always fails)'
+      operationId: 4ea4800d3e01737872b5c16c6bd875be
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+      responses:
+        '400':
+          description: 'No search term given'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  '/{app_id}/devices/{id}/':
+    get:
+      tags:
+        - devices
+      summary: 'Read a single device by id'
+      operationId: abb76655fc7ea071ced8512f56dc18da
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Device'
+        '400':
+          description: 'ID must be numeric'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: 'Device not found'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+    delete:
+      tags:
+        - devices
+      summary: 'Delete a device'
+      description: 'Delete existing device'
+      operationId: baa94cc7da1cfcc41ae966b0b18bea4a
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: 'Device deleted'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse'
+        '400':
+          description: 'Invalid device id'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: 'Device does not exist'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: 'Device delete failed'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+    patch:
+      tags:
+        - devices
+      summary: 'Update an existing device'
+      description: 'Update device details'
+      operationId: f30ed1fc8fa1e9499956b87a13c1136a
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                hostname:
+                  type: string
+                  example: switch-01
+                ip_addr:
+                  type: string
+                  example: 192.168.1.1
+                type:
+                  description: 'Device type id, see tools/deviceTypes'
+                  type: integer
+                description:
+                  type: string
+                sections:
+                  type: string
+                snmp_community:
+                  type: string
+                snmp_version:
+                  type: string
+                  enum: ['0', '1', '2', '3']
+                snmp_port:
+                  type: integer
+                snmp_timeout:
+                  type: integer
+                snmp_queries:
+                  type: string
+                snmp_v3_sec_level:
+                  description: 'Representative SNMPv3 field; other snmp_v3_* sub-fields are also accepted'
+                  type: string
+                  enum: [none, noAuthNoPriv, authNoPriv, authPriv]
+                rack:
+                  type: integer
+                rack_start:
+                  type: integer
+                rack_size:
+                  type: integer
+                location:
+                  type: integer
+              type: object
+      responses:
+        '200':
+          description: 'Device updated'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse'
+        '400':
+          description: 'Invalid device id / Hostname is mandatory / Invalid devicetype identifier / Device type does not exist / No parameters'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: 'Device edit failed'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  '/{app_id}/devices/{id}/addresses/':
+    get:
+      tags:
+        - devices
+      summary: 'List all IP addresses assigned to this device'
+      operationId: ccecf2785d809ed0d2b20f4076adbc4e
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+        -
+          name: id
+          in: path
+          description: 'Device id'
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Address'
+        '404':
+          description: 'No addresses found'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  '/{app_id}/devices/{id}/subnets/':
+    get:
+      tags:
+        - devices
+      summary: 'List all subnets whose gateway/device is this device'
+      operationId: b21fb095410165f835824aee14f4bea0
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+        -
+          name: id
+          in: path
+          description: 'Device id'
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Subnet'
+        '404':
+          description: 'No subnets found'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  '/{app_id}/circuits/':
+    get:
+      tags:
+        - circuits
+      summary: 'List all circuits (alias: /circuits/all/)'
+      description: "Read circuits/providers functions\n\nparameters (circuits):\n\t\t- / \t\t\t\t\t\t\treturns all circuits\n\t\t- /{id}/                        returns circuit details\n\t\t- /id/{id}/                     returns circuit details by cid\n\t\t- /circuit_id/{id}/             returns circuit details by cid\n\t\t- /all/\t\t\t\t\t\t\treturns all circuits\n\n\nparameters (providers):\n\t\t- /providers/ \t\t\t\t\treturns all providers\n\t\t- /providers/{id}/\t\t\t\treturns providers details\n\t\t- /providers/{id}/circuits/\t\treturns all circuits belonging to provider"
+      operationId: 8069b90098cd8cb68d96dc7b4c90c38d
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  properties: { id: { type: string, example: '1' }, cid: { type: string }, provider: { type: string }, type: { type: string }, capacity: { type: string }, status: { type: string, enum: [Active, Inactive, Reserved] }, device1: { type: string }, location1: { type: string }, device2: { type: string }, location2: { type: string }, comment: { type: string }, parent: { type: string }, customer_id: { type: string }, differentiator: { type: string } }
+                  type: object
+        '404':
+          description: 'No circuits configured'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+    post:
+      tags:
+        - circuits
+      summary: 'Create a new circuit'
+      description: "Creates new provider / circuit\n\n/circuits/\n/circuits/providers/"
+      operationId: 5a3440187a9ef31172fd968b05335412
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              required:
+                - cid
+                - provider
+              properties:
+                cid:
+                  description: 'Circuit ID, must be unique per differentiator'
+                  type: string
+                provider:
+                  description: 'Existing circuit provider id'
+                  type: integer
+                type:
+                  description: 'Defaults to Default if not provided'
+                  type: string
+                capacity:
+                  type: string
+                status:
+                  type: string
+                  default: Active
+                  enum: [Active, Inactive, Reserved]
+                device1:
+                  description: 'Defaults to 0 if neither device1 nor location1 is provided'
+                  type: integer
+                location1:
+                  description: 'Defaults to 0 if neither device1 nor location1 is provided'
+                  type: integer
+                device2:
+                  description: 'Defaults to 0 if neither device2 nor location2 is provided'
+                  type: integer
+                location2:
+                  description: 'Defaults to 0 if neither device2 nor location2 is provided'
+                  type: integer
+                comment:
+                  type: string
+                parent:
+                  type: integer
+                customer_id:
+                  type: integer
+                differentiator:
+                  type: string
+              type: object
+      responses:
+        '201':
+          description: 'circuit created'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse'
+        '400':
+          description: 'Circuit ID is mandatory / Invalid circuit provider / Invalid circuit type / Invalid status / Invalid device or location'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '409':
+          description: 'Circuit ID already exists / No values present'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: 'circuit creation failed'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+    options:
+      tags:
+        - circuits
+      summary: 'Discover supported circuits/providers routes/methods (HATEOAS)'
+      description: 'Returns json encoded options'
+      operationId: b6ac18f6606ac872d1397fe20af38618
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+      responses:
+        '200':
+          description: OK
+  '/{app_id}/circuits/providers/':
+    get:
+      tags:
+        - circuits
+      summary: 'List all circuit providers (alias: /circuits/providers/all/)'
+      operationId: 52cf84c04d8b762bbb89d539e2aac97d
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  properties: { id: { type: string, example: '1' }, name: { type: string }, description: { type: string }, contact: { type: string } }
+                  type: object
+        '404':
+          description: 'No providers configured'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+    post:
+      tags:
+        - circuits
+      summary: 'Create a new circuit provider'
+      operationId: b4d744da7182b16d49477bac50225b38
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              required:
+                - name
+              properties:
+                name:
+                  type: string
+                description:
+                  type: string
+                contact:
+                  type: string
+              type: object
+      responses:
+        '201':
+          description: 'provider created'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse'
+        '404':
+          description: 'Name is mandatory'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '409':
+          description: 'No values present'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: 'provider creation failed'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+    options:
+      tags:
+        - circuits
+      summary: 'Discover supported circuit providers routes/methods (HATEOAS)'
+      operationId: 5ac1af5b665b83f818aa18956f4ecf3a
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+      responses:
+        '200':
+          description: OK
+  '/{app_id}/circuits/{id}/':
+    get:
+      tags:
+        - circuits
+      summary: 'Read a single circuit by id'
+      operationId: c19cf81e3e1a0ceb60cba92989a0216e
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                properties:
+                  id: { type: string, example: '1' }
+                  cid: { type: string }
+                  provider: { type: string }
+                  type: { type: string }
+                  capacity: { type: string }
+                  status: { type: string, enum: [Active, Inactive, Reserved] }
+                  device1: { type: string }
+                  location1: { type: string }
+                  device2: { type: string }
+                  location2: { type: string }
+                  comment: { type: string }
+                  parent: { type: string }
+                  customer_id: { type: string }
+                  differentiator: { type: string }
+                type: object
+        '400':
+          description: 'Invalid ID'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: 'circuit not found'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+    delete:
+      tags:
+        - circuits
+      summary: 'Delete a circuit'
+      description: "Deletes provider or circuit\n\n/circuits/{id}/\n/circuits/providers/{id}/"
+      operationId: 561cce41b41282d654bdbd5087bd3a56
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: 'circuit deleted'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse'
+        '400':
+          description: 'circuit id is required / circuit id must be numeric'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: 'Nonexisting circuit id'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: 'circuit delete failed'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+    patch:
+      tags:
+        - circuits
+      summary: 'Update an existing circuit'
+      description: "Updates Circuit of Provider\n\n/circuits/{id}/\n/circuits/providers/{id}/"
+      operationId: 35cd6f8e1e878304fd96d4fc1c6164d3
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                cid:
+                  type: string
+                provider:
+                  description: 'Existing circuit provider id'
+                  type: integer
+                type:
+                  type: string
+                capacity:
+                  type: string
+                status:
+                  type: string
+                  enum: [Active, Inactive, Reserved]
+                device1:
+                  type: integer
+                location1:
+                  type: integer
+                device2:
+                  type: integer
+                location2:
+                  type: integer
+                comment:
+                  type: string
+                parent:
+                  type: integer
+                customer_id:
+                  type: integer
+                differentiator:
+                  type: string
+              type: object
+      responses:
+        '200':
+          description: 'circuit updated'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse'
+        '400':
+          description: 'circuit id is required / circuit id must be numeric / Invalid circuit provider / Invalid circuit type / Invalid status / Invalid device or location'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: 'Nonexisting circuit id'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '409':
+          description: 'Circuit ID already exists / No values present'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: 'circuit edit failed'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  '/{app_id}/circuits/id/{cid}/':
+    get:
+      tags:
+        - circuits
+      summary: 'Read a single circuit by its Circuit ID (cid) value - alias of /circuits/circuit_id/{cid}/'
+      operationId: 1698d140ee28d6f27125722e1acb1c1d
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+        -
+          name: cid
+          in: path
+          description: 'Circuit ID (cid) value'
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                properties:
+                  id: { type: string }
+                  cid: { type: string }
+                  provider: { type: string }
+                type: object
+        '404':
+          description: 'circuit not found'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  '/{app_id}/circuits/circuit_id/{cid}/':
+    get:
+      tags:
+        - circuits
+      summary: 'Read a single circuit by its Circuit ID (cid) value - alias of /circuits/id/{cid}/'
+      operationId: fe1e78d1be26c98e7637f942c0dd06a9
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+        -
+          name: cid
+          in: path
+          description: 'Circuit ID (cid) value'
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                properties:
+                  id: { type: string }
+                  cid: { type: string }
+                  provider: { type: string }
+                type: object
+        '404':
+          description: 'circuit not found'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  '/{app_id}/circuits/providers/{id}/':
+    get:
+      tags:
+        - circuits
+      summary: 'Read a single circuit provider by id'
+      operationId: dd9bcb502630954e3611c4b5cd75d533
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+        -
+          name: id
+          in: path
+          description: 'Provider id'
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                properties:
+                  id: { type: string, example: '1' }
+                  name: { type: string }
+                  description: { type: string }
+                  contact: { type: string }
+                type: object
+        '400':
+          description: 'Invalid ID'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: 'provider not found'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+    delete:
+      tags:
+        - circuits
+      summary: 'Delete a circuit provider (also removes references to it from any circuits)'
+      operationId: 1479b616c012e363c2ac4c74f5cd51bd
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: 'provider deleted'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse'
+        '400':
+          description: 'provider id is required / provider id must be numeric'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: 'Nonexisting provider id'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: 'provider delete failed'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+    patch:
+      tags:
+        - circuits
+      summary: 'Update an existing circuit provider'
+      operationId: a7608ed60c94aba46a0c8ba6c44c4311
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                name:
+                  type: string
+                description:
+                  type: string
+                contact:
+                  type: string
+              type: object
+      responses:
+        '200':
+          description: 'provider updated'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse'
+        '400':
+          description: 'provider id is required / provider id must be numeric'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: 'Nonexisting provider id'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '409':
+          description: 'No values present'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: 'provider edit failed'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  '/{app_id}/circuits/providers/{id}/circuits/':
+    get:
+      tags:
+        - circuits
+      summary: 'List all circuits belonging to a given provider'
+      operationId: 79d667a76ec88ddb507cb5989674e01e
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+        -
+          name: id
+          in: path
+          description: 'Provider id'
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  properties: { id: { type: string }, cid: { type: string }, provider: { type: string } }
+                  type: object
+        '404':
+          description: 'No circuits belonging to provider'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  '/{app_id}/nat/':
+    get:
+      tags:
+        - nat
+      summary: 'List all NAT entries (alias: /nat/all/)'
+      description: "GET NAT functions\n\n ID can be:\n     - /                     // returns all NATs\n     - /{id}/                // returns NAT details\n\n If no ID is provided all nats are returned"
+      operationId: 14ecf0686213754d85ec576229ca1012
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  properties: { id: { type: integer, example: 1 }, name: { type: string, example: 'Outbound NAT', nullable: true }, type: { type: string, enum: [source, destination, static] }, src: { description: "Map of identifier type to array of ids. Currently only 'ipaddresses' is supported.", properties: { ipaddresses: { type: array, items: { type: integer } } }, type: object }, dst: { description: 'Same structure as src', properties: { ipaddresses: { type: array, items: { type: integer } } }, type: object }, src_port: { type: integer, nullable: true }, dst_port: { type: integer, nullable: true }, device: { description: 'Device id', type: integer, nullable: true }, description: { type: string, nullable: true }, policy: { type: string, enum: ['Yes', 'No'] }, policy_dst: { type: string, nullable: true } }
+                  type: object
+    post:
+      tags:
+        - nat
+      summary: 'Create a new NAT entry'
+      description: 'Creates new NAT'
+      operationId: 495b5d6afe660c5629eec5296469df15
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              required:
+                - name
+                - type
+              properties:
+                name:
+                  description: 'NAT name (mandatory)'
+                  type: string
+                  example: 'Outbound NAT'
+                type:
+                  description: 'NAT type (mandatory)'
+                  type: string
+                  enum: [source, destination, static]
+                src:
+                  description: "Map of identifier type to array of ids. Currently only 'ipaddresses' is supported."
+                  properties: { ipaddresses: { description: 'Address ids', type: array, items: { type: integer } } }
+                  type: object
+                dst:
+                  description: 'Same structure as src'
+                  properties: { ipaddresses: { description: 'Address ids', type: array, items: { type: integer } } }
+                  type: object
+                src_port:
+                  description: 'Must be numeric'
+                  type: integer
+                dst_port:
+                  description: 'Must be numeric'
+                  type: integer
+                device:
+                  description: 'Device id, must reference an existing device'
+                  type: integer
+                description:
+                  type: string
+                policy:
+                  type: string
+                  enum: ['Yes', 'No']
+                policy_dst:
+                  type: string
+              type: object
+      responses:
+        '201':
+          description: 'NAT created'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse'
+        '400':
+          description: 'Possible causes: Missing NAT name; Missing NAT type; Invalid type; ID should not be set for creation; Invalid value for src_port/dst_port (must be numeric); Invalid src/dst format (must be an array); Invalid key identifier for src/dst; Invalid value for src/dst (must be an array or integer); Wrong format for device ID (must be numeric); Device ID not found'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: 'ID not found for the given src/dst identifier type'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: 'NAT creation failed'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+    options:
+      tags:
+        - nat
+      summary: 'Discover supported NAT routes/methods (HATEOAS)'
+      description: 'Returns json encoded options and version'
+      operationId: e72ad65db1c9ab674d4c2289b61fa9b4
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+      responses:
+        '200':
+          description: OK
+    head:
+      tags:
+        - nat
+      summary: 'HEAD request for NAT list/details (runs the same processing as GET, but no response body is returned)'
+      description: 'HEAD, no response'
+      operationId: 6f36591ad1b60c7b596ba1a211960bd6
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+      responses:
+        '200':
+          description: 'OK (headers only, no body)'
+  '/{app_id}/nat/{id}/':
+    get:
+      tags:
+        - nat
+      summary: 'Read a single NAT entry by id'
+      operationId: ec41a760617054cab7f42a598c0fd770
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  properties: { id: { type: integer, example: 1 }, name: { type: string, example: 'Outbound NAT', nullable: true }, type: { type: string, enum: [source, destination, static] }, src: { description: "Map of identifier type to array of ids. Currently only 'ipaddresses' is supported.", properties: { ipaddresses: { type: array, items: { type: integer } } }, type: object }, dst: { description: 'Same structure as src', properties: { ipaddresses: { type: array, items: { type: integer } } }, type: object }, src_port: { type: integer, nullable: true }, dst_port: { type: integer, nullable: true }, device: { description: 'Device id', type: integer, nullable: true }, description: { type: string, nullable: true }, policy: { type: string, enum: ['Yes', 'No'] }, policy_dst: { type: string, nullable: true } }
+                  type: object
+        '400':
+          description: 'Invalid ID format'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+    delete:
+      tags:
+        - nat
+      summary: 'Delete an existing NAT entry'
+      description: 'Deletes existing NAT'
+      operationId: f6570aad7f3d08b2eefcb0dbc59f6981
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: 'NAT deleted'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse'
+        '400':
+          description: 'Invalid ID format'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: 'ID not found'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: 'NAT delete failed'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+    patch:
+      tags:
+        - nat
+      summary: 'Update an existing NAT entry'
+      description: 'Updates existing NAT'
+      operationId: 3bd68c5934212a41a46eff7d5e4b76ca
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                name:
+                  type: string
+                type:
+                  type: string
+                  enum: [source, destination, static]
+                src:
+                  description: "Map of identifier type to array of ids. Currently only 'ipaddresses' is supported."
+                  properties: { ipaddresses: { description: 'Address ids', type: array, items: { type: integer } } }
+                  type: object
+                dst:
+                  description: 'Same structure as src'
+                  properties: { ipaddresses: { description: 'Address ids', type: array, items: { type: integer } } }
+                  type: object
+                src_port:
+                  description: 'Must be numeric'
+                  type: integer
+                dst_port:
+                  description: 'Must be numeric'
+                  type: integer
+                device:
+                  description: 'Device id, must reference an existing device'
+                  type: integer
+                description:
+                  type: string
+                policy:
+                  type: string
+                  enum: ['Yes', 'No']
+                policy_dst:
+                  type: string
+              type: object
+      responses:
+        '200':
+          description: 'NAT modified'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse'
+        '400':
+          description: 'Possible causes: Invalid ID format; Invalid value for src_port/dst_port (must be numeric); Invalid src/dst format (must be an array); Invalid key identifier for src/dst; Invalid value for src/dst (must be an array or integer); Wrong format for device ID (must be numeric); Device ID not found'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: 'ID not found (NAT id, or src/dst identifier)'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: 'NAT modification failed'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  '/{app_id}/prefix/':
+    options:
+      tags:
+        - prefix
+      summary: 'Discover supported prefix routes/methods (HATEOAS)'
+      description: 'Returns json encoded options and version'
+      operationId: f3c02f70859dc1a2b0a17429bc9a1165
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+      responses:
+        '200':
+          description: OK
+  '/{app_id}/prefix/{customer_type}/':
+    get:
+      tags:
+        - prefix
+      summary: 'List candidate master subnets matching a customer_type custom field (any address family)'
+      description: 'Searches subnets where the custom field configured as $custom_field_name (default: custom_customer_type) equals {customer_type}, ordered by $custom_field_orderby/$custom_field_order_direction (default: subnet asc).'
+      operationId: ace3342f8b594f5866c0c6417a2287b7
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+        -
+          name: customer_type
+          in: path
+          description: 'Value of the customer_type custom field to search subnets for'
+          required: true
+          schema:
+            type: string
+        -
+          name: usage
+          in: query
+          description: 'If set to true, append subnet usage statistics to each returned subnet'
+          required: false
+          schema:
+            type: string
+            enum:
+              - 'true'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Subnet'
+        '400':
+          description: 'Invalid custom field custom_customer_type (field not defined on subnets table)'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: 'No master subnets found'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  '/{app_id}/prefix/{customer_type}/{address_type}/':
+    get:
+      tags:
+        - prefix
+      summary: 'List candidate master subnets matching a customer_type custom field, filtered by address family'
+      operationId: 077394078bfab5db4de8994620595fa1
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+        -
+          name: customer_type
+          in: path
+          description: 'Value of the customer_type custom field to search subnets for'
+          required: true
+          schema:
+            type: string
+        -
+          name: address_type
+          in: path
+          description: 'IP protocol version filter'
+          required: true
+          schema:
+            type: string
+            enum:
+              - IPv4
+              - IPv6
+              - v4
+              - v6
+              - '4'
+              - '6'
+        -
+          name: usage
+          in: query
+          description: 'If set to true, append subnet usage statistics to each returned subnet'
+          required: false
+          schema:
+            type: string
+            enum:
+              - 'true'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Subnet'
+        '400':
+          description: 'Invalid custom field custom_customer_type, or invalid address type'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: 'No master subnets found'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  '/{app_id}/prefix/{customer_type}/{address_type}/{mask}/':
+    get:
+      tags:
+        - prefix
+      summary: 'Find the first available subnet of the given mask under any master subnet matching customer_type/address_type'
+      description: 'Iterates matching master subnets (ordered by the configured custom field ordering) and returns the first free subnet found with the requested bitmask. Does not create it.'
+      operationId: 1fcf48780b4f5a7d382b4d533e12534b
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+        -
+          name: customer_type
+          in: path
+          description: 'Value of the customer_type custom field to search subnets for'
+          required: true
+          schema:
+            type: string
+        -
+          name: address_type
+          in: path
+          description: 'IP protocol version filter'
+          required: true
+          schema:
+            type: string
+            enum:
+              - IPv4
+              - IPv6
+              - v4
+              - v6
+              - '4'
+              - '6'
+        -
+          name: mask
+          in: path
+          description: 'Requested subnet bitmask (8-128, IPv4 limited to <=32)'
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                description: 'First available subnet found'
+                type: string
+        '400':
+          description: 'Invalid custom field, invalid address type, or invalid subnet mask'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: 'No subnets found'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+    post:
+      tags:
+        - prefix
+      summary: 'Create the first available subnet of the given mask under any master subnet matching customer_type/address_type'
+      description: 'Searches master subnets matching {customer_type}/{address_type}, finds the first free subnet with the requested bitmask, and creates it. sectionId, masterSubnetId and permissions are inherited automatically from the matched master subnet and must not be supplied.'
+      operationId: 11f3b29344a58ed6b1da940817caa5c1
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+        -
+          name: customer_type
+          in: path
+          description: 'Value of the customer_type custom field to search subnets for'
+          required: true
+          schema:
+            type: string
+        -
+          name: address_type
+          in: path
+          description: 'IP protocol version filter'
+          required: true
+          schema:
+            type: string
+            enum:
+              - IPv4
+              - IPv6
+              - v4
+              - v6
+              - '4'
+              - '6'
+        -
+          name: mask
+          in: path
+          description: 'Requested subnet bitmask (8-128, IPv4 limited to <=32)'
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                description:
+                  description: "Defaults to 'Prefix controller autocreated' if not provided"
+                  type: string
+                vlanId:
+                  type: integer
+                vrfId:
+                  type: integer
+              type: object
+      responses:
+        '201':
+          description: 'Subnet created'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse'
+        '400':
+          description: 'Invalid custom field, invalid address type, or invalid subnet mask'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: 'No subnets found'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '409':
+          description: 'Subnet is not within boundaries of its master subnet, or overlaps an existing subnet'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: 'Failed to create subnet'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  '/{app_id}/prefix/{customer_type}/address/':
+    get:
+      tags:
+        - prefix
+      summary: 'List candidate master subnets for address allocation matching a customer_type custom field'
+      description: 'Searches subnets where the custom field configured as $custom_field_name_addr (default: custom_customer_address_type) equals {customer_type}. Subnets that already contain slave subnets are excluded, since only leaf subnets can hold addresses.'
+      operationId: b0aba9b8396ce82026024ce35d43a2c5
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+        -
+          name: customer_type
+          in: path
+          description: 'Value of the address custom field to search subnets for'
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Subnet'
+        '400':
+          description: 'Invalid custom field custom_customer_address_type (field not defined on subnets table)'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: 'No master subnets found'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  '/{app_id}/prefix/{customer_type}/address/{address_type}/':
+    get:
+      tags:
+        - prefix
+      summary: 'List candidate master subnets for address allocation, filtered by address family'
+      operationId: df98a1ff724b7c31de90dd89fddb479b
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+        -
+          name: customer_type
+          in: path
+          description: 'Value of the address custom field to search subnets for'
+          required: true
+          schema:
+            type: string
+        -
+          name: address_type
+          in: path
+          description: 'IP protocol version filter'
+          required: true
+          schema:
+            type: string
+            enum:
+              - IPv4
+              - IPv6
+              - v4
+              - v6
+              - '4'
+              - '6'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Subnet'
+        '400':
+          description: 'Invalid custom field custom_customer_address_type, or invalid address type'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: 'No master subnets found'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  '/{app_id}/prefix/{customer_type}/{address_type}/address/':
+    get:
+      tags:
+        - prefix
+      summary: 'Find the first available address under any master subnet matching customer_type/address_type'
+      description: 'Iterates matching master subnets (leaf subnets only) and returns the first free IP address found. Does not create it.'
+      operationId: b114d962a068689e4816a0f67c487bdb
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+        -
+          name: customer_type
+          in: path
+          description: 'Value of the address custom field to search subnets for'
+          required: true
+          schema:
+            type: string
+        -
+          name: address_type
+          in: path
+          description: 'IP protocol version filter'
+          required: true
+          schema:
+            type: string
+            enum:
+              - IPv4
+              - IPv6
+              - v4
+              - v6
+              - '4'
+              - '6'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: string
+              example: 192.168.1.5
+        '400':
+          description: 'Invalid custom field custom_customer_address_type, or invalid address type'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: 'No address found'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+    post:
+      tags:
+        - prefix
+      summary: 'Create the first available address under any master subnet matching customer_type/address_type'
+      description: 'Searches leaf master subnets (no slave subnets) matching {customer_type}/{address_type}, finds the first free IP address, and creates it. ip_addr and subnetId are derived automatically and must not be supplied.'
+      operationId: c9f6376c170565e194e5f273cd173dba
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+        -
+          name: customer_type
+          in: path
+          description: 'Value of the address custom field to search subnets for'
+          required: true
+          schema:
+            type: string
+        -
+          name: address_type
+          in: path
+          description: 'IP protocol version filter'
+          required: true
+          schema:
+            type: string
+            enum:
+              - IPv4
+              - IPv6
+              - v4
+              - v6
+              - '4'
+              - '6'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                hostname:
+                  type: string
+                description:
+                  description: "Defaults to 'Prefix controller autocreated' if not provided"
+                  type: string
+                mac:
+                  type: string
+                owner:
+                  type: string
+                state:
+                  description: 'IP tag id, defaults to 2 (Used)'
+                  type: integer
+              type: object
+      responses:
+        '201':
+          description: 'Address created'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse'
+        '400':
+          description: 'Invalid custom field, or invalid address type'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: 'No addresses found'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '409':
+          description: 'IP address already exists'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: 'Failed to create address'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  '/{app_id}/prefix/external_id/{external_identifier_field}/':
+    get:
+      tags:
+        - prefix
+      summary: 'Find subnets and/or addresses linked by the configured external identifier field'
+      description: 'Searches both subnets and ipaddresses tables for rows whose external identifier column (private property external_identifier_field, default: csid) equals the provided value. Returns whichever of subnets/addresses were found; omits the key entirely for the side with no matches.'
+      operationId: 0a673b7ccc64e02a5cd7d2484c478aa6
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+        -
+          name: external_identifier_field
+          in: path
+          description: 'Value to match against the csid (external identifier) column, not the field name itself'
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                properties:
+                  subnets: { type: array, items: { $ref: '#/components/schemas/Subnet' } }
+                  addresses: { type: array, items: { $ref: '#/components/schemas/Address' } }
+                type: object
+        '404':
+          description: 'No objects found'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  '/{app_id}/tools/':
+    options:
+      tags:
+        - tools
+      summary: 'Discover supported tools routes/methods (HATEOAS)'
+      description: 'returns general Controllers and supported methods'
+      operationId: 04e6a69dee364d9b312a64c58fe3249e
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+      responses:
+        '200':
+          description: OK
+  '/{app_id}/tools/{subcontroller}/':
+    options:
+      tags:
+        - tools
+      summary: 'Discover supported routes/methods for a tools subcontroller (HATEOAS)'
+      operationId: ec487635f12a2580e5f43de54807124e
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+        -
+          name: subcontroller
+          in: path
+          description: 'One of: ipTags, devices, deviceTypes, vlans, vrf, nameservers, scanAgents, locations, racks, nat, customers'
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
+  '/{app_id}/tools/tags/':
+    get:
+      tags:
+        - tools
+      summary: 'List all IP tags'
+      description: "fetch tools object\n\n\tstructure:\n\t\t/tools/{subcontroller}/{identifier}/{parameter}/\n\n\t\t/tools/id/id2/id3/\n\n\t\t- {subcontroller}\t- defines which tools object to work on\n\t\t- {identifier}\t\t- defines id for that object (optional)\n\t\t- {parameter}\t\t- additional parameter (optional)\n\n Special options:\n     - /tools/device_types/{id}/\n     - /tools/device_types/{id}/devices/\n\n     - /tools/vlans/{id}/subnets/\n\n     - /tools/vrf/{id}/subnets/\n\n     - /tools/locations/{id}/subnets/\n     - /tools/locations/{id}/devices/\n     - /tools/locations/{id}/racks/\n     - /tools/locations/{id}/ipaddresses/\n\n     - /tools/racks/{id}/devices/\n\n     - /tools/nat/{id}/objects/\n     - /tools/nat/{id}/objects_full/"
+      operationId: 4a2b4e8fa5cb594fbdc6063e7a367a1b
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  properties: { id: { type: integer, example: 1 }, type: { type: string, example: Offline }, showtag: { type: boolean }, bgcolor: { type: string, example: '#f59c99' }, fgcolor: { type: string, example: '#ffffff' }, compress: { type: string, enum: ['No', 'Yes'] }, locked: { type: string, enum: ['No', 'Yes'] }, updateTag: { type: boolean } }
+                  type: object
+        '404':
+          description: 'No objects found'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+    post:
+      tags:
+        - tools
+      summary: 'Create a new IP tag'
+      description: "Creates new tools object\n\n\trequired parameters:\n\t\tid {subcontroller}\n\n\t\t/tools/{subcontroller}/"
+      operationId: ddc0cfdbfc052b9af16898486558da0b
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              required:
+                - type
+              properties:
+                type:
+                  type: string
+                  example: Maintenance
+                showtag:
+                  type: boolean
+                  default: true
+                bgcolor:
+                  type: string
+                  example: '#000'
+                fgcolor:
+                  type: string
+                  example: '#fff'
+                compress:
+                  type: string
+                  default: 'No'
+                  enum: ['No', 'Yes']
+                locked:
+                  type: string
+                  default: 'No'
+                  enum: ['No', 'Yes']
+                updateTag:
+                  type: boolean
+                  default: false
+              type: object
+      responses:
+        '201':
+          description: 'Tag created'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse'
+        '400':
+          description: 'No parameters'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: 'Object creation failed'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  '/{app_id}/tools/tags/{id}/':
+    get:
+      tags:
+        - tools
+      summary: 'Read a single IP tag by id'
+      operationId: 5e8596041de39e32947664c8c65bdda2
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                properties:
+                  id: { type: integer }
+                  type: { type: string }
+                  showtag: { type: boolean }
+                  bgcolor: { type: string }
+                  fgcolor: { type: string }
+                  compress: { type: string, enum: ['No', 'Yes'] }
+                  locked: { type: string, enum: ['No', 'Yes'] }
+                  updateTag: { type: boolean }
+                type: object
+        '400':
+          description: 'Identifier must be numeric'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: 'No objects found'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+    delete:
+      tags:
+        - tools
+      summary: 'Delete an IP tag'
+      description: 'Also clears ipaddresses.state references to this tag.'
+      operationId: e458b115e0f25c6ce478e85bf3814a03
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: 'Tag deleted'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse'
+        '400':
+          description: 'Invalid identifier'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: 'Object delete failed'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+    patch:
+      tags:
+        - tools
+      summary: 'Update an IP tag'
+      description: 'Updates tools object'
+      operationId: 22d584d0c39f70295db05dba6c5af802
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                type:
+                  type: string
+                showtag:
+                  type: boolean
+                bgcolor:
+                  type: string
+                fgcolor:
+                  type: string
+                compress:
+                  type: string
+                  enum: ['No', 'Yes']
+                locked:
+                  type: string
+                  enum: ['No', 'Yes']
+                updateTag:
+                  type: boolean
+              type: object
+      responses:
+        '200':
+          description: 'Tag updated'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse'
+        '400':
+          description: 'No parameters or invalid identifier'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: 'Object edit failed'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  '/{app_id}/tools/tags/{id}/addresses/':
+    get:
+      tags:
+        - tools
+      summary: 'List addresses currently marked with this IP tag'
+      description: 'Matches ipaddresses.state == {id}.'
+      operationId: 4290aecfd4f38adf07bb59f5930908c9
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Address'
+        '404':
+          description: 'No objects found'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  '/{app_id}/tools/devices/':
+    get:
+      tags:
+        - tools
+      summary: 'List all devices'
+      operationId: d97dfd8a12e03fa71f13e7b9902bb223
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Device'
+        '404':
+          description: 'No objects found'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+    post:
+      tags:
+        - tools
+      summary: 'Create a new device'
+      operationId: 99fd0b3424b5f8eabb0f76c641693d59
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              required:
+                - hostname
+              properties:
+                hostname:
+                  type: string
+                ip_addr:
+                  type: string
+                  nullable: true
+                type:
+                  description: 'Device type id (deviceTypes.tid)'
+                  type: integer
+                description:
+                  type: string
+                  nullable: true
+                sections:
+                  description: 'Semicolon separated list of section ids'
+                  type: string
+                  nullable: true
+                snmp_community:
+                  type: string
+                  nullable: true
+                snmp_version:
+                  type: string
+                  enum: ['0', '1', '2', '3']
+                snmp_port:
+                  type: integer
+                  nullable: true
+                snmp_timeout:
+                  type: integer
+                  nullable: true
+                snmp_queries:
+                  type: string
+                  nullable: true
+                rack:
+                  type: integer
+                  nullable: true
+                rack_start:
+                  type: integer
+                  nullable: true
+                rack_size:
+                  type: integer
+                  nullable: true
+                location:
+                  type: integer
+                  nullable: true
+                address:
+                  description: 'If lat/long are not set, resolved to coordinates via Nominatim'
+                  type: string
+                  nullable: true
+                lat:
+                  type: string
+                  nullable: true
+                long:
+                  type: string
+                  nullable: true
+              type: object
+      responses:
+        '201':
+          description: 'Device created'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse'
+        '400':
+          description: 'No parameters, invalid device type or invalid ip_addr'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: 'Object creation failed'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  '/{app_id}/tools/devices/{id}/':
+    get:
+      tags:
+        - tools
+      summary: 'Read a single device by id'
+      operationId: 104304c708ff706cc6bc043f0d3d5b35
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Device'
+        '400':
+          description: 'Identifier must be numeric'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: 'No objects found'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+    delete:
+      tags:
+        - tools
+      summary: 'Delete a device'
+      description: 'Also clears ipaddresses.switch references to this device.'
+      operationId: 3903ea8abe527df55da091b356af9fcc
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: 'Device deleted'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse'
+        '400':
+          description: 'Invalid identifier'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: 'Object delete failed'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+    patch:
+      tags:
+        - tools
+      summary: 'Update a device'
+      operationId: 23af986021c427024614e5d180b3973a
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                hostname:
+                  type: string
+                ip_addr:
+                  type: string
+                  nullable: true
+                type:
+                  description: 'Device type id (deviceTypes.tid)'
+                  type: integer
+                description:
+                  type: string
+                  nullable: true
+                sections:
+                  type: string
+                  nullable: true
+                snmp_community:
+                  type: string
+                  nullable: true
+                rack:
+                  type: integer
+                  nullable: true
+                rack_start:
+                  type: integer
+                  nullable: true
+                rack_size:
+                  type: integer
+                  nullable: true
+                location:
+                  type: integer
+                  nullable: true
+                address:
+                  type: string
+                  nullable: true
+                lat:
+                  type: string
+                  nullable: true
+                long:
+                  type: string
+                  nullable: true
+              type: object
+      responses:
+        '200':
+          description: 'Device updated'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse'
+        '400':
+          description: 'No parameters, invalid device type, invalid ip_addr or invalid identifier'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: 'Object edit failed'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  '/{app_id}/tools/devices/{id}/addresses/':
+    get:
+      tags:
+        - tools
+      summary: 'List addresses whose switch is this device'
+      description: 'Matches ipaddresses.switch == {id}.'
+      operationId: 40b205f9d1cdbfe523d024a2f2e882ab
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Address'
+        '404':
+          description: 'No objects found'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  '/{app_id}/tools/device_types/':
+    get:
+      tags:
+        - tools
+      summary: 'List all device types'
+      operationId: e9cc5d61c75c8d3d2c6f9d9b26906972
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  properties: { tid: { type: integer, example: 1 }, tname: { type: string, example: Switch }, tdescription: { type: string, nullable: true }, bgcolor: { type: string, example: '#E6E6E6' }, fgcolor: { type: string, example: '#000' } }
+                  type: object
+        '404':
+          description: 'No objects found'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+    post:
+      tags:
+        - tools
+      summary: 'Create a new device type'
+      operationId: 47141d30ae9fe664fd4a2f90534e232a
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              required:
+                - tname
+              properties:
+                tname:
+                  type: string
+                  example: 'Custom type'
+                tdescription:
+                  type: string
+                  nullable: true
+                bgcolor:
+                  type: string
+                  example: '#E6E6E6'
+                fgcolor:
+                  type: string
+                  example: '#000'
+              type: object
+      responses:
+        '201':
+          description: 'Device type created'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse'
+        '400':
+          description: 'No parameters'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: 'Object creation failed'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  '/{app_id}/tools/device_types/{id}/':
+    get:
+      tags:
+        - tools
+      summary: 'Read a single device type by id'
+      description: '{id} maps to the deviceTypes.tid field.'
+      operationId: 0e91a77f920c7cf8fd23e9f73902f39e
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                properties:
+                  tid: { type: integer }
+                  tname: { type: string }
+                  tdescription: { type: string, nullable: true }
+                  bgcolor: { type: string }
+                  fgcolor: { type: string }
+                type: object
+        '400':
+          description: 'Identifier must be numeric'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: 'No objects found'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+    delete:
+      tags:
+        - tools
+      summary: 'Delete a device type'
+      description: '{id} maps to the deviceTypes.tid field.'
+      operationId: 4b06bde4a8d083cd7d1633a7304f8660
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: 'Device type deleted'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse'
+        '400':
+          description: 'Invalid identifier'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: 'Object delete failed'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+    patch:
+      tags:
+        - tools
+      summary: 'Update a device type'
+      description: '{id} maps to the deviceTypes.tid field.'
+      operationId: 4126f97e18e811917b97cf07c712e83a
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                tname:
+                  type: string
+                tdescription:
+                  type: string
+                  nullable: true
+                bgcolor:
+                  type: string
+                fgcolor:
+                  type: string
+              type: object
+      responses:
+        '200':
+          description: 'Device type updated'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse'
+        '400':
+          description: 'No parameters or invalid identifier'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: 'Object edit failed'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  '/{app_id}/tools/device_types/{id}/devices/':
+    get:
+      tags:
+        - tools
+      summary: 'List devices of this device type'
+      operationId: 8df70ebf852b8ff89b6c506818ccf162
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+        -
+          name: id
+          in: path
+          description: 'Device type id (tid)'
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Device'
+        '404':
+          description: 'No objects found'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  '/{app_id}/tools/vlans/':
+    get:
+      tags:
+        - tools
+      summary: 'List all VLANs (read-only alias; manage VLANs via the /vlans controller)'
+      operationId: 2247385913385e6cf8ce63b54313bc45
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Vlan'
+        '404':
+          description: 'No objects found'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+    post:
+      tags:
+        - tools
+      summary: 'Not supported here - VLANs must be created via the /vlans controller'
+      operationId: 664d699f2709c50f13f2918837dc5273
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+      responses:
+        '400':
+          description: 'Please use vlans controller'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  '/{app_id}/tools/vlans/{id}/':
+    get:
+      tags:
+        - tools
+      summary: 'Read a single VLAN by id'
+      description: '{id} maps to the vlans.vlanId field.'
+      operationId: e6e5c76f776ad79e9c4456fec9a1045e
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Vlan'
+        '400':
+          description: 'Identifier must be numeric'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: 'No objects found'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+    delete:
+      tags:
+        - tools
+      summary: 'Not supported here - VLANs must be deleted via the /vlans controller'
+      operationId: 2c7d7e3d10aa76504be05177db2b6a99
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '400':
+          description: 'Please use vlans controller'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+    patch:
+      tags:
+        - tools
+      summary: 'Not supported here - VLANs must be updated via the /vlans controller'
+      operationId: 28a477d7cca6abe9593c2dad57d17dfb
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '400':
+          description: 'Please use vlans controller'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  '/{app_id}/tools/vlans/{id}/subnets/':
+    get:
+      tags:
+        - tools
+      summary: 'List subnets that belong to this VLAN'
+      operationId: 9104926710c31775f789ed26b8e83b74
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+        -
+          name: id
+          in: path
+          description: 'VLAN id (vlanId)'
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Subnet'
+        '404':
+          description: 'No objects found'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  '/{app_id}/tools/vrfs/':
+    get:
+      tags:
+        - tools
+      summary: 'List all VRFs (read-only alias; manage VRFs via the /vrf controller)'
+      operationId: 208d13a7dcbfe5929c117b7a17263cfd
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Vrf'
+        '404':
+          description: 'No objects found'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+    post:
+      tags:
+        - tools
+      summary: 'Not supported here - VRFs must be created via the /vrf controller'
+      operationId: 66b46f7ac170aae56cd0b865f616edad
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+      responses:
+        '400':
+          description: 'Please use vrf controller'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  '/{app_id}/tools/vrfs/{id}/':
+    get:
+      tags:
+        - tools
+      summary: 'Read a single VRF by id'
+      description: '{id} maps to the vrf.vrfId field.'
+      operationId: 7c2af97baa126d6c4740780cb6ba6781
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Vrf'
+        '400':
+          description: 'Identifier must be numeric'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: 'No objects found'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+    delete:
+      tags:
+        - tools
+      summary: 'Not supported here - VRFs must be deleted via the /vrf controller'
+      operationId: 97e827df025faf7255312d1da48d1f61
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '400':
+          description: 'Please use vrf controller'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+    patch:
+      tags:
+        - tools
+      summary: 'Not supported here - VRFs must be updated via the /vrf controller'
+      operationId: fafeec73f58f25f7250cd70ccdcfcf2a
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '400':
+          description: 'Please use vrf controller'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  '/{app_id}/tools/vrfs/{id}/subnets/':
+    get:
+      tags:
+        - tools
+      summary: 'List subnets that belong to this VRF'
+      operationId: 6c7e4ff34c723c881141f348c12e4d98
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+        -
+          name: id
+          in: path
+          description: 'VRF id (vrfId)'
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Subnet'
+        '404':
+          description: 'No objects found'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  '/{app_id}/tools/nameservers/':
+    get:
+      tags:
+        - tools
+      summary: 'List all nameserver sets'
+      operationId: 87699836358072b6f76baab7d2f8b985
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  properties: { id: { type: integer, example: 1 }, name: { type: string, example: 'Google NS' }, namesrv1: { description: 'Semicolon separated list of nameserver IPs', type: string, example: 8.8.8.8;8.8.4.4 }, description: { type: string, nullable: true }, permissions: { description: 'JSON-encoded map of groupId => permission level', type: string, nullable: true } }
+                  type: object
+        '404':
+          description: 'No objects found'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+    post:
+      tags:
+        - tools
+      summary: 'Create a new nameserver set'
+      operationId: b16bbd0c658373d8584aa6a6d49f1e7c
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              required:
+                - name
+                - namesrv1
+              properties:
+                name:
+                  type: string
+                  example: 'Google NS'
+                namesrv1:
+                  description: 'Semicolon separated list of nameserver IPs'
+                  type: string
+                  example: 8.8.8.8;8.8.4.4
+                description:
+                  type: string
+                  nullable: true
+                permissions:
+                  description: 'JSON-encoded map of groupId => permission level'
+                  type: string
+                  nullable: true
+              type: object
+      responses:
+        '201':
+          description: 'Nameserver set created'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse'
+        '400':
+          description: 'No parameters'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: 'Object creation failed'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  '/{app_id}/tools/nameservers/{id}/':
+    get:
+      tags:
+        - tools
+      summary: 'Read a single nameserver set by id'
+      operationId: 3de8527ceb62f765c06b921ed3fefc58
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                properties:
+                  id: { type: integer }
+                  name: { type: string }
+                  namesrv1: { type: string }
+                  description: { type: string, nullable: true }
+                  permissions: { type: string, nullable: true }
+                type: object
+        '400':
+          description: 'Identifier must be numeric'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: 'No objects found'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+    delete:
+      tags:
+        - tools
+      summary: 'Delete a nameserver set'
+      operationId: 3f79139f4dc801e804d6074d7c3e00c0
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: 'Nameserver set deleted'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse'
+        '400':
+          description: 'Invalid identifier'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: 'Object delete failed'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+    patch:
+      tags:
+        - tools
+      summary: 'Update a nameserver set'
+      operationId: b6935dbc65cb9e7c111dadaf4e86b6ab
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                name:
+                  type: string
+                namesrv1:
+                  type: string
+                description:
+                  type: string
+                  nullable: true
+                permissions:
+                  type: string
+                  nullable: true
+              type: object
+      responses:
+        '200':
+          description: 'Nameserver set updated'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse'
+        '400':
+          description: 'No parameters or invalid identifier'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: 'Object edit failed'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  '/{app_id}/tools/scanagents/':
+    get:
+      tags:
+        - tools
+      summary: 'List all scan agents'
+      operationId: c2d2d336cabbe3e1c5cb4e29327439b0
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  properties: { id: { type: integer, example: 1 }, name: { type: string, example: localhost }, description: { type: string, nullable: true }, type: { type: string, enum: [direct, api, mysql] }, code: { description: 'Unique agent code used by the scanning script', type: string, nullable: true }, last_access: { type: string, format: date-time, nullable: true } }
+                  type: object
+        '404':
+          description: 'No objects found'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+    post:
+      tags:
+        - tools
+      summary: 'Create a new scan agent'
+      operationId: 867d16b33140ad00de5f3672b107ee36
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              required:
+                - name
+              properties:
+                name:
+                  type: string
+                description:
+                  type: string
+                  nullable: true
+                type:
+                  type: string
+                  enum: [direct, api, mysql]
+                code:
+                  description: 'Unique agent code used by the scanning script'
+                  type: string
+                  nullable: true
+              type: object
+      responses:
+        '201':
+          description: 'Scan agent created'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse'
+        '400':
+          description: 'No parameters'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: 'Object creation failed'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  '/{app_id}/tools/scanagents/{id}/':
+    get:
+      tags:
+        - tools
+      summary: 'Read a single scan agent by id'
+      operationId: 16d0e4d9397ec0f6bb9cbdb6712ebd32
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                properties:
+                  id: { type: integer }
+                  name: { type: string }
+                  description: { type: string, nullable: true }
+                  type: { type: string, enum: [direct, api, mysql] }
+                  code: { type: string, nullable: true }
+                  last_access: { type: string, format: date-time, nullable: true }
+                type: object
+        '400':
+          description: 'Identifier must be numeric'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: 'No objects found'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+    delete:
+      tags:
+        - tools
+      summary: 'Delete a scan agent'
+      operationId: 21f82c8871ec7511e50f2ff4be1492ad
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: 'Scan agent deleted'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse'
+        '400':
+          description: 'Invalid identifier'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: 'Object delete failed'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+    patch:
+      tags:
+        - tools
+      summary: 'Update a scan agent'
+      operationId: d29e1fbaae2da77b41699a387d31bcc7
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                name:
+                  type: string
+                description:
+                  type: string
+                  nullable: true
+                type:
+                  type: string
+                  enum: [direct, api, mysql]
+                code:
+                  type: string
+                  nullable: true
+              type: object
+      responses:
+        '200':
+          description: 'Scan agent updated'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse'
+        '400':
+          description: 'No parameters or invalid identifier'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: 'Object edit failed'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  '/{app_id}/tools/locations/':
+    get:
+      tags:
+        - tools
+      summary: 'List all locations'
+      operationId: f9755927788708a7dd043dc6aeb070ac
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  properties: { id: { type: integer, example: 1 }, name: { type: string }, description: { type: string, nullable: true }, address: { type: string, nullable: true }, lat: { type: string, nullable: true }, long: { type: string, nullable: true } }
+                  type: object
+        '404':
+          description: 'No objects found'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+    post:
+      tags:
+        - tools
+      summary: 'Create a new location'
+      operationId: de24af825179f8ccae2585011ca0d406
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              required:
+                - name
+              properties:
+                name:
+                  type: string
+                description:
+                  type: string
+                  nullable: true
+                address:
+                  description: 'If lat/long are not set, resolved to coordinates via Nominatim'
+                  type: string
+                  nullable: true
+                lat:
+                  type: string
+                  nullable: true
+                long:
+                  type: string
+                  nullable: true
+              type: object
+      responses:
+        '201':
+          description: 'Location created'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse'
+        '400':
+          description: 'No parameters'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: 'Object creation failed'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  '/{app_id}/tools/locations/{id}/':
+    get:
+      tags:
+        - tools
+      summary: 'Read a single location by id'
+      operationId: 4c950b7bb4218373ad1b1fcec446e11a
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                properties:
+                  id: { type: integer }
+                  name: { type: string }
+                  description: { type: string, nullable: true }
+                  address: { type: string, nullable: true }
+                  lat: { type: string, nullable: true }
+                  long: { type: string, nullable: true }
+                type: object
+        '400':
+          description: 'Identifier must be numeric'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: 'No objects found'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+    delete:
+      tags:
+        - tools
+      summary: 'Delete a location'
+      operationId: 4bcaf13e6cabdb49de975138554ce636
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: 'Location deleted'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse'
+        '400':
+          description: 'Invalid identifier'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: 'Object delete failed'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+    patch:
+      tags:
+        - tools
+      summary: 'Update a location'
+      operationId: 4b740ebf860cf29db050ec0b7a79e0fb
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                name:
+                  type: string
+                description:
+                  type: string
+                  nullable: true
+                address:
+                  type: string
+                  nullable: true
+                lat:
+                  type: string
+                  nullable: true
+                long:
+                  type: string
+                  nullable: true
+              type: object
+      responses:
+        '200':
+          description: 'Location updated'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse'
+        '400':
+          description: 'No parameters or invalid identifier'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: 'Object edit failed'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  '/{app_id}/tools/locations/{id}/subnets/':
+    get:
+      tags:
+        - tools
+      summary: 'List subnets assigned to this location'
+      operationId: fecc4850970d995d6afbdea684777e80
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Subnet'
+        '404':
+          description: 'No objects found'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  '/{app_id}/tools/locations/{id}/devices/':
+    get:
+      tags:
+        - tools
+      summary: 'List devices assigned to this location'
+      operationId: 97c75fe86e7ebc250969897344491b31
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Device'
+        '404':
+          description: 'No objects found'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  '/{app_id}/tools/locations/{id}/racks/':
+    get:
+      tags:
+        - tools
+      summary: 'List racks assigned to this location'
+      operationId: 60301cf8de9453a403ffbb1b81ff96e4
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  properties: { id: { type: integer }, name: { type: string }, size: { type: integer, nullable: true }, location: { type: integer, nullable: true } }
+                  type: object
+        '404':
+          description: 'No objects found'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  '/{app_id}/tools/locations/{id}/ipaddresses/':
+    get:
+      tags:
+        - tools
+      summary: 'List IP addresses assigned to this location'
+      operationId: 13faec9687b1a562be227d9b5a46e450
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Address'
+        '404':
+          description: 'No objects found'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  '/{app_id}/tools/racks/':
+    get:
+      tags:
+        - tools
+      summary: 'List all racks'
+      operationId: 57ffe9e7ea39c1b7855f33e3c4d98a32
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  properties: { id: { type: integer, example: 1 }, name: { type: string }, size: { type: integer, nullable: true }, subrack: { type: boolean }, location: { type: integer, nullable: true }, row: { type: integer }, hasBack: { type: boolean }, topDown: { type: boolean }, description: { type: string, nullable: true }, customer_id: { type: integer, nullable: true } }
+                  type: object
+        '404':
+          description: 'No objects found'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+    post:
+      tags:
+        - tools
+      summary: 'Create a new rack'
+      operationId: 2b5a5b8d9dd9222438b61ef4d3b1ffa4
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              required:
+                - name
+              properties:
+                name:
+                  type: string
+                size:
+                  description: "Number of U's"
+                  type: integer
+                  nullable: true
+                subrack:
+                  type: boolean
+                  default: false
+                location:
+                  type: integer
+                  nullable: true
+                row:
+                  type: integer
+                  default: 1
+                hasBack:
+                  type: boolean
+                  default: false
+                topDown:
+                  type: boolean
+                  default: false
+                description:
+                  type: string
+                  nullable: true
+                customer_id:
+                  type: integer
+                  nullable: true
+              type: object
+      responses:
+        '201':
+          description: 'Rack created'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse'
+        '400':
+          description: 'No parameters'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: 'Object creation failed'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  '/{app_id}/tools/racks/{id}/':
+    get:
+      tags:
+        - tools
+      summary: 'Read a single rack by id'
+      operationId: 693b4a3601e70353e3a1cce2f45c8e6e
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                properties:
+                  id: { type: integer }
+                  name: { type: string }
+                  size: { type: integer, nullable: true }
+                  subrack: { type: boolean }
+                  location: { type: integer, nullable: true }
+                  row: { type: integer }
+                  hasBack: { type: boolean }
+                  topDown: { type: boolean }
+                  description: { type: string, nullable: true }
+                  customer_id: { type: integer, nullable: true }
+                type: object
+        '400':
+          description: 'Identifier must be numeric'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: 'No objects found'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+    delete:
+      tags:
+        - tools
+      summary: 'Delete a rack'
+      operationId: b0563e234f6039b90799b26a4f6d6abc
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: 'Rack deleted'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse'
+        '400':
+          description: 'Invalid identifier'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: 'Object delete failed'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+    patch:
+      tags:
+        - tools
+      summary: 'Update a rack'
+      operationId: 6e827d63ca307aab666e48abaaf4024d
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                name:
+                  type: string
+                size:
+                  type: integer
+                  nullable: true
+                subrack:
+                  type: boolean
+                location:
+                  type: integer
+                  nullable: true
+                row:
+                  type: integer
+                hasBack:
+                  type: boolean
+                topDown:
+                  type: boolean
+                description:
+                  type: string
+                  nullable: true
+                customer_id:
+                  type: integer
+                  nullable: true
+              type: object
+      responses:
+        '200':
+          description: 'Rack updated'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse'
+        '400':
+          description: 'No parameters or invalid identifier'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: 'Object edit failed'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  '/{app_id}/tools/racks/{id}/devices/':
+    get:
+      tags:
+        - tools
+      summary: 'List devices mounted in this rack'
+      operationId: 90a56c287829484fa23053e6407d124e
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Device'
+        '404':
+          description: 'No objects found'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  '/{app_id}/tools/nat/':
+    get:
+      tags:
+        - tools
+      summary: 'List all NAT rules'
+      operationId: a369ea241e0f1fdc71c8ac14cdcd4722
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  properties: { id: { type: integer, example: 1 }, name: { type: string, nullable: true }, type: { type: string, enum: [source, static, destination] }, src: { description: 'JSON-encoded map of object type => array of ids', type: string, nullable: true }, dst: { description: 'JSON-encoded map of object type => array of ids', type: string, nullable: true }, src_port: { type: integer, nullable: true }, dst_port: { type: integer, nullable: true }, device: { description: 'Device id owning this NAT rule', type: integer, nullable: true }, description: { type: string, nullable: true }, policy: { type: string, enum: ['Yes', 'No'] }, policy_dst: { type: string, nullable: true } }
+                  type: object
+        '404':
+          description: 'No objects found'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+    post:
+      tags:
+        - tools
+      summary: 'Create a new NAT rule'
+      operationId: 40d5d8e75899c7af627d3b5a293dd19b
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              properties:
+                name:
+                  type: string
+                  nullable: true
+                type:
+                  type: string
+                  default: source
+                  enum: [source, static, destination]
+                src:
+                  description: 'JSON-encoded map of object type => array of ids'
+                  type: string
+                  nullable: true
+                dst:
+                  description: 'JSON-encoded map of object type => array of ids'
+                  type: string
+                  nullable: true
+                src_port:
+                  type: integer
+                  nullable: true
+                dst_port:
+                  type: integer
+                  nullable: true
+                device:
+                  description: 'Device id owning this NAT rule'
+                  type: integer
+                  nullable: true
+                description:
+                  type: string
+                  nullable: true
+                policy:
+                  type: string
+                  default: 'No'
+                  enum: ['Yes', 'No']
+                policy_dst:
+                  type: string
+                  nullable: true
+              type: object
+      responses:
+        '201':
+          description: 'NAT rule created'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse'
+        '400':
+          description: 'No parameters'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: 'Object creation failed'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  '/{app_id}/tools/nat/{id}/':
+    get:
+      tags:
+        - tools
+      summary: 'Read a single NAT rule by id'
+      operationId: a0f833c5528e1d57a20dd13740ebd6c7
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                properties:
+                  id: { type: integer }
+                  name: { type: string, nullable: true }
+                  type: { type: string, enum: [source, static, destination] }
+                  src: { type: string, nullable: true }
+                  dst: { type: string, nullable: true }
+                  device: { type: integer, nullable: true }
+                  description: { type: string, nullable: true }
+                type: object
+        '400':
+          description: 'Identifier must be numeric'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: 'No objects found'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+    delete:
+      tags:
+        - tools
+      summary: 'Delete a NAT rule'
+      operationId: f27365617384db185ca39135146a659b
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: 'NAT rule deleted'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse'
+        '400':
+          description: 'Invalid identifier'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: 'Object delete failed'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+    patch:
+      tags:
+        - tools
+      summary: 'Update a NAT rule'
+      operationId: 7ee08d343c3a86d18b4ef980c67ef259
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                name:
+                  type: string
+                  nullable: true
+                type:
+                  type: string
+                  enum: [source, static, destination]
+                src:
+                  type: string
+                  nullable: true
+                dst:
+                  type: string
+                  nullable: true
+                src_port:
+                  type: integer
+                  nullable: true
+                dst_port:
+                  type: integer
+                  nullable: true
+                device:
+                  type: integer
+                  nullable: true
+                description:
+                  type: string
+                  nullable: true
+                policy:
+                  type: string
+                  enum: ['Yes', 'No']
+                policy_dst:
+                  type: string
+                  nullable: true
+              type: object
+      responses:
+        '200':
+          description: 'NAT rule updated'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse'
+        '400':
+          description: 'No parameters or invalid identifier'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: 'Object edit failed'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  '/{app_id}/tools/nat/{id}/objects/':
+    get:
+      tags:
+        - tools
+      summary: 'Get a NAT rule with its src/dst object id lists decoded'
+      description: 'src and dst are returned as a map of object type (e.g. subnets, ipaddresses) to an array of referenced object ids.'
+      operationId: 1eafd16db908373660be40df2d2922cd
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: OK
+        '404':
+          description: 'No objects found'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  '/{app_id}/tools/nat/{id}/objects_full/':
+    get:
+      tags:
+        - tools
+      summary: 'Get a NAT rule with its src/dst objects fully resolved'
+      description: 'Like objects/, but each referenced id is replaced with the full fetched object.'
+      operationId: 51190d4247c61b33e5ebccb2f281f6c5
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: OK
+        '404':
+          description: 'No objects found'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  '/{app_id}/tools/customers/':
+    get:
+      tags:
+        - tools
+      summary: 'List all customers'
+      operationId: e163592019d96e505cfccbf8546b0905
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  properties: { id: { type: integer, example: 1 }, title: { type: string }, address: { type: string, nullable: true }, postcode: { type: string, nullable: true }, city: { type: string, nullable: true }, state: { type: string, nullable: true }, lat: { type: string, nullable: true }, long: { type: string, nullable: true }, contact_person: { type: string, nullable: true }, contact_phone: { type: string, nullable: true }, contact_mail: { type: string, nullable: true }, note: { type: string, nullable: true }, status: { type: string, enum: [Active, Reserved, Inactive] } }
+                  type: object
+        '404':
+          description: 'No objects found'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+    post:
+      tags:
+        - tools
+      summary: 'Create a new customer'
+      operationId: 64640cb7a252fbc33a63b1ea242c6c28
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              required:
+                - title
+              properties:
+                title:
+                  type: string
+                address:
+                  type: string
+                  nullable: true
+                postcode:
+                  type: string
+                  nullable: true
+                city:
+                  type: string
+                  nullable: true
+                state:
+                  type: string
+                  nullable: true
+                lat:
+                  type: string
+                  nullable: true
+                long:
+                  type: string
+                  nullable: true
+                contact_person:
+                  type: string
+                  nullable: true
+                contact_phone:
+                  type: string
+                  nullable: true
+                contact_mail:
+                  type: string
+                  nullable: true
+                note:
+                  type: string
+                  nullable: true
+                status:
+                  type: string
+                  default: Active
+                  enum: [Active, Reserved, Inactive]
+              type: object
+      responses:
+        '201':
+          description: 'Customer created'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse'
+        '400':
+          description: 'No parameters'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: 'Object creation failed'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  '/{app_id}/tools/customers/{id}/':
+    get:
+      tags:
+        - tools
+      summary: 'Read a single customer by id'
+      operationId: ce971c4ce7cc1d49b2afcd4916a325e0
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                properties:
+                  id: { type: integer }
+                  title: { type: string }
+                  address: { type: string, nullable: true }
+                  city: { type: string, nullable: true }
+                  contact_phone: { type: string, nullable: true }
+                  contact_mail: { type: string, nullable: true }
+                  status: { type: string, enum: [Active, Reserved, Inactive] }
+                type: object
+        '400':
+          description: 'Identifier must be numeric'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: 'No objects found'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+    delete:
+      tags:
+        - tools
+      summary: 'Delete a customer'
+      operationId: 04977ee452e9111211bca7da64e6afb5
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: 'Customer deleted'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse'
+        '400':
+          description: 'Invalid identifier'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: 'Object delete failed'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+    patch:
+      tags:
+        - tools
+      summary: 'Update a customer'
+      operationId: 30e37d274e3e2a940471609dae364ee3
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+        -
+          name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              properties:
+                title:
+                  type: string
+                address:
+                  type: string
+                  nullable: true
+                postcode:
+                  type: string
+                  nullable: true
+                city:
+                  type: string
+                  nullable: true
+                state:
+                  type: string
+                  nullable: true
+                lat:
+                  type: string
+                  nullable: true
+                long:
+                  type: string
+                  nullable: true
+                contact_person:
+                  type: string
+                  nullable: true
+                contact_phone:
+                  type: string
+                  nullable: true
+                contact_mail:
+                  type: string
+                  nullable: true
+                note:
+                  type: string
+                  nullable: true
+                status:
+                  type: string
+                  enum: [Active, Reserved, Inactive]
+              type: object
+      responses:
+        '200':
+          description: 'Customer updated'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse'
+        '400':
+          description: 'No parameters or invalid identifier'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: 'Object edit failed'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  '/{app_id}/search/':
+    options:
+      tags:
+        - search
+      summary: 'Discover supported search routes/methods (HATEOAS)'
+      description: 'Returns json encoded options and version'
+      operationId: 6ffa1ea1598944ff75854a9e765be4c8
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+      responses:
+        '200':
+          description: OK
+  '/{app_id}/search/{search_string}/':
+    get:
+      tags:
+        - search
+      summary: 'Search subnets, addresses, VLANs and VRFs for a matching string or IP address'
+      description: 'Runs the search string against every object type that is enabled through the subnets/addresses/vlan/vrf query flags (subnets and addresses are searched by default, vlan and vrf are not). IP-like search strings are reformatted so that a partial address also matches. Each enabled object type gets its own key in the response data; a type with no hits reports its own "code":404 entry inline rather than failing the whole request. The effective flags are echoed back under "search_filter".'
+      operationId: 79cdc40847c49d89288476c17a1cf212
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+        -
+          name: search_string
+          in: path
+          description: 'Search string or (partial) IP address to search for'
+          required: true
+          schema:
+            type: string
+        -
+          name: subnets
+          in: query
+          description: 'Include subnets in the search (1=on, default; 0=off)'
+          required: false
+          schema:
+            type: integer
+            default: 1
+            enum:
+              - 0
+              - 1
+        -
+          name: addresses
+          in: query
+          description: 'Include IP addresses in the search (1=on, default; 0=off)'
+          required: false
+          schema:
+            type: integer
+            default: 1
+            enum:
+              - 0
+              - 1
+        -
+          name: vlan
+          in: query
+          description: 'Include VLANs in the search (1=on; 0=off, default)'
+          required: false
+          schema:
+            type: integer
+            default: 0
+            enum:
+              - 0
+              - 1
+        -
+          name: vrf
+          in: query
+          description: 'Include VRFs in the search (1=on; 0=off, default)'
+          required: false
+          schema:
+            type: integer
+            default: 0
+            enum:
+              - 0
+              - 1
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                properties:
+                  code: { type: integer, example: 200 }
+                  data: { properties: { subnets: { type: array, items: { $ref: '#/components/schemas/Subnet' } }, addresses: { type: array, items: { $ref: '#/components/schemas/Address' } }, vlan: { type: array, items: { $ref: '#/components/schemas/Vlan' } }, vrf: { type: array, items: { $ref: '#/components/schemas/Vrf' } }, search_filter: { description: 'Effective subnets/addresses/vlan/vrf flags applied to this search', type: object, example: { subnets: '1', addresses: '1', vlan: '0', vrf: '0' } } }, type: object }
+                type: object
+        '400':
+          description: 'Search string not provided'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  '/{app_id}/user/':
+    get:
+      tags:
+        - user
+      summary: 'Get current token expiration date'
+      description: "Authenticates user and returns token\n\n\tIdentifier can be:\n\t\t- /token_expires/\t\t\t\t// returns token expiration date\n\t\t- /expires/\t\t\t\t\t\t// returns token expiration date\n\t\t- /all/\t\t\t\t\t\t\t// returns all phpipam users\n\t\t- /admins/\t\t\t\t\t\t// returns ipam admins"
+      operationId: 15ee092bf2ff988e8b0d61af0e52c161
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                properties:
+                  expires: { type: string, format: date-time }
+                type: object
+        '401':
+          description: 'Invalid/missing token'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+    post:
+      tags:
+        - user
+      summary: 'Log in and obtain a phpipam-token (ssl_token security model)'
+      description: 'Send HTTP Basic Authentication credentials (a phpIPAM user/password with API permission on this app). If a still-valid token already exists for the user it is extended, otherwise a new one is generated. No phpipam-token header is required or used for this call.'
+      operationId: cbfbfdc313b07084288ee5995bb83d95
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                properties:
+                  token: { type: string }
+                  expires: { type: string, format: date-time }
+                type: object
+        '400':
+          description: 'Missing username/password'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '403':
+          description: 'Invalid credentials'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          description: 'IP blocked after excessive login failures'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+      security:
+        -
+          basicAuth: []
+    delete:
+      tags:
+        - user
+      summary: 'Revoke the current token (ssl_token security model)'
+      description: 'Deletes token'
+      operationId: 3a0b6ca6c0dac09b0384d0717927cba7
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+      responses:
+        '200':
+          description: 'Token removed'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse'
+        '401':
+          description: 'Invalid/missing token'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '409':
+          description: 'Authentication not needed (ssl_code apps have no per-session token)'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+    options:
+      tags:
+        - user
+      summary: 'Discover supported user routes/methods (HATEOAS)'
+      description: 'returns general Controllers and supported methods'
+      operationId: 27a750a63b7d4292c05b991b8d0b773d
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+      responses:
+        '200':
+          description: OK
+    patch:
+      tags:
+        - user
+      summary: 'Extend the validity of the current token (ssl_token security model)'
+      description: 'Extends token validity'
+      operationId: c106e47eb9bead90f16416b3207742cc
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                properties:
+                  expires: { type: string, format: date-time }
+                type: object
+        '401':
+          description: 'Invalid/missing token'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '409':
+          description: 'Authentication not needed (ssl_code apps have no per-session token)'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  '/{app_id}/user/all/':
+    get:
+      tags:
+        - user
+      summary: 'List all phpIPAM users (requires RWA app permission)'
+      operationId: e98e0a959b4d42185bf5f7882a47f7c2
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+      responses:
+        '200':
+          description: OK
+        '503':
+          description: 'Invalid app permissions'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  '/{app_id}/user/admins/':
+    get:
+      tags:
+        - user
+      summary: 'List phpIPAM administrator users (requires RWA app permission)'
+      operationId: 480308f989d6afaec8a822fc87d75e9d
+      parameters:
+        -
+          $ref: '#/components/parameters/app_id'
+      responses:
+        '200':
+          description: OK
+        '503':
+          description: 'Invalid app permissions'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+components:
+  schemas:
+    ErrorResponse:
+      properties:
+        code:
+          description: 'HTTP status code, repeated in the body'
+          type: integer
+          example: 400
+        success:
+          type: boolean
+          example: false
+        message:
+          type: string
+          example: 'Missing parameters'
+      type: object
+    SuccessResponse:
+      properties:
+        code:
+          type: integer
+          example: 200
+        success:
+          type: boolean
+          example: true
+        message:
+          type: string
+          example: 'Subnet updated'
+          nullable: true
+        data:
+          description: 'Payload, shape depends on the endpoint'
+          nullable: true
+      type: object
+    Section:
+      properties:
+        id:
+          type: integer
+          example: 1
+        name:
+          type: string
+          example: Customers
+        description:
+          type: string
+          nullable: true
+        masterSection:
+          description: 'Parent section id, 0 for a top-level section'
+          type: integer
+          example: 0
+        permissions:
+          description: 'JSON-encoded map of groupId => permission level'
+          type: string
+          nullable: true
+        strictMode:
+          type: boolean
+        subnetOrdering:
+          type: string
+          nullable: true
+        order:
+          type: integer
+          nullable: true
+        showSubnet:
+          type: boolean
+        showVLAN:
+          type: boolean
+        showVRF:
+          type: boolean
+        showSupernetOnly:
+          type: boolean
+        DNS:
+          type: string
+          nullable: true
+      type: object
+    Subnet:
+      properties:
+        id:
+          type: integer
+          example: 3
+        subnet:
+          description: 'Network address, stored as decimal string (IPv4 or IPv6)'
+          type: string
+          example: '168427776'
+        mask:
+          type: string
+          example: '24'
+        sectionId:
+          type: integer
+          example: 1
+        description:
+          type: string
+          nullable: true
+        linked_subnet:
+          type: integer
+          nullable: true
+        firewallAddressObject:
+          type: string
+          nullable: true
+        vrfId:
+          type: integer
+          nullable: true
+        masterSubnetId:
+          description: '0 for a top-level subnet'
+          type: integer
+          example: 0
+        allowRequests:
+          type: boolean
+        vlanId:
+          type: integer
+          nullable: true
+        showName:
+          type: boolean
+        device:
+          type: integer
+          nullable: true
+        permissions:
+          description: 'JSON-encoded map of groupId => permission level'
+          type: string
+          nullable: true
+        pingSubnet:
+          type: boolean
+        discoverSubnet:
+          type: boolean
+        resolveDNS:
+          type: boolean
+        DNSrecursive:
+          type: boolean
+        DNSrecords:
+          type: boolean
+        nameserverId:
+          type: integer
+          nullable: true
+        scanAgent:
+          type: integer
+          nullable: true
+        isFolder:
+          type: boolean
+        isFull:
+          type: boolean
+        isPool:
+          type: boolean
+        state:
+          type: integer
+          nullable: true
+        threshold:
+          type: integer
+          nullable: true
+        location:
+          type: integer
+          nullable: true
+        editDate:
+          type: string
+          format: date-time
+          nullable: true
+      type: object
+    Address:
+      properties:
+        id:
+          type: integer
+          example: 1
+        subnetId:
+          type: integer
+          example: 3
+        ip_addr:
+          description: 'Stored as decimal string; dotted/colon notation is used on input/output at the API boundary'
+          type: string
+          example: '168427779'
+        is_gateway:
+          type: boolean
+        description:
+          type: string
+          nullable: true
+        hostname:
+          type: string
+          nullable: true
+        mac:
+          type: string
+          nullable: true
+        owner:
+          type: string
+          nullable: true
+        state:
+          description: 'Address status/tag id (Used, Offline, Reserved, DHCP...)'
+          type: integer
+          nullable: true
+        switch:
+          type: integer
+          nullable: true
+        location:
+          type: integer
+          nullable: true
+        port:
+          type: string
+          nullable: true
+        note:
+          type: string
+          nullable: true
+        lastSeen:
+          type: string
+          format: date-time
+          nullable: true
+        excludePing:
+          type: boolean
+        PTRignore:
+          type: boolean
+        PTR:
+          type: integer
+          nullable: true
+        firewallAddressObject:
+          type: string
+          nullable: true
+        editDate:
+          type: string
+          format: date-time
+          nullable: true
+      type: object
+    Vlan:
+      properties:
+        vlanId:
+          type: integer
+          example: 1
+        domainId:
+          description: 'L2 domain id (see l2domains controller)'
+          type: integer
+          example: 1
+        name:
+          type: string
+          example: 'Servers DMZ'
+        number:
+          type: integer
+          example: 4001
+        description:
+          type: string
+          nullable: true
+        editDate:
+          type: string
+          format: date-time
+          nullable: true
+      type: object
+    Vrf:
+      properties:
+        vrfId:
+          type: integer
+          example: 1
+        name:
+          type: string
+          example: Customer-A
+        rd:
+          description: 'Route distinguisher'
+          type: string
+          nullable: true
+        description:
+          type: string
+          nullable: true
+        sections:
+          description: 'Comma-separated list of section ids this VRF is restricted to'
+          type: string
+          nullable: true
+        editDate:
+          type: string
+          format: date-time
+          nullable: true
+      type: object
+    Device:
+      properties:
+        id:
+          type: integer
+          example: 1
+        hostname:
+          type: string
+          nullable: true
+        ip_addr:
+          type: string
+          nullable: true
+        type:
+          description: 'Device type id, see tools/deviceTypes'
+          type: integer
+        description:
+          type: string
+          nullable: true
+        sections:
+          description: 'Comma-separated list of section ids'
+          type: string
+          nullable: true
+        snmp_community:
+          type: string
+          nullable: true
+        snmp_version:
+          type: string
+          nullable: true
+          enum:
+            - '0'
+            - '1'
+            - '2'
+            - '3'
+        snmp_port:
+          type: integer
+          nullable: true
+        snmp_timeout:
+          type: integer
+          nullable: true
+        snmp_queries:
+          type: string
+          nullable: true
+        rack:
+          type: integer
+          nullable: true
+        rack_start:
+          type: integer
+          nullable: true
+        rack_size:
+          type: integer
+          nullable: true
+        location:
+          type: integer
+          nullable: true
+        editDate:
+          type: string
+          format: date-time
+          nullable: true
+      type: object
+  parameters:
+    app_id:
+      name: app_id
+      in: path
+      description: 'API application identifier, created under Administration > API. Selects which application (and therefore which security model and permission set) handles the request.'
+      required: true
+      schema:
+        type: string
+        example: myapp
+  securitySchemes:
+    ssl_token:
+      type: apiKey
+      description: "Token-based authentication (app security = 'ssl_token', HTTPS required). Obtain a token by sending POST /api/{app_id}/user/ with HTTP Basic Authentication (a phpIPAM user/password with API permission on the app). The response contains data.token and data.expires. Send that token on every subsequent request in the phpipam-token header (an alias token header is also accepted). Refresh the expiration with PATCH /api/{app_id}/user/ and revoke it with DELETE /api/{app_id}/user/, both sent with the same header."
+      name: phpipam-token
+      in: header
+    ssl_code:
+      type: apiKey
+      description: "Static application-code authentication (app security = 'ssl_code', HTTPS required). No login step: the app's static app_code (set in Administration > API) is sent as-is in the phpipam-token header on every request. There is no token lifecycle — user/ GET is allowed, but POST/PATCH/DELETE on user/ are rejected with 409 since no per-session token exists."
+      name: phpipam-token
+      in: header
+    crypt:
+      type: apiKey
+      description: "Encrypted-body authentication (app security = 'crypt'). No phpipam-token header is used; instead the entire request payload (normally sent as JSON body or query string) is AES-encrypted (see Config api_crypt_encryption_library, default openssl-128-cbc) with the app's app_code as the password, base64-encoded, and sent as a single enc_request value (query string or POST body). The server decrypts it with the same app_code before processing the request as if the plaintext had been sent directly. Possessing a valid app_code is itself the authentication — there is no separate token."
+      name: enc_request
+      in: query
+    basicAuth:
+      type: http
+      description: 'HTTP Basic Authentication, used once to log in via POST /user/ and obtain a phpipam-token (ssl_token security model only). Not used on any other route.'
+      scheme: basic
+security:
+  -
+    ssl_token: []
+  -
+    ssl_code: []
+  -
+    crypt: []
+tags:
+  -
+    name: sections
+    description: sections
+  -
+    name: subnets
+    description: subnets
+  -
+    name: addresses
+    description: addresses
+  -
+    name: vlans
+    description: vlans
+  -
+    name: vrfs
+    description: vrfs
+  -
+    name: l2domains
+    description: l2domains
+  -
+    name: devices
+    description: devices
+  -
+    name: circuits
+    description: circuits
+  -
+    name: nat
+    description: nat
+  -
+    name: prefix
+    description: prefix
+  -
+    name: tools
+    description: tools
+  -
+    name: search
+    description: search
+  -
+    name: user
+    description: user

--- a/public/app/admin/api/index.php
+++ b/public/app/admin/api/index.php
@@ -113,6 +113,8 @@ $app_perms_text = ["SSL with User token"=>"ssl_token","SSL with App code token"=
 	?>
 
 	<h4><?php print _('API documentation'); ?></h4>
+	<a href="api/docs/index.html" target="_blank"><?php print _('Local API reference'); ?></a>
+	&nbsp;|&nbsp;
 	<a href="http://phpipam.net/api-documentation/" target="_blank">http://phpipam.net/api-documentation/</a>
 
 <?php


### PR DESCRIPTION
Adds zircote/swagger-php as a require-dev Composer dependency to generate public/api/openapi.yaml from PHP8 attributes on the 13 API controllers, and exposes it via a self-hosted Scalar viewer (public/api/docs/index.html) linked from the API admin page.

Resolve https://github.com/phpipam/phpipam/issues/858