### PR TITLE
Fix: Support SAML groups sent as arrays for JIT provisioning (Keycloak compatibility)

### DIFF
--- a/app/saml2/index.php
+++ b/app/saml2/index.php
@@ -178,8 +178,17 @@ try {
             $values["email"] = $auth->getAttribute("email")[0];
             $values["role"] = filter_var($auth->getAttribute("is_admin")[0], FILTER_VALIDATE_BOOLEAN) ? "Administrator" : "User";
 
-            // Parse groups
-            $saml_groups = array_map('trim', pf_explode(',', $auth->getAttribute("groups")[0])) ?: [];
+            // Parse groups (Fix for Keycloak SAML field)
+            $raw_groups = $auth->getAttribute("groups");
+            $saml_groups = [];
+            
+            if (is_array($raw_groups)) {
+                if (count($raw_groups) === 1 && strpos($raw_groups[0], ',') !== false) {
+                    $saml_groups = array_map('trim', pf_explode(',', $raw_groups[0]));
+                } else {
+                    $saml_groups = array_map('trim', $raw_groups);
+                }
+            }
 
             $ug = [];
             foreach ($Tools->fetch_all_objects("userGroups", "g_id") as $g) {


### PR DESCRIPTION
### Description
This PR updates the SAML2 JIT (Just-In-Time) provisioning logic in `app/saml2/index.php` to correctly parse group memberships when the Identity Provider (IdP) sends them as an array of separate attribute values (which is the default behavior for Keycloak).

### Motivation and Context
Currently, phpIPAM expects all SAML groups to be delivered as a single comma-separated string within the first attribute value:
`$saml_groups = array_map('trim', pf_explode(',', $auth->getAttribute("groups")[0])) ?: [];`

However, modern IdPs like Keycloak send groups as multiple `<saml:AttributeValue>` nodes under the "groups" attribute. The `php-saml` library parses this into a standard PHP array of strings. Because the current code only targets index `[0]` and tries to explode it by a comma, it completely ignores the rest of the groups and fails to assign the correct roles to the user during JIT login.

### How Has This Been Fixed?
I updated the group parsing block to dynamically handle both formats:
1. **Array of strings:** Directly maps the array of group names (Keycloak style).
2. **Comma-separated string:** Falls back to the original `pf_explode` behavior if only a single string with commas is received (legacy/other IdPs).

This approach ensures full backward compatibility with existing setups while adding out-of-the-box support for Keycloak.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)