### PR TITLE
Make API OPTIONS report actual controller capabilities

### DIFF
--- a/functions/api/controllers/Tools.php
+++ b/functions/api/controllers/Tools.php
@@ -148,7 +148,7 @@ class Tools_controller extends Common_api_functions {
 		// get api
 		$app = $this->Tools->fetch_object ("api", "app_id", $this->_params->app_id);
 
-		// controllers
+		// top-level controllers - dedicated API controller files, not tools sub-resources
 		$controllers = [
 						["rel"=>"sections",	"href"=>"/api/".$_GET['app_id']."/sections/"],
 						["rel"=>"subnets",		"href"=>"/api/".$_GET['app_id']."/subnets/"],
@@ -156,13 +156,17 @@ class Tools_controller extends Common_api_functions {
 						["rel"=>"addresses",	"href"=>"/api/".$_GET['app_id']."/addresses/"],
 						["rel"=>"vlans",		"href"=>"/api/".$_GET['app_id']."/vlan/"],
 						["rel"=>"vrfs",		"href"=>"/api/".$_GET['app_id']."/vrf/"],
-						["rel"=>"nameservers",	"href"=>"/api/".$_GET['app_id']."/tools/nameservers/"],
-						["rel"=>"scanAgents",	"href"=>"/api/".$_GET['app_id']."/tools/scanagents/"],
-						["rel"=>"locations",	"href"=>"/api/".$_GET['app_id']."/tools/locations/"],
-						["rel"=>"racks",	    "href"=>"/api/".$_GET['app_id']."/tools/racks/"],
-						["rel"=>"nat",	        "href"=>"/api/".$_GET['app_id']."/tools/nat/"],
+						["rel"=>"circuits",	"href"=>"/api/".$_GET['app_id']."/circuits/"],
 						["rel"=>"tools",		"href"=>"/api/".$_GET['app_id']."/tools/"]
 					];
+
+		// tools sub-resources - generated from the actual subcontroller registry so this
+		// list can't drift from what's really routable under /tools/{id}/ (see
+		// define_tools_controllers(); array key is the rel, value is the URL segment)
+		foreach ($this->subcontrollers as $rel=>$url_segment) {
+			$controllers[] = ["rel"=>$rel, "href"=>"/api/".$_GET['app_id']."/tools/".$url_segment."/"];
+		}
+
 		# Response
 		return ["code"=>200, "data"=>["permissions"=>$this->Subnets->parse_permissions($app->app_permissions), "controllers"=>$controllers]];
 	}

--- a/functions/api/controllers/Tools.php
+++ b/functions/api/controllers/Tools.php
@@ -157,6 +157,7 @@ class Tools_controller extends Common_api_functions {
 						["rel"=>"vlans",		"href"=>"/api/".$_GET['app_id']."/vlan/"],
 						["rel"=>"vrfs",		"href"=>"/api/".$_GET['app_id']."/vrf/"],
 						["rel"=>"circuits",	"href"=>"/api/".$_GET['app_id']."/circuits/"],
+						["rel"=>"circuitsLogical",	"href"=>"/api/".$_GET['app_id']."/circuitsLogical/"],
 						["rel"=>"tools",		"href"=>"/api/".$_GET['app_id']."/tools/"]
 					];
 


### PR DESCRIPTION
Part of #4642 (context/overview for a set of 4 related API fixes).

## Gap

`OPTIONS /api/{app_id}/` is supposed to describe what the API supports, but the
`controllers` list is missing entries for functionality that's fully working and
routable - most notably `customers` (a working `tools/` sub-resource) and `circuits` (a
working top-level controller):

```
curl -s -k -X OPTIONS https://host/api/my_app/
```
```json
{
  "code": 200, "success": true,
  "data": {
    "permissions": "Write",
    "controllers": [
      {"rel": "sections", "href": "/api/my_app/sections/"},
      {"rel": "subnets", "href": "/api/my_app/subnets/"},
      {"rel": "folders", "href": "/api/my_app/folders/"},
      {"rel": "addresses", "href": "/api/my_app/addresses/"},
      {"rel": "vlans", "href": "/api/my_app/vlan/"},
      {"rel": "vrfs", "href": "/api/my_app/vrf/"},
      {"rel": "nameservers", "href": "/api/my_app/tools/nameservers/"},
      {"rel": "scanAgents", "href": "/api/my_app/tools/scanagents/"},
      {"rel": "locations", "href": "/api/my_app/tools/locations/"},
      {"rel": "racks", "href": "/api/my_app/tools/racks/"},
      {"rel": "nat", "href": "/api/my_app/tools/nat/"},
      {"rel": "tools", "href": "/api/my_app/tools/"}
    ]
  }
}
```

No `customers`, no `circuits` - despite both being usable today. This ambiguity is also
visible in #4560, where a user couldn't tell circuits had a controller at all.

## Root cause

`Tools_controller::OPTIONS()` (the handler used for both `OPTIONS /api/{app}/` and
`OPTIONS /api/{app}/tools/...`, since `index.php` forces `controller=Tools` whenever an
OPTIONS request has none) builds `controllers` from a hand-maintained static array that's
disconnected from `$this->subcontrollers`, the actual registry of what's dispatchable under
`tools/`. It had already drifted.

## Fix

Generate the `tools/*` portion of the list from `$this->subcontrollers` directly, so it
can't silently drift out of sync again, and add the missing top-level `circuits` entry
(and `circuitsLogical`, once #4646 also lands - see note below). Per-controller
`OPTIONS()` methods (e.g. `Circuits::OPTIONS()`, which already correctly reports
verb-level capabilities for its own routes) are untouched - this is specifically about the
root/tools discovery list being wrong, not a broader OPTIONS redesign.

Related to #4560 (contributed to the confusion about whether a circuits controller
existed).

## Tested with

Verified `OPTIONS /api/{app_id}/` now lists `customers` and `circuits`, and every
`tools/*` sub-resource entry matches what `Tools_controller` actually dispatches
(including the URL-segment quirks, e.g. `ipTags` → `tools/tags/`, `vrf` → `tools/vrfs/`).

Tested against PHP 8.2, 8.3, and 8.4 - lint clean and passing on each, no new PHP errors.

**Suggested merge order:** independent, can merge in any order. This branch already adds
a `circuitsLogical` entry to the list in anticipation of #4646 (CircuitsLogical
controller) - harmless if this merges first (the href just won't resolve to anything
until #4646 also lands), but ideally merge together or #4646 first.