### PR TITLE
Extend API search to cover devices, circuits, logical circuits, locations

### DIFF
--- a/functions/api/controllers/Search.php
+++ b/functions/api/controllers/Search.php
@@ -12,10 +12,14 @@ class Search_controller extends Common_api_functions {
 	 * @var array
 	 */
 	private $search_items = [
-						"subnets"   => "1",
-						"addresses" => "1",
-						"vlan"      => "0",
-						"vrf"       => "0"
+						"subnets"         => "1",
+						"addresses"       => "1",
+						"vlan"            => "0",
+						"vrf"             => "0",
+						"devices"         => "0",
+						"circuits"        => "0",
+						"circuitsLogical" => "0",
+						"locations"       => "0"
 	];
 
 	/**
@@ -111,6 +115,10 @@ class Search_controller extends Common_api_functions {
 			if ($this->search_items['addresses']==1) 	{ $result['addresses'] = $this->search_addresses (); }
 			if ($this->search_items['vlan']==1) 		{ $result['vlan']      = $this->search_vlans (); }
 			if ($this->search_items['vrf']==1) 			{ $result['vrf']       = $this->search_vrfs (); }
+			if ($this->search_items['devices']==1) 		{ $result['devices']   = $this->search_devices (); }
+			if ($this->search_items['circuits']==1) 		{ $result['circuits']  = $this->search_circuits (); }
+			if ($this->search_items['circuitsLogical']==1) { $result['circuitsLogical'] = $this->search_circuitsLogical (); }
+			if ($this->search_items['locations']==1) 	{ $result['locations'] = $this->search_locations (); }
 
 			// add filter
 			$result['search_filter'] = $this->search_items;
@@ -214,6 +222,78 @@ class Search_controller extends Common_api_functions {
 		}
 		else {
 			return ["code"=>200, "data"=>$this->prepare_result ($result, "vrfs", true, false)];
+		}
+	}
+
+	/**
+	 * Search devices
+	 * @method search_devices
+	 * @return array
+	 */
+	private function search_devices () {
+		// search
+		$result = $this->Tools->search_devices($this->_params->id, $this->Tools->fetch_custom_fields ("devices"));
+
+		// result
+		if(sizeof($result)==0) {
+			return ["code"=>404, "data"=>"No devices found"];
+		}
+		else {
+			return ["code"=>200, "data"=>$this->prepare_result ($result, "devices", true, false)];
+		}
+	}
+
+	/**
+	 * Search circuits
+	 * @method search_circuits
+	 * @return array
+	 */
+	private function search_circuits () {
+		// search
+		$result = $this->Tools->search_circuits($this->_params->id, $this->Tools->fetch_custom_fields ("circuits"));
+
+		// result
+		if(sizeof($result)==0) {
+			return ["code"=>404, "data"=>"No circuits found"];
+		}
+		else {
+			return ["code"=>200, "data"=>$this->prepare_result ($result, "circuits", true, false)];
+		}
+	}
+
+	/**
+	 * Search logical circuits
+	 * @method search_circuitsLogical
+	 * @return array
+	 */
+	private function search_circuitsLogical () {
+		// search
+		$result = $this->Tools->search_circuitsLogical($this->_params->id, $this->Tools->fetch_custom_fields ("circuitsLogical"));
+
+		// result
+		if(sizeof($result)==0) {
+			return ["code"=>404, "data"=>"No logical circuits found"];
+		}
+		else {
+			return ["code"=>200, "data"=>$this->prepare_result ($result, "circuitsLogical", true, false)];
+		}
+	}
+
+	/**
+	 * Search locations
+	 * @method search_locations
+	 * @return array
+	 */
+	private function search_locations () {
+		// search
+		$result = $this->Tools->search_locations($this->_params->id, $this->Tools->fetch_custom_fields ("locations"));
+
+		// result
+		if(sizeof($result)==0) {
+			return ["code"=>404, "data"=>"No locations found"];
+		}
+		else {
+			return ["code"=>200, "data"=>$this->prepare_result ($result, "locations", true, false)];
 		}
 	}
 }

--- a/functions/classes/class.Tools.php
+++ b/functions/classes/class.Tools.php
@@ -529,6 +529,72 @@ class Tools extends Common_functions {
 	}
 
 	/**
+	 * Search for locations
+	 *
+	 * @access public
+	 * @param mixed $search_term
+	 * @param array $custom_fields (default: [])
+	 * @return array
+	 */
+	public function search_locations ($search_term, $custom_fields = []) {
+		# query
+		$query[] = "select * from `locations` where `name` like :search_term or `description` like :search_term or `address` like :search_term ";
+		# custom
+		if(sizeof($custom_fields) > 0) {
+			foreach($custom_fields as $myField) {
+				$myField['name'] = $this->Database->escape($myField['name']);
+				$query[] = " or `{$myField['name']}` like :search_term ";
+			}
+		}
+		$query[] = ";";
+		# join query
+		$query = implode("\n", $query);
+
+		# fetch
+		try { $search = $this->Database->getObjectsQuery('locations', $query, ["search_term"=>"%$search_term%"]); }
+		catch (Exception $e) {
+			$this->Result->show("danger", _("Error: ").$e->getMessage());
+			return false;
+		}
+
+		# return result
+		return $search;
+	}
+
+	/**
+	 * Search for logical circuits
+	 *
+	 * @access public
+	 * @param mixed $search_term
+	 * @param array $custom_fields (default: [])
+	 * @return array
+	 */
+	public function search_circuitsLogical ($search_term, $custom_fields = []) {
+		# query
+		$query[] = "select * from `circuitsLogical` where `logical_cid` like :search_term or `purpose` like :search_term or `comments` like :search_term ";
+		# custom
+		if(sizeof($custom_fields) > 0) {
+			foreach($custom_fields as $myField) {
+				$myField['name'] = $this->Database->escape($myField['name']);
+				$query[] = " or `{$myField['name']}` like :search_term ";
+			}
+		}
+		$query[] = ";";
+		# join query
+		$query = implode("\n", $query);
+
+		# fetch
+		try { $search = $this->Database->getObjectsQuery('circuitsLogical', $query, ["search_term"=>"%$search_term%"]); }
+		catch (Exception $e) {
+			$this->Result->show("danger", _("Error: ").$e->getMessage());
+			return false;
+		}
+
+		# return result
+		return $search;
+	}
+
+	/**
 	 * Reformat possible nun-full IPv4 address for search
 	 *
 	 *	e.g. 10.10.10 -> 10.10.10.0 - 10.10.10.255


### PR DESCRIPTION
Part of #4642 (context/overview for a set of 4 related API fixes).

## Gap

`/api/{app_id}/search/{term}/` only ever searches subnets, addresses, VLANs, and VRFs:

```
curl -s -k -X GET --header "token: …" --header "Content-Type: application/json" \
  https://host/api/my_app/search/Test1/ | jq
```
```json
{
  "code": 200, "success": true,
  "data": {
    "subnets": {"code": 200, "data": [ ... ]},
    "addresses": {"code": 404, "data": "No addresses found"},
    "search_filter": {"subnets": "1", "addresses": "1", "vlan": "0", "vrf": "0"}
  }
}
```

Devices, Circuits, CircuitsLogical, and Locations aren't searchable at all, opt-in or
otherwise.

## Fix

Add `devices`, `circuits`, `circuitsLogical`, and `locations` to `Search_controller`'s
`search_items`, each opt-in via query param exactly like the existing `vlan`/`vrf`
(`?devices=1`), so default behavior is unchanged. `search_devices()` and `search_circuits()`
already existed in `class.Tools.php` (added for the web UI's own search page, #4407) but
were never wired into the API - this reuses them as-is. `search_locations()` and
`search_circuitsLogical()` are new, following the same `LIKE`-query-plus-custom-fields
shape as the existing `search_*` methods.

This is the API-side counterpart to #4497, which adds locations to the web UI's own search
page - that PR doesn't touch the REST API's `Search_controller` at all, so there's no
overlap.

## Tested with

Verified the default search filter is unchanged (only subnets/addresses active), and each
new type finds seeded data correctly when enabled via its query param.

Tested against PHP 8.2, 8.3, and 8.4 - lint clean and all scenarios passing on each, no new
PHP errors.