### PR TITLE
Break the recursive master walk at the next root prefix

### DIFF
--- a/functions/classes/class.Tools.php
+++ b/functions/classes/class.Tools.php
@@ -2258,7 +2258,7 @@ class Tools extends Common_functions {
         	    elseif ($master_set && $p->master!=0) {
             	    $out[] = $p;
         	    }
-        	    elseif ($master_set && $p->master!=0) {
+        	    elseif ($master_set && $p->master==0) {
             	    break;
         	    }
             }


### PR DESCRIPTION
The master + recursive branch of `fetch_prefixes` has two `elseif` arms in a row with the same condition, `$master_set && $p->master!=0`. PHP takes the first, so the one holding the `break` is dead and the loop never stops early. The comment on the line above the block says what it was supposed to do, "go from master id to next 0 (root)", and the only thing that can end that walk is a prefix whose master is 0.

As it stands the walk keeps collecting every later prefix that has a non-zero master, including the ones under a different root, so callers get a subtree with strangers appended to it rather than one that ends where the next root starts.

Two other places in the tree repeat a branch the same way, `app/tools/vlan/index.php` and `app/admin/api/index.php`, but in both the repeat is only dead weight and nothing behaves differently, so I left them out of this one.
